### PR TITLE
#893 add missing virtual destructor

### DIFF
--- a/rlp/EthTransaction.h
+++ b/rlp/EthTransaction.h
@@ -83,6 +83,8 @@ struct EthTransaction {
         const uint256& chainId)
         : nonce(nonce), gasLimit(gasLimit), to(to), value(value), data(data), chainId(chainId)
     {}
+
+    virtual ~EthTransaction() {}
     
     /**
      * @brief Signs a transaction, returning the resulting signature.


### PR DESCRIPTION
fixes #893 

`EthTransaction` class was missing virtual destructor that lead to invalid memory freeing for objects of the derived classes ( which are `LegacyTx`, `Type1Tx` and `Type2Tx` ) and caused `AddressSanitizer: new-delete-type-mismatch` error and potentially might cause `SIGABRT`

see the [original issue](https://github.com/skalenetwork/skale-consensus/issues/893) for more info

adding missing virtual destructor solves the issue