### PR TITLE
Feature/skaled 2180 rotation on the fly

### DIFF
--- a/db/CacheLevelDB.cpp
+++ b/db/CacheLevelDB.cpp
@@ -109,7 +109,7 @@ Schain* CacheLevelDB::getSchain() const {
     return sChain;
 }
 
-string CacheLevelDB::readString( string& _key ) {
+string CacheLevelDB::readString( const string& _key ) {
     checkForDeadLockRead( __FUNCTION__ );
     shared_lock< shared_timed_mutex > lock( m );
     return readStringUnsafe( _key );
@@ -117,7 +117,7 @@ string CacheLevelDB::readString( string& _key ) {
 
 #include "utils/Time.h"
 
-string CacheLevelDB::readStringUnsafe( string& _key ) {
+string CacheLevelDB::readStringUnsafe( const string& _key ) {
     uint64_t time = 0;
 
     readCounter.fetch_add( 1 );

--- a/db/CacheLevelDB.h
+++ b/db/CacheLevelDB.h
@@ -69,8 +69,8 @@ protected:
         const char* _value, uint64_t _valueLen, block_id _blockId, schain_index _index );
     string index2Path( uint64_t index );
 
-    string readString( string& _key );
-    string readStringUnsafe( string& _key );
+    string readString( const string& _key );
+    string readStringUnsafe( const string& _key );
 
     void writeString( const string& key1, const string& value1, bool overWrite = false );
 

--- a/db/ProposalHashDB.cpp
+++ b/db/ProposalHashDB.cpp
@@ -37,6 +37,7 @@ ProposalHashDB::ProposalHashDB(
     Schain* _sChain, string& _dirName, string& _prefix, node_id _nodeId, uint64_t _maxDBSize )
     : CacheLevelDB( _sChain, _dirName, _prefix, _nodeId, _maxDBSize,
           LevelDBOptions::getProposalHashDBOptions(), false ) {
+#ifndef MIRAGE
     static string SCHAIN_INDEX = "schainIndex";
 
     auto index = this->readString( SCHAIN_INDEX );
@@ -50,6 +51,7 @@ ProposalHashDB::ProposalHashDB(
                             "This should never happen.  Fix the config and restart the node." ) );
         }
     }
+#endif
 }
 
 

--- a/db/ProposalHashDB.cpp
+++ b/db/ProposalHashDB.cpp
@@ -38,7 +38,7 @@ ProposalHashDB::ProposalHashDB(
     : CacheLevelDB( _sChain, _dirName, _prefix, _nodeId, _maxDBSize,
           LevelDBOptions::getProposalHashDBOptions(), false ) {
 #ifndef MIRAGE
-    static string SCHAIN_INDEX = "schainIndex";
+    constexpr const char* SCHAIN_INDEX = "schainIndex";
 
     auto index = this->readString( SCHAIN_INDEX );
 

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -768,10 +768,6 @@ void ConsensusEngine::exitGracefully() {
 }
 
 #ifdef MIRAGE
-void ConsensusEngine::restartWithNewConfig( const std::string& _config ) {
-    ( void ) _config;
-}
-
 void ConsensusEngine::updateLogger() const {
     logThreadLocal_ = nodes.begin()->second->getLog();
 }

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -767,6 +767,16 @@ void ConsensusEngine::exitGracefully() {
     thread( [this]() { exitGracefullyAsync(); } ).detach();
 }
 
+#ifdef MIRAGE
+void ConsensusEngine::restartWithNewConfig( const std::string& _config ) {
+    ( void ) _config;
+}
+
+void ConsensusEngine::updateLogger() const {
+    logThreadLocal_ = nodes.begin()->second->getLog();
+}
+#endif
+
 // used in tests only
 void ConsensusEngine::testExitGracefullyBlocking() {
     exitGracefully();

--- a/node/ConsensusEngine.h
+++ b/node/ConsensusEngine.h
@@ -242,8 +242,6 @@ public:
     virtual void exitGracefully() override;
 
 #ifdef MIRAGE
-    virtual void restartWithNewConfig( const std::string& _config ) override;
-
     virtual void updateLogger() const override;
 #endif
 

--- a/node/ConsensusEngine.h
+++ b/node/ConsensusEngine.h
@@ -241,6 +241,12 @@ public:
 
     virtual void exitGracefully() override;
 
+#ifdef MIRAGE
+    virtual void restartWithNewConfig( const std::string& _config ) override;
+
+    virtual void updateLogger() const override;
+#endif
+
 
     // used in tests
     void testExitGracefullyBlocking();
@@ -298,13 +304,11 @@ public:
 
     static int getOpenDescriptors();
 
-
     uint64_t submitOracleRequest(
         const string& _spec, string& _receipt, string& _errorMessage ) override;
 
 
     uint64_t checkOracleResult( const string& _receipt, string& _result ) override;
-
 
 
     std::shared_ptr< std::vector< std::uint8_t > > getSerializedBlock( std::uint64_t _blockNumber );

--- a/node/ConsensusInterface.h
+++ b/node/ConsensusInterface.h
@@ -221,8 +221,6 @@ public:
     virtual SyncInfo getSyncInfo() = 0;
 
 #ifdef MIRAGE
-    virtual void restartWithNewConfig( const std::string& _config ) = 0;
-
     virtual void updateLogger() const = 0;
 #endif
 

--- a/node/ConsensusInterface.h
+++ b/node/ConsensusInterface.h
@@ -113,6 +113,7 @@ public:
 
     virtual consensus_engine_status getStatus() const = 0;
 
+
 #define ORACLE_SUCCESS 0
 #define ORACLE_UNKNOWN_RECEIPT 1
 #define ORACLE_TIMEOUT 2
@@ -202,7 +203,6 @@ public:
 
     virtual uint64_t checkOracleResult(const std::string &_receipt, std::string &_result) = 0;
 
-
     struct SyncInfo {
         // sync information as required by eth_syncing API request of geth
         bool isSyncing = false;
@@ -219,6 +219,12 @@ public:
     // return sync information as requested by eth_syncing API of geth
     // if isSyncing is false, all fields will be set to zero.
     virtual SyncInfo getSyncInfo() = 0;
+
+#ifdef MIRAGE
+    virtual void restartWithNewConfig( const std::string& _config ) = 0;
+
+    virtual void updateLogger() const = 0;
+#endif
 
 };
 


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/2180

on committee rotation skaled will recreate consensus instance thus will reinitialize all the variables

logger is a thread local variable so it has to be updated in the same thread it was created

disable schain index check because nodes are no longer guaranteed to keep their index in chain after rotation (only for FAIR)