### PR TITLE
write te stats to logs

### DIFF
--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -714,6 +714,9 @@ void Schain::printBlockLog( const ptr< CommittedBlock >& _block ) {
                << ":DSDS:" << getSchain()->getNode()->getNetwork()->computeTotalDelayedSends()
                << ":SET:" << CryptoManager::getEcdsaStats()
                << ":SBT:" << CryptoManager::getBLSStats()
+#ifdef BITE
+               << ":STET:" << CryptoManager::getTEDecryptStats()
+#endif
                << ":SEC:" << CryptoManager::getECDSATotals()
                << ":SBC:" << CryptoManager::getBLSTotals()
                << ":ZSC:" << getCryptoManager()->getZMQSocketCount()

--- a/crypto/CryptoManager.h
+++ b/crypto/CryptoManager.h
@@ -303,6 +303,8 @@ public:
 
 #ifdef BITE
     static void addTEDecryptStats(uint64_t _time);
+
+    static uint64_t getTEDecryptStats() { return teDecryptShareTotal / LEVELDB_STATS_HISTORY; }
 #endif
 
     static void addBLSSignStats(uint64_t _time);


### PR DESCRIPTION
relates to https://github.com/skalenetwork/internal-support/issues/1228

added more logs to display metrics for sgx threshold encryption part