### PR TITLE
IS 945 increase timeouts for catchup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
       run: ls libBLS/deps/deps_inst/x86_or_x64/include/jsonrpccpp/client.h
     
     - name: workaround for HUNTER
-      run: cd .. && mkdir -p "${HOME}"/.hunter/_Base/Download/crc32c/1.0.5/dc7fa8c/ && wget -O "${HOME}"/.hunter/_Base/Download/crc32c/1.0.5/dc7fa8c/hunter-1.0.5.tar.gz https://github.com/hunter-packages/crc32c/archive/refs/tags/hunter-1.0.5.tar.gz 
+      run: cd .. && mkdir -p "${HOME}"/.hunter/_Base/Download/crc32c/1.0.5/dc7fa8c/ && wget -O "${HOME}"/.hunter/_Base/Download/crc32c/1.0.5/dc7fa8c/hunter-1.0.5.tar.gz https://github.com/hunter-packages/crc32c/archive/tags/hunter-1.0.5.tar.gz 
 
     - name: build consensus
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,8 +174,8 @@ jobs:
     - name: verify jsonrpc has been built
       run: ls libBLS/deps/deps_inst/x86_or_x64/include/jsonrpccpp/client.h
     
-    - name: workaround for HUNTER
-      run: cd .. && mkdir -p "${HOME}"/.hunter/_Base/Download/crc32c/1.0.5/dc7fa8c/ && wget -O "${HOME}"/.hunter/_Base/Download/crc32c/1.0.5/dc7fa8c/hunter-1.0.5.tar.gz https://github.com/hunter-packages/crc32c/archive/tags/hunter-1.0.5.tar.gz 
+    # - name: workaround for HUNTER
+    #   run: cd .. && mkdir -p "${HOME}"/.hunter/_Base/Download/crc32c/1.0.5/dc7fa8c/ && wget -O "${HOME}"/.hunter/_Base/Download/crc32c/1.0.5/dc7fa8c/hunter-1.0.5.tar.gz https://github.com/hunter-packages/crc32c/archive/tags/hunter-1.0.5.tar.gz 
 
     - name: build consensus
       run: |

--- a/SkaleCommon.h
+++ b/SkaleCommon.h
@@ -183,6 +183,14 @@ static constexpr uint64_t WAIT_AFTER_NETWORK_ERROR_MS = 3000;
 
 static constexpr uint64_t CONNECTION_REFUSED_LOG_INTERVAL_MS = 10 * 60 * 1000;
 
+static constexpr uint64_t CATCHUP_TIMEOUT_MS = 30 * 1000;
+
+static constexpr uint64_t SYNC_NODE_CATCHUP_TIMEOUT_MS = 300 * 1000;
+
+static constexpr uint64_t READ_JSON_HEADER_TIMEOUT_MS = 6 * 1000;
+
+static constexpr uint64_t SYNC_NODE_READ_JSON_HEADER_TIMEOUT_MS = 300 * 1000;
+
 // Non-tunable params
 
 static constexpr uint32_t SOCKET_BACKLOG = 64;

--- a/SkaleCommon.h
+++ b/SkaleCommon.h
@@ -183,13 +183,13 @@ static constexpr uint64_t WAIT_AFTER_NETWORK_ERROR_MS = 3000;
 
 static constexpr uint64_t CONNECTION_REFUSED_LOG_INTERVAL_MS = 10 * 60 * 1000;
 
-static constexpr uint64_t CATCHUP_TIMEOUT_MS = 30 * 1000;
+static constexpr uint64_t CATCHUP_TIMEOUT_SEC = 30;
 
-static constexpr uint64_t SYNC_NODE_CATCHUP_TIMEOUT_MS = 300 * 1000;
+static constexpr uint64_t SYNC_NODE_CATCHUP_TIMEOUT_SEC = 300;
 
-static constexpr uint64_t READ_JSON_HEADER_TIMEOUT_MS = 6 * 1000;
+static constexpr uint64_t READ_JSON_HEADER_TIMEOUT_SEC = 6;
 
-static constexpr uint64_t SYNC_NODE_READ_JSON_HEADER_TIMEOUT_MS = 300 * 1000;
+static constexpr uint64_t SYNC_NODE_READ_JSON_HEADER_TIMEOUT_SEC = 300;
 
 // Non-tunable params
 

--- a/catchup/client/CatchupClientAgent.cpp
+++ b/catchup/client/CatchupClientAgent.cpp
@@ -76,7 +76,7 @@ nlohmann::json CatchupClientAgent::readCatchupResponseHeader(
     CHECK_ARGUMENT( _socket )
     CHECK_ARGUMENT( _requestHeader )
     auto result = sChain->getIo()->readJsonHeader( _socket->getDescriptor(),
-        "Read catchup response", 30, _socket->getIP(), MAX_CATCHUP_DOWNLOAD_BYTES );
+        "Read catchup response", 300, _socket->getIP(), MAX_CATCHUP_DOWNLOAD_BYTES );
     return result;
 }
 

--- a/catchup/client/CatchupClientAgent.cpp
+++ b/catchup/client/CatchupClientAgent.cpp
@@ -75,7 +75,7 @@ nlohmann::json CatchupClientAgent::readCatchupResponseHeader(
     const ptr< ClientSocket >& _socket, ptr< CatchupRequestHeader > _requestHeader ) {
     CHECK_ARGUMENT( _socket )
     CHECK_ARGUMENT( _requestHeader )
-    uint32_t timeoutSec = getNode()->isSyncOnlyNode() ? getNode()->getSyncNodeCatchupTimeoutSec() :
+    uint32_t timeoutSec = getNode()->isSyncOnlyNode() ? getNode()->getsyncNodeCatchupTimeoutSec() :
                                                         getNode()->getCatchupTimeoutSec();
     auto result = sChain->getIo()->readJsonHeader( _socket->getDescriptor(),
         "Read catchup response", timeoutSec, _socket->getIP(), MAX_CATCHUP_DOWNLOAD_BYTES );

--- a/catchup/client/CatchupClientAgent.cpp
+++ b/catchup/client/CatchupClientAgent.cpp
@@ -76,7 +76,7 @@ nlohmann::json CatchupClientAgent::readCatchupResponseHeader(
     CHECK_ARGUMENT( _socket )
     CHECK_ARGUMENT( _requestHeader )
     uint32_t timeoutSec = getNode()->isSyncOnlyNode() ? getNode()->getSyncNodecatchupTimeoutSec() :
-                                                        getNode()->getcatchupTimeoutSec();
+                                                        getNode()->getCatchupTimeoutSec();
     auto result = sChain->getIo()->readJsonHeader( _socket->getDescriptor(),
         "Read catchup response", timeoutSec, _socket->getIP(), MAX_CATCHUP_DOWNLOAD_BYTES );
     return result;

--- a/catchup/client/CatchupClientAgent.cpp
+++ b/catchup/client/CatchupClientAgent.cpp
@@ -75,7 +75,7 @@ nlohmann::json CatchupClientAgent::readCatchupResponseHeader(
     const ptr< ClientSocket >& _socket, ptr< CatchupRequestHeader > _requestHeader ) {
     CHECK_ARGUMENT( _socket )
     CHECK_ARGUMENT( _requestHeader )
-    uint32_t timeoutSec = getNode()->isSyncOnlyNode() ? getNode()->getSyncNodecatchupTimeoutSec() :
+    uint32_t timeoutSec = getNode()->isSyncOnlyNode() ? getNode()->getSyncNodeCatchupTimeoutSec() :
                                                         getNode()->getCatchupTimeoutSec();
     auto result = sChain->getIo()->readJsonHeader( _socket->getDescriptor(),
         "Read catchup response", timeoutSec, _socket->getIP(), MAX_CATCHUP_DOWNLOAD_BYTES );

--- a/catchup/client/CatchupClientAgent.cpp
+++ b/catchup/client/CatchupClientAgent.cpp
@@ -75,8 +75,8 @@ nlohmann::json CatchupClientAgent::readCatchupResponseHeader(
     const ptr< ClientSocket >& _socket, ptr< CatchupRequestHeader > _requestHeader ) {
     CHECK_ARGUMENT( _socket )
     CHECK_ARGUMENT( _requestHeader )
-    uint32_t timeoutSec = getNode()->isSyncOnlyNode() ? getNode()->getSyncNodeCatchupTimeoutMs() :
-                                                        getNode()->getCatchupTimeoutMs();
+    uint32_t timeoutSec = getNode()->isSyncOnlyNode() ? getNode()->getSyncNodecatchupTimeoutSec() :
+                                                        getNode()->getcatchupTimeoutSec();
     auto result = sChain->getIo()->readJsonHeader( _socket->getDescriptor(),
         "Read catchup response", timeoutSec, _socket->getIP(), MAX_CATCHUP_DOWNLOAD_BYTES );
     return result;

--- a/catchup/client/CatchupClientAgent.cpp
+++ b/catchup/client/CatchupClientAgent.cpp
@@ -75,7 +75,8 @@ nlohmann::json CatchupClientAgent::readCatchupResponseHeader(
     const ptr< ClientSocket >& _socket, ptr< CatchupRequestHeader > _requestHeader ) {
     CHECK_ARGUMENT( _socket )
     CHECK_ARGUMENT( _requestHeader )
-    uint32_t timeoutSec = getNode()->isSyncOnlyNode() ? 300 : 30;
+    uint32_t timeoutSec = getNode()->isSyncOnlyNode() ? getNode()->getSyncNodeCatchupTimeoutMs() :
+                                                        getNode()->getCatchupTimeoutMs();
     auto result = sChain->getIo()->readJsonHeader( _socket->getDescriptor(),
         "Read catchup response", timeoutSec, _socket->getIP(), MAX_CATCHUP_DOWNLOAD_BYTES );
     return result;

--- a/catchup/client/CatchupClientAgent.cpp
+++ b/catchup/client/CatchupClientAgent.cpp
@@ -75,8 +75,9 @@ nlohmann::json CatchupClientAgent::readCatchupResponseHeader(
     const ptr< ClientSocket >& _socket, ptr< CatchupRequestHeader > _requestHeader ) {
     CHECK_ARGUMENT( _socket )
     CHECK_ARGUMENT( _requestHeader )
+    uint32_t timeoutSec = getNode()->isSyncOnlyNode() ? 300 : 30;
     auto result = sChain->getIo()->readJsonHeader( _socket->getDescriptor(),
-        "Read catchup response", 300, _socket->getIP(), MAX_CATCHUP_DOWNLOAD_BYTES );
+        "Read catchup response", timeoutSec, _socket->getIP(), MAX_CATCHUP_DOWNLOAD_BYTES );
     return result;
 }
 

--- a/network/IO.cpp
+++ b/network/IO.cpp
@@ -265,7 +265,7 @@ nlohmann::json IO::readJsonHeader( file_descriptor descriptor, const char* _erro
 
     try {
         uint32_t timeoutSec = sChain->getNode()->isSyncOnlyNode() ?
-                                sChain->getNode()->getSyncNodereadJsonHeaderTimeoutSec() :
+                                sChain->getNode()->getSyncNodeReadJsonHeaderTimeoutSec() :
                                 sChain->getNode()->getReadJsonHeaderTimeoutSec();
         readBytes( descriptor, buf2, msg_len( sizeof( uint64_t ) ), timeoutSec );
     } catch ( ExitRequestedException& ) {

--- a/network/IO.cpp
+++ b/network/IO.cpp
@@ -265,8 +265,8 @@ nlohmann::json IO::readJsonHeader( file_descriptor descriptor, const char* _erro
 
     try {
         uint32_t timeoutSec = sChain->getNode()->isSyncOnlyNode() ?
-                                getNode()->getSyncNodeReadJsonHeaderTimeoutMs() :
-                                getNode()->getReadJsonHeaderTimeoutMs();
+                                sChain->getNode()->getSyncNodeReadJsonHeaderTimeoutMs() :
+                                sChain->getNode()->getReadJsonHeaderTimeoutMs();
         readBytes( descriptor, buf2, msg_len( sizeof( uint64_t ) ), timeoutSec );
     } catch ( ExitRequestedException& ) {
         throw;

--- a/network/IO.cpp
+++ b/network/IO.cpp
@@ -264,7 +264,9 @@ nlohmann::json IO::readJsonHeader( file_descriptor descriptor, const char* _erro
     auto buf2 = make_shared< vector< uint8_t > >( sizeof( uint64_t ) );
 
     try {
-        uint32_t timeoutSec = sChain->getNode()->isSyncOnlyNode() ? 300 : 6;
+        uint32_t timeoutSec = sChain->getNode()->isSyncOnlyNode() ?
+                                getNode()->getSyncNodeReadJsonHeaderTimeoutMs() :
+                                getNode()->getReadJsonHeaderTimeoutMs();
         readBytes( descriptor, buf2, msg_len( sizeof( uint64_t ) ), timeoutSec );
     } catch ( ExitRequestedException& ) {
         throw;

--- a/network/IO.cpp
+++ b/network/IO.cpp
@@ -264,7 +264,7 @@ nlohmann::json IO::readJsonHeader( file_descriptor descriptor, const char* _erro
     auto buf2 = make_shared< vector< uint8_t > >( sizeof( uint64_t ) );
 
     try {
-        readBytes( descriptor, buf2, msg_len( sizeof( uint64_t ) ), 6 );
+        readBytes( descriptor, buf2, msg_len( sizeof( uint64_t ) ), 300 );
     } catch ( ExitRequestedException& ) {
         throw;
     } catch ( ... ) {

--- a/network/IO.cpp
+++ b/network/IO.cpp
@@ -265,7 +265,7 @@ nlohmann::json IO::readJsonHeader( file_descriptor descriptor, const char* _erro
 
     try {
         uint32_t timeoutSec = sChain->getNode()->isSyncOnlyNode() ?
-                                sChain->getNode()->getSyncNodeReadJsonHeaderTimeoutSec() :
+                                sChain->getNode()->getsyncNodeReadJsonHeaderTimeoutSec() :
                                 sChain->getNode()->getReadJsonHeaderTimeoutSec();
         readBytes( descriptor, buf2, msg_len( sizeof( uint64_t ) ), timeoutSec );
     } catch ( ExitRequestedException& ) {

--- a/network/IO.cpp
+++ b/network/IO.cpp
@@ -264,7 +264,8 @@ nlohmann::json IO::readJsonHeader( file_descriptor descriptor, const char* _erro
     auto buf2 = make_shared< vector< uint8_t > >( sizeof( uint64_t ) );
 
     try {
-        readBytes( descriptor, buf2, msg_len( sizeof( uint64_t ) ), 300 );
+        uint32_t timeoutSec = sChain->getNode()->isSyncOnlyNode() ? 300 : 6;
+        readBytes( descriptor, buf2, msg_len( sizeof( uint64_t ) ), timeoutSec );
     } catch ( ExitRequestedException& ) {
         throw;
     } catch ( ... ) {

--- a/network/IO.cpp
+++ b/network/IO.cpp
@@ -266,7 +266,7 @@ nlohmann::json IO::readJsonHeader( file_descriptor descriptor, const char* _erro
     try {
         uint32_t timeoutSec = sChain->getNode()->isSyncOnlyNode() ?
                                 sChain->getNode()->getSyncNodereadJsonHeaderTimeoutSec() :
-                                sChain->getNode()->getreadJsonHeaderTimeoutSec();
+                                sChain->getNode()->getReadJsonHeaderTimeoutSec();
         readBytes( descriptor, buf2, msg_len( sizeof( uint64_t ) ), timeoutSec );
     } catch ( ExitRequestedException& ) {
         throw;

--- a/network/IO.cpp
+++ b/network/IO.cpp
@@ -265,8 +265,8 @@ nlohmann::json IO::readJsonHeader( file_descriptor descriptor, const char* _erro
 
     try {
         uint32_t timeoutSec = sChain->getNode()->isSyncOnlyNode() ?
-                                sChain->getNode()->getSyncNodeReadJsonHeaderTimeoutMs() :
-                                sChain->getNode()->getReadJsonHeaderTimeoutMs();
+                                sChain->getNode()->getSyncNodereadJsonHeaderTimeoutSec() :
+                                sChain->getNode()->getreadJsonHeaderTimeoutSec();
         readBytes( descriptor, buf2, msg_len( sizeof( uint64_t ) ), timeoutSec );
     } catch ( ExitRequestedException& ) {
         throw;

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -252,6 +252,13 @@ void Node::initParamsFromConfig() {
     maxTransactionsPerBlock =
         getParamUint64( "maxTransactionsPerBlock", MAX_TRANSACTIONS_PER_BLOCK );
     minBlockIntervalMs = getParamUint64( "minBlockIntervalMs", MIN_BLOCK_INTERVAL_MS );
+    catchupTimeoutMs = getParamUint64( "catchupTimeoutMs", CATCHUP_TIMEOUT_MS );
+    syncNodeCatchupTimeoutMs =
+        getParamUint64( "syncNodeCatchupTimeoutMs", SYNC_NODE_CATCHUP_TIMEOUT_MS );
+    readJsonHeaderTimeoutMs =
+        getParamUint64( "readJsonHeaderTimeoutMs", READ_JSON_HEADER_TIMEOUT_MS );
+    syncNodeReadJsonHeaderTimeoutMs =
+        getParamUint64( "syncNodeReadJsonHeaderTimeoutMs", SYNC_NODE_READ_JSON_HEADER_TIMEOUT_MS );
     testNet = ( getParamUint64( "isTestNet", 0 ) > 0 );
 
     blockDBSize = storageLimits->getBlockDbSize();

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -253,12 +253,12 @@ void Node::initParamsFromConfig() {
         getParamUint64( "maxTransactionsPerBlock", MAX_TRANSACTIONS_PER_BLOCK );
     minBlockIntervalMs = getParamUint64( "minBlockIntervalMs", MIN_BLOCK_INTERVAL_MS );
     catchupTimeoutSec = getParamUint64( "catchupTimeoutSec", CATCHUP_TIMEOUT_SEC );
-    syncNodecatchupTimeoutSec =
-        getParamUint64( "syncNodecatchupTimeoutSec", SYNC_NODE_CATCHUP_TIMEOUT_SEC );
+    syncNodeCatchupTimeoutSec =
+        getParamUint64( "syncNodeCatchupTimeoutSec", SYNC_NODE_CATCHUP_TIMEOUT_SEC );
     readJsonHeaderTimeoutSec =
         getParamUint64( "readJsonHeaderTimeoutSec", READ_JSON_HEADER_TIMEOUT_SEC );
-    syncNodereadJsonHeaderTimeoutSec =
-        getParamUint64( "syncNodereadJsonHeaderTimeoutSec", SYNC_NODE_READ_JSON_HEADER_TIMEOUT_SEC );
+    syncNodeReadJsonHeaderTimeoutSec =
+        getParamUint64( "syncNodeReadJsonHeaderTimeoutSec", SYNC_NODE_READ_JSON_HEADER_TIMEOUT_SEC );
     testNet = ( getParamUint64( "isTestNet", 0 ) > 0 );
 
     blockDBSize = storageLimits->getBlockDbSize();

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -252,13 +252,13 @@ void Node::initParamsFromConfig() {
     maxTransactionsPerBlock =
         getParamUint64( "maxTransactionsPerBlock", MAX_TRANSACTIONS_PER_BLOCK );
     minBlockIntervalMs = getParamUint64( "minBlockIntervalMs", MIN_BLOCK_INTERVAL_MS );
-    catchupTimeoutMs = getParamUint64( "catchupTimeoutMs", CATCHUP_TIMEOUT_MS );
-    syncNodeCatchupTimeoutMs =
-        getParamUint64( "syncNodeCatchupTimeoutMs", SYNC_NODE_CATCHUP_TIMEOUT_MS );
-    readJsonHeaderTimeoutMs =
-        getParamUint64( "readJsonHeaderTimeoutMs", READ_JSON_HEADER_TIMEOUT_MS );
-    syncNodeReadJsonHeaderTimeoutMs =
-        getParamUint64( "syncNodeReadJsonHeaderTimeoutMs", SYNC_NODE_READ_JSON_HEADER_TIMEOUT_MS );
+    catchupTimeoutSec = getParamUint64( "catchupTimeoutSec", CATCHUP_TIMEOUT_MS );
+    syncNodecatchupTimeoutSec =
+        getParamUint64( "syncNodecatchupTimeoutSec", SYNC_NODE_CATCHUP_TIMEOUT_MS );
+    readJsonHeaderTimeoutSec =
+        getParamUint64( "readJsonHeaderTimeoutSec", READ_JSON_HEADER_TIMEOUT_MS );
+    syncNodereadJsonHeaderTimeoutSec =
+        getParamUint64( "syncNodereadJsonHeaderTimeoutSec", SYNC_NODE_READ_JSON_HEADER_TIMEOUT_MS );
     testNet = ( getParamUint64( "isTestNet", 0 ) > 0 );
 
     blockDBSize = storageLimits->getBlockDbSize();

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -252,13 +252,13 @@ void Node::initParamsFromConfig() {
     maxTransactionsPerBlock =
         getParamUint64( "maxTransactionsPerBlock", MAX_TRANSACTIONS_PER_BLOCK );
     minBlockIntervalMs = getParamUint64( "minBlockIntervalMs", MIN_BLOCK_INTERVAL_MS );
-    catchupTimeoutSec = getParamUint64( "catchupTimeoutSec", CATCHUP_TIMEOUT_MS );
+    catchupTimeoutSec = getParamUint64( "catchupTimeoutSec", CATCHUP_TIMEOUT_SEC );
     syncNodecatchupTimeoutSec =
-        getParamUint64( "syncNodecatchupTimeoutSec", SYNC_NODE_CATCHUP_TIMEOUT_MS );
+        getParamUint64( "syncNodecatchupTimeoutSec", SYNC_NODE_CATCHUP_TIMEOUT_SEC );
     readJsonHeaderTimeoutSec =
-        getParamUint64( "readJsonHeaderTimeoutSec", READ_JSON_HEADER_TIMEOUT_MS );
+        getParamUint64( "readJsonHeaderTimeoutSec", READ_JSON_HEADER_TIMEOUT_SEC );
     syncNodereadJsonHeaderTimeoutSec =
-        getParamUint64( "syncNodereadJsonHeaderTimeoutSec", SYNC_NODE_READ_JSON_HEADER_TIMEOUT_MS );
+        getParamUint64( "syncNodereadJsonHeaderTimeoutSec", SYNC_NODE_READ_JSON_HEADER_TIMEOUT_SEC );
     testNet = ( getParamUint64( "isTestNet", 0 ) > 0 );
 
     blockDBSize = storageLimits->getBlockDbSize();

--- a/node/Node.h
+++ b/node/Node.h
@@ -405,6 +405,14 @@ public:
     uint64_t getMaxTransactionsPerBlock() const;
 
     uint64_t getMinBlockIntervalMs() const;
+    
+    uint64_t getCatchupTimeoutMs() const;
+
+    uint64_t getSyncNodeCatchupTimeoutMs() const;
+
+    uint64_t getReadJsonHeaderTimeoutMs() const;
+
+    uint64_t getSyncNodeReadJsonHeaderTimeoutMs() const;
 
     uint64_t getWaitAfterNetworkErrorMs();
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -406,11 +406,11 @@ public:
 
     uint64_t getMinBlockIntervalMs() const;
     
-    uint64_t getcatchupTimeoutSec() const;
+    uint64_t getCatchupTimeoutSec() const;
 
     uint64_t getSyncNodecatchupTimeoutSec() const;
 
-    uint64_t getreadJsonHeaderTimeoutSec() const;
+    uint64_t getReadJsonHeaderTimeoutSec() const;
 
     uint64_t getSyncNodereadJsonHeaderTimeoutSec() const;
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -203,13 +203,13 @@ class Node {
 
     uint64_t blockDBSize = 0;
 
-    uint64_t catchupTimeoutMs = 0;
+    uint64_t catchupTimeoutSec = 0;
 
-    uint64_t syncNodeCatchupTimeoutMs = 0;
+    uint64_t syncNodecatchupTimeoutSec = 0;
 
-    uint64_t readJsonHeaderTimeoutMs = 0;
+    uint64_t readJsonHeaderTimeoutSec = 0;
 
-    uint64_t syncNodeReadJsonHeaderTimeoutMs = 0;
+    uint64_t syncNodereadJsonHeaderTimeoutSec = 0;
     ;
     uint64_t proposalHashDBSize = 0;
     uint64_t proposalVectorDBSize = 0;
@@ -406,13 +406,13 @@ public:
 
     uint64_t getMinBlockIntervalMs() const;
     
-    uint64_t getCatchupTimeoutMs() const;
+    uint64_t getcatchupTimeoutSec() const;
 
-    uint64_t getSyncNodeCatchupTimeoutMs() const;
+    uint64_t getSyncNodecatchupTimeoutSec() const;
 
-    uint64_t getReadJsonHeaderTimeoutMs() const;
+    uint64_t getreadJsonHeaderTimeoutSec() const;
 
-    uint64_t getSyncNodeReadJsonHeaderTimeoutMs() const;
+    uint64_t getSyncNodereadJsonHeaderTimeoutSec() const;
 
     uint64_t getWaitAfterNetworkErrorMs();
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -202,6 +202,14 @@ class Node {
     uint64_t minBlockIntervalMs = 0;
 
     uint64_t blockDBSize = 0;
+
+    uint64_t catchupTimeoutMs = 0;
+
+    uint64_t syncNodeCatchupTimeoutMs = 0;
+
+    uint64_t readJsonHeaderTimeoutMs = 0;
+
+    uint64_t syncNodeReadJsonHeaderTimeoutMs = 0;
     ;
     uint64_t proposalHashDBSize = 0;
     uint64_t proposalVectorDBSize = 0;

--- a/node/Node.h
+++ b/node/Node.h
@@ -408,11 +408,11 @@ public:
     
     uint64_t getCatchupTimeoutSec() const;
 
-    uint64_t getSyncNodecatchupTimeoutSec() const;
+    uint64_t getSyncNodeCatchupTimeoutSec() const;
 
     uint64_t getReadJsonHeaderTimeoutSec() const;
 
-    uint64_t getSyncNodereadJsonHeaderTimeoutSec() const;
+    uint64_t getSyncNodeReadJsonHeaderTimeoutSec() const;
 
     uint64_t getWaitAfterNetworkErrorMs();
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -205,11 +205,11 @@ class Node {
 
     uint64_t catchupTimeoutSec = 0;
 
-    uint64_t syncNodecatchupTimeoutSec = 0;
+    uint64_t syncNodeCatchupTimeoutSec = 0;
 
     uint64_t readJsonHeaderTimeoutSec = 0;
 
-    uint64_t syncNodereadJsonHeaderTimeoutSec = 0;
+    uint64_t syncNodeReadJsonHeaderTimeoutSec = 0;
     ;
     uint64_t proposalHashDBSize = 0;
     uint64_t proposalVectorDBSize = 0;
@@ -408,11 +408,11 @@ public:
     
     uint64_t getCatchupTimeoutSec() const;
 
-    uint64_t getSyncNodeCatchupTimeoutSec() const;
+    uint64_t getsyncNodeCatchupTimeoutSec() const;
 
     uint64_t getReadJsonHeaderTimeoutSec() const;
 
-    uint64_t getSyncNodeReadJsonHeaderTimeoutSec() const;
+    uint64_t getsyncNodeReadJsonHeaderTimeoutSec() const;
 
     uint64_t getWaitAfterNetworkErrorMs();
 

--- a/node/NodeGettersSetters.cpp
+++ b/node/NodeGettersSetters.cpp
@@ -434,7 +434,7 @@ uint64_t Node::getCatchupTimeoutSec() const {
     return catchupTimeoutSec;
 }
 
-uint64_t Node::getSyncNodecatchupTimeoutSec() const {
+uint64_t Node::getSyncNodeCatchupTimeoutSec() const {
     return syncNodecatchupTimeoutSec;
 }
 
@@ -442,6 +442,6 @@ uint64_t Node::getReadJsonHeaderTimeoutSec() const {
     return readJsonHeaderTimeoutSec;
 }
 
-uint64_t Node::getSyncNodereadJsonHeaderTimeoutSec() const {
+uint64_t Node::getSyncNodeReadJsonHeaderTimeoutSec() const {
     return syncNodereadJsonHeaderTimeoutSec;
 }

--- a/node/NodeGettersSetters.cpp
+++ b/node/NodeGettersSetters.cpp
@@ -429,3 +429,19 @@ void Node::setExitOnBlockBoundaryRequested() {
     LOG( info, "Set exit on block boundary" );
     exitOnBlockBoundaryRequested = true;
 }
+
+void Node::getCatchupTimeoutMs() const {
+    return catchupTimeoutMs;
+}
+
+void Node::getSyncNodeCatchupTimeoutMs() const {
+    return syncNodeCatchupTimeoutMs;
+}
+
+void Node::getReadJsonHeaderTimeoutMs() const {
+    return readJsonHeaderTimeoutMs;
+}
+
+void Node::getSyncNodeReadJsonHeaderTimeoutMs() const {
+    return syncNodeReadJsonHeaderTimeoutMs;
+}

--- a/node/NodeGettersSetters.cpp
+++ b/node/NodeGettersSetters.cpp
@@ -430,18 +430,18 @@ void Node::setExitOnBlockBoundaryRequested() {
     exitOnBlockBoundaryRequested = true;
 }
 
-void Node::getCatchupTimeoutMs() const {
+uint64_t Node::getCatchupTimeoutMs() const {
     return catchupTimeoutMs;
 }
 
-void Node::getSyncNodeCatchupTimeoutMs() const {
+uint64_t Node::getSyncNodeCatchupTimeoutMs() const {
     return syncNodeCatchupTimeoutMs;
 }
 
-void Node::getReadJsonHeaderTimeoutMs() const {
+uint64_t Node::getReadJsonHeaderTimeoutMs() const {
     return readJsonHeaderTimeoutMs;
 }
 
-void Node::getSyncNodeReadJsonHeaderTimeoutMs() const {
+uint64_t Node::getSyncNodeReadJsonHeaderTimeoutMs() const {
     return syncNodeReadJsonHeaderTimeoutMs;
 }

--- a/node/NodeGettersSetters.cpp
+++ b/node/NodeGettersSetters.cpp
@@ -430,18 +430,18 @@ void Node::setExitOnBlockBoundaryRequested() {
     exitOnBlockBoundaryRequested = true;
 }
 
-uint64_t Node::getCatchupTimeoutMs() const {
-    return catchupTimeoutMs;
+uint64_t Node::getcatchupTimeoutSec() const {
+    return catchupTimeoutSec;
 }
 
-uint64_t Node::getSyncNodeCatchupTimeoutMs() const {
-    return syncNodeCatchupTimeoutMs;
+uint64_t Node::getSyncNodecatchupTimeoutSec() const {
+    return syncNodecatchupTimeoutSec;
 }
 
-uint64_t Node::getReadJsonHeaderTimeoutMs() const {
-    return readJsonHeaderTimeoutMs;
+uint64_t Node::getreadJsonHeaderTimeoutSec() const {
+    return readJsonHeaderTimeoutSec;
 }
 
-uint64_t Node::getSyncNodeReadJsonHeaderTimeoutMs() const {
-    return syncNodeReadJsonHeaderTimeoutMs;
+uint64_t Node::getSyncNodereadJsonHeaderTimeoutSec() const {
+    return syncNodereadJsonHeaderTimeoutSec;
 }

--- a/node/NodeGettersSetters.cpp
+++ b/node/NodeGettersSetters.cpp
@@ -430,7 +430,7 @@ void Node::setExitOnBlockBoundaryRequested() {
     exitOnBlockBoundaryRequested = true;
 }
 
-uint64_t Node::getcatchupTimeoutSec() const {
+uint64_t Node::getCatchupTimeoutSec() const {
     return catchupTimeoutSec;
 }
 
@@ -438,7 +438,7 @@ uint64_t Node::getSyncNodecatchupTimeoutSec() const {
     return syncNodecatchupTimeoutSec;
 }
 
-uint64_t Node::getreadJsonHeaderTimeoutSec() const {
+uint64_t Node::getReadJsonHeaderTimeoutSec() const {
     return readJsonHeaderTimeoutSec;
 }
 

--- a/node/NodeGettersSetters.cpp
+++ b/node/NodeGettersSetters.cpp
@@ -434,14 +434,14 @@ uint64_t Node::getCatchupTimeoutSec() const {
     return catchupTimeoutSec;
 }
 
-uint64_t Node::getSyncNodeCatchupTimeoutSec() const {
-    return syncNodecatchupTimeoutSec;
+uint64_t Node::getsyncNodeCatchupTimeoutSec() const {
+    return syncNodeCatchupTimeoutSec;
 }
 
 uint64_t Node::getReadJsonHeaderTimeoutSec() const {
     return readJsonHeaderTimeoutSec;
 }
 
-uint64_t Node::getSyncNodeReadJsonHeaderTimeoutSec() const {
-    return syncNodereadJsonHeaderTimeoutSec;
+uint64_t Node::getsyncNodeReadJsonHeaderTimeoutSec() const {
+    return syncNodeReadJsonHeaderTimeoutSec;
 }


### PR DESCRIPTION
fixes https://github.com/skalenetwork/internal-support/issues/945

increase timeouts for catchup

tests:
- spin up an archive node for an old chain with a lot of produced blocks
- verify that it cannt catchup old blocks
- update archive node to the latest version
- archive node should be able to catchup blocks