### PR TITLE
SKALE-3681 Do not closeSend() and closeReceive()

### DIFF
--- a/network/ZMQSockets.cpp
+++ b/network/ZMQSockets.cpp
@@ -137,8 +137,8 @@ void ZMQSockets::closeAndCleanupAll() {
     LOG(info, "Cleaning up ZMQ sockets");
 
     zmq_ctx_shutdown(context);
-    closeSend();
-    closeReceive();
+//    closeSend();
+//    closeReceive();
 
     LOG(info, "Closing ZMQ context");
 


### PR DESCRIPTION
Looks like this:
```
Invalid argument (/home/vagrant/actions-runner1/_work/skaled/skaled/libconsensus/libzmq/src/mutex.hpp:139)
```
was because of close in wrong thread (problem appeared after we began to close() socket before null'ing it)