### PR TITLE
#196

### DIFF
--- a/crypto/CryptoManager.cpp
+++ b/crypto/CryptoManager.cpp
@@ -669,6 +669,11 @@ ptr<ThresholdSigShare> CryptoManager::signBlockSigShare(
     return result;
 }
 
+
+
+
+
+
 void CryptoManager::verifyBlockSig(
         ptr<ThresholdSignature> _signature, BLAKE3Hash &_hash, const TimeStamp &_ts) {
     CHECK_STATE(_signature);
@@ -841,6 +846,54 @@ void CryptoManager::verifyThresholdSig(
 
 
 }
+
+
+// Verify threshold sig share using the current set of BLS keys.
+// Since threshold sig shares are glued for the current block
+// historic keys are not needed in this case.
+// throw an exception if the share does not verify
+
+void CryptoManager::verifyThresholdSigShare(
+        ptr<ThresholdSigShare> _sigShare, BLAKE3Hash &_hash) {
+
+    CHECK_STATE(_sigShare);
+    // sync nodes do not do sig gluing
+    CHECK_STATE(!getSchain()->getNode()->isSyncOnlyNode())
+
+    MONITOR(__CLASS_NAME__, __FUNCTION__)
+
+    if ((getSchain()->getNode()->isSgxEnabled())) {
+
+        auto consensusBlsSigShare = dynamic_pointer_cast<ConsensusBLSSigShare>(_sigShare);
+
+        CHECK_STATE(consensusBlsSigShare);
+
+        ptr<BLSSigShare> blsSigShare = consensusBlsSigShare->getBlsSigShare();
+
+        verifyBlsSigShare(blsSigShare, _hash);
+
+    } else {
+        // mockup sigshares are not verified
+    }
+
+}
+
+
+// Verify BLS sig share using the current set of BLS keys.
+// Since threshold sig shares are glued for the current block
+// historic keys are not needed in this case.
+// throw an exception if the share does not verify
+void CryptoManager::verifyBlsSigShare(
+        ptr<BLSSigShare> _sigShare, BLAKE3Hash &_hash) {
+    CHECK_STATE(_sigShare);
+
+    _hash.getHash();
+
+    // get the correct key share from config
+    // and perform verification
+    // TO BE implemented
+}
+
 
 
 ptr<ThresholdSigShareSet> CryptoManager::createSigShareSet(block_id _blockId) {

--- a/crypto/CryptoManager.h
+++ b/crypto/CryptoManager.h
@@ -45,6 +45,7 @@ class ThresholdSignature;
 class StubClient;
 class ECP;
 class BLSPublicKey;
+class BLSSigShare;
 
 namespace CryptoPP {
 class ECP;
@@ -175,8 +176,12 @@ public:
 
     void  verifyBlockSig(string& _signature,  block_id _blockId, BLAKE3Hash & _hash, const TimeStamp& _ts = TimeStamp(uint64_t(-1), 0));
 
+    void verifyThresholdSigShare(
+            ptr<ThresholdSigShare> _sigShare, BLAKE3Hash &_hash);
 
-    static bool isRetryHappened();
+
+
+        static bool isRetryHappened();
 
     static void setRetryHappened( bool retryHappened );
 
@@ -255,6 +260,9 @@ public:
 
     void sessionVerifySigAndKey( BLAKE3Hash& _hash, const string& _sig,
         const string& _publicKey, const string& pkSig, block_id _blockID, node_id _nodeId, uint64_t _timeStamp );
+
+
+    void verifyBlsSigShare(ptr<BLSSigShare> _sigShare, BLAKE3Hash &_hash);
 
     void exitZMQClient();
 

--- a/db/BlockSigShareDB.cpp
+++ b/db/BlockSigShareDB.cpp
@@ -54,6 +54,16 @@ BlockSigShareDB::checkAndSaveShareInMemory(const ptr<ThresholdSigShare>& _sigSha
         CHECK_ARGUMENT(_sigShare)
         CHECK_ARGUMENT(_cryptoManager)
 
+
+
+        auto hash = BLAKE3Hash::getBlockHash(
+                (uint64_t ) _proposer,
+                (uint64_t) _sigShare->getBlockId(),
+                (uint64_t) getSchain()->getSchainID());
+
+        _cryptoManager->verifyThresholdSigShare(_sigShare, hash);
+
+
         auto sigShareString = _sigShare->toString();
         CHECK_STATE(!sigShareString.empty())
 
@@ -84,11 +94,6 @@ BlockSigShareDB::checkAndSaveShareInMemory(const ptr<ThresholdSigShare>& _sigSha
         CHECK_STATE(signature)
 
 
-
-        auto hash = BLAKE3Hash::getBlockHash(
-                (uint64_t ) _proposer,
-                (uint64_t) signature->getBlockId(),
-                (uint64_t) getSchain()->getSchainID());
 
         _cryptoManager->verifyBlockSig(signature, hash);
 


### PR DESCRIPTION
// Verify BLS sig share using the current set of BLS keys.
// Since threshold sig shares are glued for the current block
// historic keys are not needed in this case.
// throw an exception if the share does not verify
void CryptoManager::verifyBlsSigShare(
        ptr<BLSSigShare> _sigShare, BLAKE3Hash &_hash) {
    CHECK_STATE(_sigShare);

    _hash.getHash();

    // get the correct key share from config
    // and perform verification
    // TO BE implemented
}
