### PR TITLE
Enhancement/841 Improve Sgx Related Logs

### DIFF
--- a/catchup/client/CatchupClientAgent.cpp
+++ b/catchup/client/CatchupClientAgent.cpp
@@ -269,10 +269,15 @@ ptr< CommittedBlockList > CatchupClientAgent::readMissingBlocks( ptr< ClientSock
 
 
         if ( blockSizes->size() > 1 ) {
-            LOG( info, "CATCHUP_GOT_BLOCKS:COUNT:"
+            if ( blockList->getBlocks()->size() > 1) {
+                LOG( info, "CATCHUP_GOT_BLOCKS:COUNT:"
                            << to_string( blockSizes->size() ) << ":STARTBLOCK:"
                            << string( blockList->getBlocks()->at( 0 )->getBlockID() )
                            << ":FROM_NODE:" << _socket->getIP() );
+            }
+            else {
+                LOG( err, "Could not deserialize blocks" );
+            }
         }
     } catch ( ExitRequestedException& ) {
         throw;

--- a/json/JSONFactory.cpp
+++ b/json/JSONFactory.cpp
@@ -570,7 +570,7 @@ void JSONFactory::checkSGXStatus( Json::Value& _result ) {
 
     if ( status != 0 ) {
         LOG( err, "SGX server returned error status:" << to_string( status ) );
-        LOG( err, _result.asString() );
+        LOG( err, _result["errorMessage"].asString() );
     }
 
     CHECK_STATE( status == 0 );

--- a/sgxclient/SgxZmqMessage.cpp
+++ b/sgxclient/SgxZmqMessage.cpp
@@ -80,6 +80,11 @@ shared_ptr< SgxZmqMessage > SgxZmqMessage::parse(
 
     CHECK_STATE( ( *d )["status"].IsNumber() )
     uint64_t status = ( *d )["status"].GetInt64();
+
+    if ( status != 0 ) {
+        LOG( err, ( *d )["errorMessage"].GetString() );
+    }
+
     CHECK_STATE( status == 0 );
 
     CHECK_STATE( d->HasMember( "type" ) );


### PR DESCRIPTION
# Description

Added logs on libconsensus side to print errors returned from sgx server.

# Tests

 -  Tested changing ecdsaKeyName,and keyShareName for errors relative to fetching non-existent keys.
 -  Tested changing the bls keys, but there were already error loggers on these.

Fixes #841 

## Note
This pr is replicate from a closed pr that included non-signed commits: https://github.com/skalenetwork/skale-consensus/pull/857