### PR TITLE
SKALE-2094 Fix memory leak

### DIFF
--- a/SkaleCommon.h
+++ b/SkaleCommon.h
@@ -299,8 +299,7 @@ static const uint64_t  BLOCK_SIG_SHARE_DB_SIZE = 10000000;
 static const uint64_t  DA_SIG_SHARE_DB_SIZE = 10000000;
 static const uint64_t  DA_PROOF_DB_SIZE = 10000000;
 static const uint64_t  BLOCK_PROPOSAL_DB_SIZE = 100000000;
-
-
+static const uint64_t  MAX_PROPOSAL_QUEUE_SIZE = 8;
 
 extern void setThreadName(std::string const &_n, ConsensusEngine* _engine);
 

--- a/abstracttcpclient/AbstractClientAgent.cpp
+++ b/abstracttcpclient/AbstractClientAgent.cpp
@@ -105,7 +105,7 @@ void AbstractClientAgent::enqueueItemImpl(ptr<DataStructure> item ) {
             q->push( item );
 
             if (q->size() > MAX_PROPOSAL_QUEUE_SIZE) {
-                // the destination is not
+                // the destination is not accepting proposals, remove older
                 q->pop();
             }
         }

--- a/abstracttcpclient/AbstractClientAgent.cpp
+++ b/abstracttcpclient/AbstractClientAgent.cpp
@@ -103,6 +103,11 @@ void AbstractClientAgent::enqueueItemImpl(ptr<DataStructure> item ) {
             std::lock_guard< std::mutex > lock( *queueMutex[schain_index( i )] );
             auto q = itemQueue[schain_index( i )];
             q->push( item );
+
+            if (q->size() > MAX_PROPOSAL_QUEUE_SIZE) {
+                // the destination is not
+                q->pop();
+            }
         }
         queueCond.at( schain_index( i ) )->notify_all();
     }


### PR DESCRIPTION
The outgoing proposal queue had unlimited size, so if a node did not accept proposals, it would grow indefinitely