### PR TITLE
IS 1187 - Fix Type 1 transaction parsing

### DIFF
--- a/rlp/ParsedEthTransaction.cpp
+++ b/rlp/ParsedEthTransaction.cpp
@@ -310,6 +310,8 @@ ptr< std::vector< uint8_t > > ParsedEthTransaction::getTransactionDataField() {
         index = 5;
         break;
     case 1:
+        index = 6;
+        break;
     case 2:
         index = 7;
         break;
@@ -329,6 +331,8 @@ void ParsedEthTransaction::setTransactionDataField(vector<uint8_t>&  _dataField)
         index = 5;
         break;
     case 1:
+        index = 6;
+        break;
     case 2:
         index = 7;
         break;


### PR DESCRIPTION
fixes skalenetwork/internal-support#1187 , skalenetwork/internal-support#1188 

### Description

Type 1 transactions' data field was incorrectly fetched.
Type 1 transactions were still being correctly RLP parsed, but after building the in-memory structure holding each field individually, the method to fetch the data part was fetching using the wrong index.