### PR TITLE
SKALE-1485 Build system is switched to gcc/g++ 9.2 and 8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@
 language: cpp
 env:
   global:
-    - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
     - TARGET=all
     - TRAVIS_BUILD_TYPE=Debug
 
@@ -37,11 +37,14 @@ matrix:
 
 addons:
   apt:
+    sources:
+       - ubuntu-toolchain-r-test
     packages:
       - software-properties-common
       - apt-utils
       - libprocps-dev
-      - g++-7
+      - gcc-9
+      - g++-9
       - valgrind
       - gawk
       - sed


### PR DESCRIPTION
**THIS IS INVESTIGATION, NO NEED TO MERGE BEFORE RELEASE**

- gcc/g++ 9 and 8 support
- no new tests needed

To install latest gcc/g++ 9:

sudo add-apt-repository ppa:ubuntu-toolchain-r/test
sudo apt-get update
sudo apt-get install gcc-9 g++-9
gcc-9 --version; g++-9 --version
sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9
gcc --version; g++ --version

To replace your current cmake with latest 3.17.1:

sudo apt purge --auto-remove cmake
sudo apt update
sudo apt install snapd
sudo snap install cmake --classic
sudo ldconfig
cmake --version
