### PR TITLE
Bug/skale 2107 add state root

### DIFF
--- a/blockproposal/pusher/BlockProposalClientAgent.cpp
+++ b/blockproposal/pusher/BlockProposalClientAgent.cpp
@@ -137,7 +137,7 @@ ptr<BlockProposal> BlockProposalClientAgent::corruptProposal(ptr<BlockProposal> 
         auto proposal2 = make_shared<BlockProposal>(
                 _proposal->getSchainID(), _proposal->getProposerNodeID(),
                 _proposal->getBlockID(), _proposal->getProposerIndex(), make_shared<TransactionList>(
-                        make_shared<vector<ptr<Transaction>>>()), MODERN_TIME + 1, 1,
+                        make_shared<vector<ptr<Transaction>>>()), _proposal->getStateRoot(), MODERN_TIME + 1, 1,
                 nullptr, getSchain()->getCryptoManager());
 
 

--- a/blockproposal/server/BlockProposalServerAgent.cpp
+++ b/blockproposal/server/BlockProposalServerAgent.cpp
@@ -357,6 +357,7 @@ BlockProposalServerAgent::processProposalRequest(ptr<ServerConnection> _connecti
 
     auto proposal = make_shared<ReceivedBlockProposal>(*sChain, requestHeader->getBlockId(),
                                                        requestHeader->getProposerIndex(), transactionList,
+                                                       requestHeader->getStateRoot(),
                                                        requestHeader->getTimeStamp(),
                                                        requestHeader->getTimeStampMs(),
                                                        requestHeader->getHash(), requestHeader->getSignature());

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -469,7 +469,7 @@ void Schain::pushBlockToExtFace(ptr<CommittedBlock> &_block) {
         if (extFace) {
             extFace->createBlock(*tv, _block->getTimeStamp(), _block->getTimeStampMs(),
                                  (__uint64_t) _block->getBlockID(),
-                                 cur_price);
+                                 cur_price, _block->getStateRoot());
         }
 
     } catch (ExitRequestedException &e) { throw; }

--- a/datastructures/BlockProposal.cpp
+++ b/datastructures/BlockProposal.cpp
@@ -25,9 +25,11 @@
 #include <boost/iostreams/device/array.hpp>
 #include <boost/iostreams/stream.hpp>
 
+
 #include "SkaleCommon.h"
 #include "Log.h"
 
+#include <network/Utils.h>
 #include "exceptions/FatalError.h"
 #include "exceptions/InvalidArgumentException.h"
 #include "exceptions/ParsingException.h"
@@ -58,6 +60,7 @@ ptr<SHAHash> BlockProposal::getHash() {
 }
 
 
+
 void BlockProposal::calculateHash() {
     CryptoPP::SHA256 sha3;
     sha3.Update(reinterpret_cast < uint8_t * > ( &proposerIndex), sizeof(proposerIndex));
@@ -67,6 +70,12 @@ void BlockProposal::calculateHash() {
     sha3.Update(reinterpret_cast < uint8_t * > ( &transactionCount ), sizeof(transactionCount));
     sha3.Update(reinterpret_cast < uint8_t * > ( &timeStamp ), sizeof(timeStamp));
     sha3.Update(reinterpret_cast < uint8_t * > ( &timeStampMs ), sizeof(timeStampMs));
+
+    // export into 8-bit unsigned values, most significant bit first:
+
+    auto sr = Utils::u256ToBigEndianArray(getStateRoot());
+    auto v = Utils::carray2Hex(sr->data(),  sr->size());
+    sha3.Update((unsigned char *) v->data(), v->size());
     if (transactionList->size() > 0) {
         auto merkleRoot = transactionList->calculateTopMerkleRoot();
         sha3.Update(merkleRoot->getHash()->data(), SHA_HASH_LEN);
@@ -78,16 +87,17 @@ void BlockProposal::calculateHash() {
 
 
 BlockProposal::BlockProposal(uint64_t _timeStamp, uint32_t _timeStampMs) : timeStamp(_timeStamp),
-    timeStampMs(_timeStampMs){
+                                                                           timeStampMs(_timeStampMs) {
     proposerNodeID = 0;
 };
 
 BlockProposal::BlockProposal(schain_id _sChainId, node_id _proposerNodeId, block_id _blockID,
-                             schain_index _proposerIndex, ptr<TransactionList> _transactions, uint64_t _timeStamp,
-                             __uint32_t _timeStampMs, ptr<string> _signature, ptr<CryptoManager> _cryptoManager)
+                             schain_index _proposerIndex, ptr<TransactionList> _transactions, u256 _stateRoot,
+                             uint64_t _timeStamp, __uint32_t _timeStampMs, ptr<string> _signature,
+                             ptr<CryptoManager> _cryptoManager)
         : schainID(_sChainId), proposerNodeID(_proposerNodeId), blockID(_blockID),
-        proposerIndex(_proposerIndex), timeStamp(_timeStamp),timeStampMs(_timeStampMs),
-        transactionList(_transactions), signature(_signature){
+          proposerIndex(_proposerIndex), timeStamp(_timeStamp), timeStampMs(_timeStampMs),
+          transactionList(_transactions), stateRoot(_stateRoot), signature(_signature) {
 
     CHECK_ARGUMENT(_cryptoManager != nullptr || _signature != nullptr);
     CHECK_ARGUMENT(_cryptoManager == nullptr || _signature == nullptr);
@@ -102,7 +112,6 @@ BlockProposal::BlockProposal(schain_id _sChainId, node_id _proposerNodeId, block
         signature = _signature;
     }
 }
-
 
 
 ptr<PartialHashesList> BlockProposal::createPartialHashesList() {
@@ -170,16 +179,16 @@ uint32_t BlockProposal::getTimeStampMs() const {
 void BlockProposal::addSignature(ptr<string> _signature) {
     LOCK(m)
     CHECK_ARGUMENT(_signature != nullptr)
-    CHECK_STATE( signature == nullptr)
+    CHECK_STATE(signature == nullptr)
     signature = _signature;
 }
 
-ptr<string>  BlockProposal::getSignature() {
+ptr<string> BlockProposal::getSignature() {
     LOCK(m)
-    return  signature;
+    return signature;
 }
 
-ptr<BlockProposalRequestHeader> BlockProposal::createBlockProposalHeader(Schain* _sChain,
+ptr<BlockProposalRequestHeader> BlockProposal::createBlockProposalHeader(Schain *_sChain,
                                                                          ptr<BlockProposal> _proposal) {
 
 
@@ -246,7 +255,7 @@ ptr<vector<uint8_t> > BlockProposal::serialize() {
 
 
 ptr<BlockProposal> BlockProposal::deserialize(ptr<vector<uint8_t> > _serializedProposal,
-                                                ptr<CryptoManager> _manager) {
+                                              ptr<CryptoManager> _manager) {
 
     ptr<string> headerStr = BlockProposal::extractHeader(_serializedProposal);
 
@@ -266,9 +275,10 @@ ptr<BlockProposal> BlockProposal::deserialize(ptr<vector<uint8_t> > _serializedP
     ASSERT(sig != nullptr);
 
     auto proposal = make_shared<BlockProposal>(blockHeader->getSchainID(), blockHeader->getProposerNodeId(),
-                                             blockHeader->getBlockID(), blockHeader->getProposerIndex(),
-                                             list, blockHeader->getTimeStamp(), blockHeader->getTimeStampMs(),
-                                             blockHeader->getSignature(), nullptr);
+                                               blockHeader->getBlockID(), blockHeader->getProposerIndex(),
+                                               list, blockHeader->getStateRoot(), blockHeader->getTimeStamp(),
+                                               blockHeader->getTimeStampMs(),
+                                               blockHeader->getSignature(), nullptr);
 
     _manager->verifyProposalECDSA(proposal, blockHeader->getBlockHash(), blockHeader->getSignature());
 
@@ -277,7 +287,8 @@ ptr<BlockProposal> BlockProposal::deserialize(ptr<vector<uint8_t> > _serializedP
     return proposal;
 }
 
-ptr<BlockProposal> BlockProposal::defragment(ptr<BlockProposalFragmentList> _fragmentList, ptr<CryptoManager> _cryptoManager) {
+ptr<BlockProposal>
+BlockProposal::defragment(ptr<BlockProposalFragmentList> _fragmentList, ptr<CryptoManager> _cryptoManager) {
     try {
         return deserialize(_fragmentList->serialize(), _cryptoManager);
     } catch (exception &e) {
@@ -329,8 +340,8 @@ ptr<BlockProposalFragment> BlockProposal::getFragment(uint64_t _totalFragments, 
 }
 
 ptr<TransactionList> BlockProposal::deserializeTransactions(ptr<BlockProposalHeader> _header,
-                                                             ptr<string> _headerString,
-                                                             ptr<vector<uint8_t> > _serializedBlock) {
+                                                            ptr<string> _headerString,
+                                                            ptr<vector<uint8_t> > _serializedBlock) {
 
     auto headerSize = _headerString->size();
 
@@ -390,7 +401,6 @@ ptr<string> BlockProposal::extractHeader(ptr<vector<uint8_t> > _serializedBlock)
 }
 
 
-
 ptr<BlockProposalHeader> BlockProposal::parseBlockHeader(const shared_ptr<string> &header) {
     CHECK_ARGUMENT(header != nullptr);
     CHECK_ARGUMENT(header->size() > 2);
@@ -401,4 +411,8 @@ ptr<BlockProposalHeader> BlockProposal::parseBlockHeader(const shared_ptr<string
 
     return make_shared<BlockProposalHeader>(js);
 
+}
+
+u256 BlockProposal::getStateRoot() const {
+    return stateRoot;
 }

--- a/datastructures/BlockProposal.h
+++ b/datastructures/BlockProposal.h
@@ -23,6 +23,8 @@
 
 #pragma  once
 
+#include<boost/multiprecision/cpp_int.hpp>
+
 #include "SkaleCommon.h"
 
 #include "DataStructure.h"
@@ -57,6 +59,7 @@ protected:
     transaction_count transactionCount;
     uint64_t  timeStamp = 0;
     uint32_t  timeStampMs = 0;
+    u256 stateRoot = 0;
 
     ptr<TransactionList> transactionList;
     ptr< SHAHash > hash = nullptr;
@@ -79,8 +82,9 @@ public:
     BlockProposal(uint64_t _timeStamp, uint32_t _timeStampMs);
 
     BlockProposal(schain_id _sChainId, node_id _proposerNodeId, block_id _blockID,
-                  schain_index _proposerIndex, ptr<TransactionList> _transactions, uint64_t _timeStamp,
-                  __uint32_t _timeStampMs, ptr<string> _signature, ptr<CryptoManager> _cryptoManager);
+                  schain_index _proposerIndex, ptr<TransactionList> _transactions, u256 _stateRoot,
+                  uint64_t _timeStamp, __uint32_t _timeStampMs, ptr<string> _signature,
+                  ptr<CryptoManager> _cryptoManager);
 
 
     uint64_t getTimeStamp() const;
@@ -122,5 +126,8 @@ public:
     static ptr<BlockProposal> defragment(ptr<BlockProposalFragmentList> _fragmentList, ptr<CryptoManager> _cryptoManager);
 
     ptr<BlockProposalFragment> getFragment(uint64_t _totalFragments, fragment_index _index);
+
+    u256 getStateRoot() const;
+
 };
 

--- a/datastructures/CommittedBlock.cpp
+++ b/datastructures/CommittedBlock.cpp
@@ -128,7 +128,7 @@ CommittedBlock::CommittedBlock(
         uint64_t timeStamp,
         __uint32_t timeStampMs, ptr<string>
         _signature, ptr<string> _thresholdSig)
-        : BlockProposal(sChainId, proposerNodeId, blockId, proposerIndex, transactions, timeStamp,
+        : BlockProposal(sChainId, proposerNodeId, blockId, proposerIndex, transactions, u256(), timeStamp,
                         timeStampMs, _signature, nullptr) {
     CHECK_ARGUMENT(_signature != nullptr);
     CHECK_ARGUMENT(_thresholdSig != nullptr);
@@ -148,7 +148,7 @@ _size,
 
 
 
-    auto p = make_shared<BlockProposal>(1, 1, _blockID, 1, list, MODERN_TIME + 1, 1, nullptr,
+    auto p = make_shared<BlockProposal>(1, 1, _blockID, 1, list, 0, MODERN_TIME + 1, 1, nullptr,
                                         _manager);
 
 

--- a/datastructures/CommittedBlock.cpp
+++ b/datastructures/CommittedBlock.cpp
@@ -147,8 +147,10 @@ _size,
     static uint64_t MODERN_TIME = 1547640182;
 
 
+    u256 stateRoot =  (uint64_t ) _blockID + 1;
 
-    auto p = make_shared<BlockProposal>(1, 1, _blockID, 1, list, 0, MODERN_TIME + 1, 1, nullptr,
+
+    auto p = make_shared<BlockProposal>(1, 1, _blockID, 1, list, stateRoot , MODERN_TIME + 1, 1, nullptr,
                                         _manager);
 
 

--- a/datastructures/MyBlockProposal.cpp
+++ b/datastructures/MyBlockProposal.cpp
@@ -29,10 +29,10 @@
 #include "MyBlockProposal.h"
 
 MyBlockProposal::MyBlockProposal(Schain &_sChain, const block_id &_blockID, const schain_index &_proposerIndex,
-                                 const ptr<TransactionList> _transactions, uint64_t _timeStamp,
+                                 const ptr<TransactionList> _transactions, u256 _stateRoot, uint64_t _timeStamp,
                                  uint32_t _timeStampMs, ptr<CryptoManager> _cryptoManager)
         : BlockProposal(_sChain.getSchainID(), _sChain.getNodeIDByIndex(_proposerIndex), _blockID, _proposerIndex,
-                        _transactions, _timeStamp, _timeStampMs, nullptr, _cryptoManager) {
+                        _transactions, _stateRoot, _timeStamp, _timeStampMs, nullptr, _cryptoManager) {
 
     totalObjects++;
 };

--- a/datastructures/MyBlockProposal.h
+++ b/datastructures/MyBlockProposal.h
@@ -32,7 +32,7 @@
 class MyBlockProposal : public BlockProposal {
 public:
     MyBlockProposal(Schain &_sChain, const block_id &_blockID, const schain_index &_proposerIndex,
-                    const ptr<TransactionList> _transactions, uint64_t _timeStamp,
+                    const ptr<TransactionList> _transactions, u256 _stateRoot, uint64_t _timeStamp,
                     uint32_t _timeStampMs, ptr<CryptoManager> _cryptoManager);
 
 

--- a/datastructures/ReceivedBlockProposal.cpp
+++ b/datastructures/ReceivedBlockProposal.cpp
@@ -35,7 +35,7 @@ ReceivedBlockProposal::ReceivedBlockProposal(Schain &_sChain, const block_id &_b
                                              ptr<string> _hash,
                                              ptr<string> _signature) : BlockProposal(
         _sChain.getSchainID(), _sChain.getNodeIDByIndex(_proposerIndex), _blockID,
-        _proposerIndex, _transactions,
+        _proposerIndex, _transactions, u256(),
         _timeStamp, _timeStampMs, _signature, nullptr) {
     this->hash = SHAHash::fromHex(_hash);
     this->signature = _signature;
@@ -45,7 +45,8 @@ ReceivedBlockProposal::ReceivedBlockProposal(Schain &_sChain, const block_id &_b
 ReceivedBlockProposal::ReceivedBlockProposal(Schain &_sChain, const block_id &_blockID, const uint64_t &_timeStamp,
                                              const uint32_t &_timeStampMs) : BlockProposal(
         _sChain.getSchainID(), 0, _blockID,
-        0, make_shared<TransactionList>(make_shared<vector<ptr<Transaction >>>()), _timeStamp, _timeStampMs, make_shared<string>("EMPTY"), ptr<CryptoManager>()) {
+        0, make_shared<TransactionList>(make_shared<vector<ptr<Transaction >>>()), u256(), _timeStamp, _timeStampMs,
+        make_shared<string>("EMPTY"), ptr<CryptoManager>()) {
     calculateHash();
     totalObjects++;
 }

--- a/datastructures/ReceivedBlockProposal.cpp
+++ b/datastructures/ReceivedBlockProposal.cpp
@@ -29,13 +29,11 @@
 
 ReceivedBlockProposal::ReceivedBlockProposal(Schain &_sChain, const block_id &_blockID,
                                              const schain_index &_proposerIndex,
-                                             const ptr<TransactionList> &_transactions,
+                                             const ptr<TransactionList> &_transactions, u256 _stateRoot,
                                              const uint64_t &_timeStamp,
-                                             const uint32_t &_timeStampMs,
-                                             ptr<string> _hash,
-                                             ptr<string> _signature) : BlockProposal(
+                                             const uint32_t &_timeStampMs, ptr<string> _hash, ptr<string> _signature) : BlockProposal(
         _sChain.getSchainID(), _sChain.getNodeIDByIndex(_proposerIndex), _blockID,
-        _proposerIndex, _transactions, u256(),
+        _proposerIndex, _transactions, _stateRoot,
         _timeStamp, _timeStampMs, _signature, nullptr) {
     this->hash = SHAHash::fromHex(_hash);
     this->signature = _signature;
@@ -45,7 +43,7 @@ ReceivedBlockProposal::ReceivedBlockProposal(Schain &_sChain, const block_id &_b
 ReceivedBlockProposal::ReceivedBlockProposal(Schain &_sChain, const block_id &_blockID, const uint64_t &_timeStamp,
                                              const uint32_t &_timeStampMs) : BlockProposal(
         _sChain.getSchainID(), 0, _blockID,
-        0, make_shared<TransactionList>(make_shared<vector<ptr<Transaction >>>()), u256(), _timeStamp, _timeStampMs,
+        0, make_shared<TransactionList>(make_shared<vector<ptr<Transaction >>>()), 0, _timeStamp, _timeStampMs,
         make_shared<string>("EMPTY"), ptr<CryptoManager>()) {
     calculateHash();
     totalObjects++;

--- a/datastructures/ReceivedBlockProposal.h
+++ b/datastructures/ReceivedBlockProposal.h
@@ -36,7 +36,7 @@ public:
 
 
     ReceivedBlockProposal(Schain &_sChain, const block_id &_blockID, const schain_index &_proposerIndex,
-                          const ptr<TransactionList> & _transactions, const uint64_t &_timeStamp,
+                          const ptr<TransactionList> &_transactions, u256 _stateRoot, const uint64_t &_timeStamp,
                           const uint32_t &_timeStampMs, ptr<string> _hash, ptr<string> _signature);
 
 

--- a/datastructures/SerializationTests.cpp
+++ b/datastructures/SerializationTests.cpp
@@ -200,6 +200,8 @@ void test_committed_block_serialize_deserialize(bool _fail) {
 
     boost::random::uniform_int_distribution<> ubyte(0, 255);
 
+    u256 stateRoot;
+
     for (int k = 0; k < 100; k++) {
         for (int i = 0; i < 20; i++) {
             auto t = CommittedBlock::createRandomSample(cryptoManager, i, gen, ubyte);
@@ -225,6 +227,7 @@ void test_committed_block_serialize_deserialize(bool _fail) {
                     throw (e);
                 }
                 REQUIRE(imp != nullptr);
+                REQUIRE(imp->getStateRoot() == t->getStateRoot());
             }
         }
     }

--- a/headers/BasicHeader.cpp
+++ b/headers/BasicHeader.cpp
@@ -39,8 +39,6 @@
 
 #include "BasicHeader.h"
 
-
-
 bool BasicHeader::isComplete() const {
     return complete;
 }
@@ -61,6 +59,10 @@ ptr<string> BasicHeader::serializeToString() {
 
     return s;
 
+}
+
+uint64_t BasicHeader::getTotalObjects() {
+    return totalObjects;
 }
 
 ptr<Buffer> BasicHeader::toBuffer() {
@@ -110,10 +112,15 @@ ptr<string> BasicHeader::getString(nlohmann::json &_js, const char *_name) {
     return make_shared<string>(result);
 }
 
-BasicHeader::BasicHeader(const char *_type) : type(_type) {
-
+BasicHeader::BasicHeader(const char *_type) : type(_type)  {
+    totalObjects++;
 }
+
 
 BasicHeader::~BasicHeader() {
+    if (totalObjects > 0)
+        totalObjects--;
 }
 
+
+atomic<uint64_t>  BasicHeader::totalObjects(1);

--- a/headers/BasicHeader.h
+++ b/headers/BasicHeader.h
@@ -40,7 +40,13 @@ protected:
 
     bool complete = false;
 
+    static atomic<uint64_t>  totalObjects;
+
 public:
+
+
+    static uint64_t getTotalObjects();
+
     bool isComplete() const;
 
     static constexpr const char *BLOCK_PROPOSAL_REQ = "BlckPrpslReq";

--- a/headers/BlockProposalHeader.cpp
+++ b/headers/BlockProposalHeader.cpp
@@ -21,12 +21,13 @@
     @date 2018
 */
 
+
 #include "SkaleCommon.h"
 #include "Log.h"
 #include "exceptions/FatalError.h"
 #include "thirdparty/json.hpp"
+#include <network/Utils.h>
 #include "crypto/SHAHash.h"
-#include "abstracttcpserver/ConnectionStatus.h"
 #include "BlockProposalRequestHeader.h"
 #include "datastructures/BlockProposal.h"
 #include "datastructures/CommittedBlock.h"
@@ -50,10 +51,12 @@ BlockProposalHeader::BlockProposalHeader(BlockProposal& _block) : Header(Header:
     this->schainID = _block.getSchainID();
     this->blockID = _block.getBlockID();
     this->blockHash = _block.getHash()->toHex();
+    this->stateRoot = _block.getStateRoot();
     this->signature = _block.getSignature();
     this->timeStamp = _block.getTimeStamp();
     this->timeStampMs = _block.getTimeStampMs();
     this->transactionSizes = make_shared<vector<uint64_t>>();
+
 
     auto items = _block.getTransactionList()->getItems();
 
@@ -95,10 +98,9 @@ void BlockProposalHeader::addFields(nlohmann::json &j) {
 
     j["timeStampMs"] = timeStampMs;
 
+    j["sr "] = stateRoot.str();
+
     ASSERT(timeStamp > 0);
-
-
-
 }
 
 BlockProposalHeader::BlockProposalHeader(nlohmann::json& _json) : Header(Header::BLOCK){
@@ -111,6 +113,8 @@ BlockProposalHeader::BlockProposalHeader(nlohmann::json& _json) : Header(Header:
     timeStampMs = Header::getUint32(_json, "timeStampMs" );
     blockHash = Header::getString(_json, "hash" ) ;
     signature = Header::getString(_json, "sig");
+    auto srStr = Header::getString(_json, "sr");
+    stateRoot = u256(*srStr);
 
     Header::nullCheck(_json, "sizes" );
     nlohmann::json jsonTransactionSizes = _json["sizes"];
@@ -147,6 +151,10 @@ uint64_t BlockProposalHeader::getTimeStamp() const {
 
 uint32_t BlockProposalHeader::getTimeStampMs() const {
     return timeStampMs;
+}
+
+const u256 &BlockProposalHeader::getStateRoot() const {
+    return stateRoot;
 }
 
 

--- a/headers/BlockProposalHeader.cpp
+++ b/headers/BlockProposalHeader.cpp
@@ -98,7 +98,7 @@ void BlockProposalHeader::addFields(nlohmann::json &j) {
 
     j["timeStampMs"] = timeStampMs;
 
-    j["sr "] = stateRoot.str();
+    j["sr"] = stateRoot.str();
 
     ASSERT(timeStamp > 0);
 }

--- a/headers/BlockProposalHeader.h
+++ b/headers/BlockProposalHeader.h
@@ -42,6 +42,11 @@ class BlockProposalHeader : public Header {
     ptr<vector<uint64_t>> transactionSizes;
     uint64_t timeStamp = 0;
     uint32_t timeStampMs = 0;
+public:
+    const u256 &getStateRoot() const;
+
+private:
+    u256 stateRoot = 0;
 
 public:
 

--- a/headers/BlockProposalRequestHeader.cpp
+++ b/headers/BlockProposalRequestHeader.cpp
@@ -68,6 +68,7 @@ BlockProposalRequestHeader::BlockProposalRequestHeader(Schain &_sChain, ptr<Bloc
 
     this->signature = proposal->getSignature();
 
+    this->stateRoot = proposal->getStateRoot();
 
     ASSERT(timeStamp > MODERN_TIME);
 
@@ -91,6 +92,7 @@ void BlockProposalRequestHeader::addFields(nlohmann::basic_json<> &jsonRequest) 
     CHECK_STATE(signature != nullptr);
     jsonRequest["hash"] = *hash;
     jsonRequest["sig"] = *signature;
+    jsonRequest["sr"] = stateRoot.str();
 }
 
 const node_id &BlockProposalRequestHeader::getProposerNodeId() const {
@@ -115,6 +117,10 @@ uint32_t BlockProposalRequestHeader::getTimeStampMs() const {
 
 ptr<string> BlockProposalRequestHeader::getSignature() const {
     return signature;
+}
+
+const u256 &BlockProposalRequestHeader::getStateRoot() const {
+    return stateRoot;
 }
 
 

--- a/headers/BlockProposalRequestHeader.h
+++ b/headers/BlockProposalRequestHeader.h
@@ -39,6 +39,7 @@ class BlockProposalRequestHeader : public AbstractBlockRequestHeader{
     uint64_t txCount;
     uint64_t  timeStamp = 0;
     uint32_t  timeStampMs = 0;
+    u256 stateRoot;
 
 public:
 
@@ -60,6 +61,8 @@ public:
     uint32_t getTimeStampMs() const;
 
     ptr<string> getSignature() const;
+
+    const u256 &getStateRoot() const;
 
 };
 

--- a/headers/Header.cpp
+++ b/headers/Header.cpp
@@ -33,17 +33,14 @@
 
 
 Header::Header(const char *_type) : BasicHeader(_type){
-    totalObjects++;
 }
 
 
 
 Header::~Header() {
-    totalObjects--;
 }
 
 
-atomic<uint64_t>  Header::totalObjects(0);
 
 void Header::addFields(nlohmann::json &j) {
     j["status"] = status;

--- a/headers/Header.h
+++ b/headers/Header.h
@@ -65,14 +65,9 @@ public:
 
     void setStatus( ConnectionStatus _status ) { this->status = _status; }
 
-    static uint64_t getTotalObjects() {
-        return totalObjects;
-    }
 
 private:
 
-
-    static atomic<uint64_t>  totalObjects;
 
 
 };

--- a/network/Utils.cpp
+++ b/network/Utils.cpp
@@ -32,6 +32,13 @@
 #include "Utils.h"
 #include "exceptions/InvalidArgumentException.h"
 
+ptr<vector<uint8_t>> Utils::u256ToBigEndianArray(const u256 &_value) {
+// export into 8-bit unsigned values, most significant bit first:
+    auto v = make_shared<vector<uint8_t>>();
+    export_bits(_value, std::back_inserter(*v), 8);
+    return v;
+}
+
 void Utils::checkTime() {
 
 

--- a/network/Utils.h
+++ b/network/Utils.h
@@ -33,6 +33,8 @@ class Utils {
 public:
 
 
+    static ptr<vector<uint8_t>> u256ToBigEndianArray(const u256 &_value);
+
     static void checkTime();
 
     static bool isValidIpAddress(ptr<string>ipAddress);

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -1,4 +1,4 @@
-/*
+ /*
     Copyright (C) 2018-2019 SKALE Labs
 
     This file is part of skale-consensus.

--- a/node/ConsensusEngine.h
+++ b/node/ConsensusEngine.h
@@ -40,10 +40,6 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
-
-
-
-
 extern thread_local ptr<Log> logThreadLocal_;
 
 using namespace spdlog::level;
@@ -81,19 +77,13 @@ private:
 
     shared_ptr< spdlog::sinks::sink > logRotatingFileSync;
 
-
-
 public:
-
-
 
     void logInit();
 
     static void setConfigLogLevel( string& _s );
 
     ptr<string> getHealthCheckDir() const;
-
-
 
     static void log( level_enum _severity, const string& _message, const string& _className );
 
@@ -102,7 +92,6 @@ public:
     shared_ptr< spdlog::logger > createLogger( const string& loggerName );
 
     static const shared_ptr< string > getDataDir();
-
 
     recursive_mutex mutex;
 

--- a/node/ConsensusInterface.h
+++ b/node/ConsensusInterface.h
@@ -60,12 +60,13 @@ class ConsensusExtFace {
 public:
     typedef std::vector<std::vector<uint8_t> > transactions_vector;
 
-    // Returns hashes and bytes of new transactions; blocks if there are no txns
-    virtual transactions_vector pendingTransactions(size_t _limit) = 0;
+    // Returns hashes and bytes of new transactions as well as state root to put into block proposal
+    virtual transactions_vector pendingTransactions(size_t _limit, u256& _stateRoot) = 0;
 
     // Creates new block with specified transactions AND removes them from the queue
     virtual void createBlock(const transactions_vector &_approvedTransactions, uint64_t _timeStamp,
-                             uint32_t _timeStampMillis, uint64_t _blockID, u256 _gasPrice) = 0;
+                             uint32_t _timeStampMillis, uint64_t _blockID, u256 _gasPrice,
+                             u256 _stateRoot) = 0;
 
     virtual ~ConsensusExtFace() = default;
 

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -80,7 +80,6 @@ Node::Node(const nlohmann::json &_cfg, ConsensusEngine *_consensusEngine) {
 
     try {
         initParamsFromConfig();
-
     } catch (...) {
         throw_with_nested(ParsingException("Could not parse params", __CLASS_NAME__));
     }

--- a/pendingqueue/PendingTransactionsAgent.h
+++ b/pendingqueue/PendingTransactionsAgent.h
@@ -94,7 +94,7 @@ private:
     recursive_mutex transactionsMutex;
 
 
-    shared_ptr<vector<ptr<Transaction>>> createTransactionsListForProposal();
+    pair<ptr<vector<ptr<Transaction>>>, u256> createTransactionsListForProposal();
 
 public:
 


### PR DESCRIPTION
This pull request adds the state root to the blockProposal. This state root is the hash of the latest snapshot just before this blockProposal or block.

The signatures of the function were changed  to pass the state root back and forth:

    virtual transactions_vector pendingTransactions(size_t _limit, u256& _stateRoot) = 0;

    // Creates new block with specified transactions AND removes them from the queue
    virtual void createBlock(const transactions_vector &_approvedTransactions, uint64_t _timeStamp,
                             uint32_t _timeStampMillis, uint64_t _blockID, u256 _gasPrice,
                             u256 _stateRoot) = 0;


For now stateRoot can be set to 0.

I have added a test for including the stateRoot in the block

Skaled will need a commit to pass zero state root for now.