### PR TITLE
fix memory leak

### DIFF
--- a/db/CacheLevelDB.cpp
+++ b/db/CacheLevelDB.cpp
@@ -397,7 +397,10 @@ CacheLevelDB::CacheLevelDB( Schain* _sChain, string& _dirName, string& _prefix, 
     verify();
 }
 
-CacheLevelDB::~CacheLevelDB() {}
+CacheLevelDB::~CacheLevelDB() {
+    if (options.block_cache)
+        delete options.block_cache;
+}
 
 using namespace boost::filesystem;
 


### PR DESCRIPTION
fixes #856 

fixes memory leak in `CacheLevelDB ` caused by not deleting `options.block_cache`
test:
- build skaled with `-fsanitize=address`
- run skaled for 400 blocks while senidng transactions on it.

result: no memory leaks detected, skaled exited without any errors.