### PR TITLE
SKALE-1532 build improvement and speedup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "libBLS"]
 	path = libBLS
-	url = https://github.com/skalenetwork/libBLS.git
+	url = git@github.com:skalenetwork/libBLS.git
 	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "libBLS"]
 	path = libBLS
-	url = git@github.com:skalenetwork/libBLS.git
+	url = https://github.com/skalenetwork/libBLS.git
 	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,11 @@ HunterGate(URL "https://github.com/ruslo/hunter/archive/v0.23.76.tar.gz" SHA1 "c
 
 project(consensus)
 
-include_directories( "${BLS_DEPS_INSTALL_ROOT}/include" ${CMAKE_BINARY_DIR}/deps/include )
-link_directories( "${BLS_DEPS_INSTALL_ROOT}/lib" )
-set( CMAKE_PREFIX_PATH "${BLS_DEPS_INSTALL_ROOT}" )
+include_directories( "${DEPS_INSTALL_ROOT}/include" ${CMAKE_BINARY_DIR}/deps/include )
+link_directories( "${DEPS_INSTALL_ROOT}/lib" )
+set( CMAKE_PREFIX_PATH "${DEPS_INSTALL_ROOT}" )
 
-find_library( FF_LIBRARY NAMES "ff" PATHS "${BLS_DEPS_INSTALL_ROOT}/lib" )
+find_library( FF_LIBRARY NAMES "ff" PATHS "${DEPS_INSTALL_ROOT}/lib" )
 
 # zeromq
 
@@ -163,9 +163,9 @@ SET(SRC_FILES
         Agent.h Agent.cpp SkaleCommon.h SkaleCommon.cpp Log.h Log.cpp microprofile.cpp miniz.c)
 
 
-message(INFO "${BLS_DEPS_INSTALL_ROOT}")
-include_directories(${BLS_INCLUDE_DIRS} "${BLS_DEPS_INSTALL_ROOT}/include")
-link_directories(${BLS_WITH_FF_INCLUDE_DIRS} "${BLS_DEPS_INSTALL_ROOT}/lib")
+message(INFO "---- DEPS_INSTALL_ROOT in consensus is: ${DEPS_INSTALL_ROOT}")
+include_directories(${BLS_INCLUDE_DIRS} "${DEPS_INSTALL_ROOT}/include")
+link_directories(${BLS_WITH_FF_INCLUDE_DIRS} "${DEPS_INSTALL_ROOT}/lib")
 
 if( SKALE_HAVE_BOOST_FROM_HUNTER )
   set( BOOST_LIBS_4_CONSENSUS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,9 @@ SET(SRC_FILES
         ${utils_src}
         Agent.h Agent.cpp SkaleCommon.h SkaleCommon.cpp Log.h Log.cpp microprofile.cpp miniz.c)
 
+include_directories( ${BLS_INCLUDE_DIRS} "${DEPS_INSTALL_ROOT}/include" )
+link_directories( "${DEPS_INSTALL_ROOT}/lib" )
+
 if( SKALE_HAVE_BOOST_FROM_HUNTER )
   set( BOOST_LIBS_4_CONSENSUS
     Boost::log Boost::thread Boost::system Boost::filesystem Boost::program_options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ endif ()
 
 add_subdirectory(libBLS)
 
+if( NOT DEFINED DEPS_INSTALL_ROOT )
+    set( DEPS_SOURCES_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/libBLS/deps")
+    set( DEPS_INSTALL_ROOT "${DEPS_SOURCES_ROOT}/deps_inst/x86_or_x64")
+endif()
+message(INFO "---- DEPS_INSTALL_ROOT in consensus is: ${DEPS_INSTALL_ROOT}")
 
 include("cmake/HunterGate.cmake")
 include("cmake/precompiledheader.cmake")
@@ -161,11 +166,6 @@ SET(SRC_FILES
         ${monitoring_src}
         ${utils_src}
         Agent.h Agent.cpp SkaleCommon.h SkaleCommon.cpp Log.h Log.cpp microprofile.cpp miniz.c)
-
-
-message(INFO "---- DEPS_INSTALL_ROOT in consensus is: ${DEPS_INSTALL_ROOT}")
-include_directories(${BLS_INCLUDE_DIRS} "${DEPS_INSTALL_ROOT}/include")
-link_directories(${BLS_WITH_FF_INCLUDE_DIRS} "${DEPS_INSTALL_ROOT}/lib")
 
 if( SKALE_HAVE_BOOST_FROM_HUNTER )
   set( BOOST_LIBS_4_CONSENSUS


### PR DESCRIPTION
repo ref is now ssh again - not http
deps references updated to avoid double building OpenSSL in skaled
No C++ code changes. No new tests required