### PR TITLE
RLP encode BITE transaction data field

### DIFF
--- a/bite/BiteDataField.cpp
+++ b/bite/BiteDataField.cpp
@@ -7,41 +7,54 @@
 #include <crypto/EncryptedAESKey.h>
 
 #include "bite/BiteDataFiled.h"
+#include "rlp/RLPStream.h"
+#include "rlp/RLP.h"
 
 /// Minimum size of BITE field excluding the ciphertext from libBLS
 /// which includes both the key + ciphered data
 const auto BITE_MIN_DATA_LEN = BITE_EPOCH_ID_LEN + ADDRESS_SIZE;
 
 BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusData, uint64_t _epoch)
-    : encryptedData(_encryptedKeyPlusData), epoch(_epoch) {
+    : keyPlusEncryptedData(_encryptedKeyPlusData), epoch(_epoch) {
     CHECK_STATE(_encryptedKeyPlusData);
     CHECK_STATE(_encryptedKeyPlusData->size() > BITE_ENCRYPTED_AES_KEY_LEN);
-    
     
     auto aesKeyArray = std::make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>>();
     std::copy_n(_encryptedKeyPlusData->begin(), BITE_ENCRYPTED_AES_KEY_LEN, aesKeyArray->begin());
     encryptedAESKey = std::make_shared<EncryptedAESKey>(aesKeyArray);
-    serializedData = make_shared<vector<uint8_t> >();
-    serializedData->reserve(BITE_MIN_DATA_LEN + _encryptedKeyPlusData->size());
+
+    // build serialized RLP-encoded data field
     uint64_t epochBE = boost::endian::native_to_big(_epoch);
-    uint8_t* epochBytes = reinterpret_cast<uint8_t*>(&epochBE);
-    serializedData->insert(serializedData->end(), epochBytes, epochBytes + sizeof(epochBE));
-    serializedData->insert(serializedData->end(), encryptedData->begin(), encryptedData->end());
+    std::vector<uint8_t> epochBytes(reinterpret_cast<uint8_t*>(&epochBE),
+                                reinterpret_cast<uint8_t*>(&epochBE) + sizeof(epochBE));
+
+    RLPStream rlpStream;
+    rlpStream << epochBytes << *_encryptedKeyPlusData;
+    serializedData = make_shared<vector<uint8_t> >(rlpStream.encode());
 }
 
 BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data) {
-    CHECK_STATE(_data)
-    CHECK_STATE(_data->size() > BITE_EPOCH_ID_LEN + BITE_ENCRYPTED_AES_KEY_LEN);
+    CHECK_STATE(_data);
 
+    // parse RLP-encoded tx data field
+    RLPItem rlp(*_data);
+    CHECK_STATE2(rlp.isList(), "RLP item is not a list");
+    CHECK_STATE2(rlp.size() == 2, "RLP item should have at least 2 fields - EPOCH_ID, and bite encrypted data");
+    
+    // validate EPOCH ID
+    const auto epoch_id = rlp[0].asBytes();
+    CHECK_STATE2(epoch_id.size() == BITE_EPOCH_ID_LEN,
+        "Incorrectly formatted BITE transaction: EPOCH_ID size is not " + to_string(BITE_EPOCH_ID_LEN) + " bytes, found: " + to_string(epoch_id.size()));
+
+    // validate encrypted data
+    keyPlusEncryptedData = make_shared<std::vector<uint8_t>>(rlp[1].asBytes());
+    CHECK_STATE2(keyPlusEncryptedData->size() >= BITE_ENCRYPTED_AES_KEY_LEN,
+        "Incorrectly formatted BITE transaction: Encrypted data size is not at least " + to_string(BITE_ENCRYPTED_AES_KEY_LEN) + " bytes, found: " + to_string(keyPlusEncryptedData->size()));
+    // get encrypted key part
     auto keyVec = std::make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> >();
-
-    std::copy_n(_data->begin() + BITE_EPOCH_ID_LEN, BITE_ENCRYPTED_AES_KEY_LEN, keyVec->begin());
-
-    auto encryptedDataStart = _data->begin() + BITE_EPOCH_ID_LEN;
+    std::copy_n(keyPlusEncryptedData->begin(), BITE_ENCRYPTED_AES_KEY_LEN, keyVec->begin());
     encryptedAESKey = make_shared<EncryptedAESKey>(keyVec);
-    encryptedData = make_shared<EncryptedData>(encryptedDataStart, _data->end());
-    keyPlusEncryptedData = make_shared<vector<uint8_t>>(_data->begin() + BITE_EPOCH_ID_LEN,
-        _data->end());
+
     serializedData = _data;
 }
 
@@ -52,15 +65,9 @@ const shared_ptr< EncryptedData >& BiteDataField::getKeyPlusEncryptedData() cons
     return keyPlusEncryptedData;
 }
 
-ptr<EncryptedData> &BiteDataField::getEncryptedData() {
-    CHECK_STATE(encryptedData)
-    return encryptedData;
-}
-
 uint64_t BiteDataField::getEpoch() {
     return epoch;
 }
-
 
 
 ptr<BiteDataField> BiteDataField::createIfMagicMatches(ptr<vector<uint8_t> > &_data, ptr<vector<uint8_t> > &_to) {
@@ -72,9 +79,6 @@ ptr<BiteDataField> BiteDataField::createIfMagicMatches(ptr<vector<uint8_t> > &_d
                     _to->begin())) {
         return nullptr;
     }
-
-    CHECK_STATE2 (_data->size() >= BITE_MIN_DATA_LEN + BITE_ENCRYPTED_AES_KEY_LEN,
-        "Icorrectly formatted BITE transaction: Data size too short" + to_string(_data->size()));
 
     return ptr<BiteDataField>(new BiteDataField(_data));
 }

--- a/bite/BiteDataField.cpp
+++ b/bite/BiteDataField.cpp
@@ -14,14 +14,24 @@
 /// which includes both the key + ciphered data
 const auto BITE_MIN_DATA_LEN = BITE_EPOCH_ID_LEN + ADDRESS_SIZE;
 
-BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusData, uint64_t _epoch)
+BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusData, uint64_t _epoch, bool _doRealCrypto)
     : keyPlusEncryptedData(_encryptedKeyPlusData), epoch(_epoch) {
     CHECK_STATE(_encryptedKeyPlusData);
     CHECK_STATE(_encryptedKeyPlusData->size() > BITE_ENCRYPTED_AES_KEY_LEN);
     
-    auto aesKeyArray = std::make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>>();
-    std::copy_n(_encryptedKeyPlusData->begin(), BITE_ENCRYPTED_AES_KEY_LEN, aesKeyArray->begin());
-    encryptedAESKey = std::make_shared<EncryptedAESKey>(aesKeyArray);
+    // get & validate ciphertext + key
+    if (_doRealCrypto) {
+        // get & validate encrypted key part
+        auto aesKey = libBLS::Ciphertext::fromBytes(*keyPlusEncryptedData).key.toBytes();
+        auto aesKeyPtr = make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>>(aesKey);
+        encryptedAESKey = make_shared<EncryptedAESKey>(aesKeyPtr);
+    }
+    else {
+        // Do not validate the key nor the ciphertext, just copy the first BITE_ENCRYPTED_AES_KEY_LEN bytes
+        auto keyVec = std::make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> >();
+        std::copy_n(keyPlusEncryptedData->begin(), BITE_ENCRYPTED_AES_KEY_LEN, keyVec->begin());
+        encryptedAESKey = make_shared<EncryptedAESKey>(keyVec);
+    }
 
     // build serialized RLP-encoded data field
     uint64_t epochBE = boost::endian::native_to_big(_epoch);
@@ -37,7 +47,7 @@ BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusD
     serializedData = make_shared<vector<uint8_t> >(listOfLists.encode());
 }
 
-BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data) {
+BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data, bool _doRealCrypto) {
     CHECK_STATE(_data);
 
     // parse RLP-encoded tx data field
@@ -55,10 +65,20 @@ BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data
     keyPlusEncryptedData = make_shared<std::vector<uint8_t>>(rlp0[1].asBytes());
     CHECK_STATE2(keyPlusEncryptedData->size() >= BITE_ENCRYPTED_AES_KEY_LEN,
         "Incorrectly formatted BITE transaction: Encrypted data size is not at least " + to_string(BITE_ENCRYPTED_AES_KEY_LEN) + " bytes, found: " + to_string(keyPlusEncryptedData->size()));
-    // get encrypted key part
-    auto keyVec = std::make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> >();
-    std::copy_n(keyPlusEncryptedData->begin(), BITE_ENCRYPTED_AES_KEY_LEN, keyVec->begin());
-    encryptedAESKey = make_shared<EncryptedAESKey>(keyVec);
+    
+    if (_doRealCrypto) {
+        // get & validate encrypted key part
+        auto aesKey = libBLS::Ciphertext::fromBytes(*keyPlusEncryptedData).key.toBytes();
+        auto aesKeyPtr = make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>>(aesKey);
+        encryptedAESKey = make_shared<EncryptedAESKey>(aesKeyPtr);
+    }
+    else {
+        // Do not validate the key nor the ciphertext, just copy the first BITE_ENCRYPTED_AES_KEY_LEN bytes
+        auto keyVec = std::make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> >();
+        std::copy_n(keyPlusEncryptedData->begin(), BITE_ENCRYPTED_AES_KEY_LEN, keyVec->begin());
+        encryptedAESKey = make_shared<EncryptedAESKey>(keyVec);
+    }
+
 
     serializedData = _data;
 }
@@ -75,7 +95,7 @@ uint64_t BiteDataField::getEpoch() {
 }
 
 
-ptr<BiteDataField> BiteDataField::createIfMagicMatches(ptr<vector<uint8_t> > &_data, ptr<vector<uint8_t> > &_to) {
+ptr<BiteDataField> BiteDataField::createIfMagicMatches(ptr<vector<uint8_t> > &_data, ptr<vector<uint8_t> > &_to, bool _doRealCrypto) {
     CHECK_STATE(_data)
     CHECK_STATE(_to)
 
@@ -85,7 +105,7 @@ ptr<BiteDataField> BiteDataField::createIfMagicMatches(ptr<vector<uint8_t> > &_d
         return nullptr;
     }
 
-    return ptr<BiteDataField>(new BiteDataField(_data));
+    return ptr<BiteDataField>(new BiteDataField(_data, _doRealCrypto));
 }
 
 

--- a/bite/BiteDataField.cpp
+++ b/bite/BiteDataField.cpp
@@ -28,12 +28,9 @@ BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusD
     std::vector<uint8_t> epochBytes(reinterpret_cast<uint8_t*>(&epochBE),
                                 reinterpret_cast<uint8_t*>(&epochBE) + sizeof(epochBE));
 
-    RLPStream list;
-    list << epochBytes << *_encryptedKeyPlusData;
-
-    RLPStream listOfLists;
-    listOfLists << list.encode(); 
-    serializedData = make_shared<vector<uint8_t> >(listOfLists.encode());
+    RLPStream rlpStream;
+    rlpStream << epochBytes << *_encryptedKeyPlusData;
+    serializedData = make_shared<vector<uint8_t> >(rlpStream.encode());
 }
 
 BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data) {
@@ -42,20 +39,15 @@ BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data
     // parse RLP-encoded tx data field
     RLPItem rlp(*_data);
     CHECK_STATE2(rlp.isList(), "RLP item is not a list");
-    CHECK_STATE2(rlp.size() >= 1, "RLP item should have at least 1 item");
-
-    // Get 1st item from list
-    RLPItem rlp0 = rlp[0];
-    CHECK_STATE2(rlp0.isList(), "RLP item 0 is not a list");
-    CHECK_STATE2(rlp0.size() == 2, "RLP item 0 should have exactly 2 fields - EPOCH_ID, and bite encrypted data");
+    CHECK_STATE2(rlp.size() == 2, "RLP item should have at least 2 fields - EPOCH_ID, and bite encrypted data");
     
     // validate EPOCH ID
-    const auto epoch_id = rlp0[0].asBytes();
-    CHECK_STATE2(epoch_id.size() <= BITE_EPOCH_ID_LEN,
-        "Incorrectly formatted BITE transaction: EPOCH_ID size is not <= " + to_string(BITE_EPOCH_ID_LEN) + " bytes, found: " + to_string(epoch_id.size()));
+    const auto epoch_id = rlp[0].asBytes();
+    CHECK_STATE2(epoch_id.size() == BITE_EPOCH_ID_LEN,
+        "Incorrectly formatted BITE transaction: EPOCH_ID size is not " + to_string(BITE_EPOCH_ID_LEN) + " bytes, found: " + to_string(epoch_id.size()));
 
     // validate encrypted data
-    keyPlusEncryptedData = make_shared<std::vector<uint8_t>>(rlp0[1].asBytes());
+    keyPlusEncryptedData = make_shared<std::vector<uint8_t>>(rlp[1].asBytes());
     CHECK_STATE2(keyPlusEncryptedData->size() >= BITE_ENCRYPTED_AES_KEY_LEN,
         "Incorrectly formatted BITE transaction: Encrypted data size is not at least " + to_string(BITE_ENCRYPTED_AES_KEY_LEN) + " bytes, found: " + to_string(keyPlusEncryptedData->size()));
     // get encrypted key part

--- a/bite/BiteDataField.cpp
+++ b/bite/BiteDataField.cpp
@@ -14,13 +14,13 @@
 /// which includes both the key + ciphered data
 const auto BITE_MIN_DATA_LEN = BITE_EPOCH_ID_LEN + ADDRESS_SIZE;
 
-BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusData, uint64_t _epoch, bool _doRealCrypto)
+BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusData, uint64_t _epoch, bool _useRealCrypto)
     : keyPlusEncryptedData(_encryptedKeyPlusData), epoch(_epoch) {
     CHECK_STATE(_encryptedKeyPlusData);
     CHECK_STATE(_encryptedKeyPlusData->size() > BITE_ENCRYPTED_AES_KEY_LEN);
     
     // get & validate ciphertext + key
-    if (_doRealCrypto) {
+    if (_useRealCrypto) {
         // get & validate encrypted key part
         auto aesKey = libBLS::Ciphertext::fromBytes(*keyPlusEncryptedData).key.toBytes();
         auto aesKeyPtr = make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>>(aesKey);
@@ -47,7 +47,7 @@ BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusD
     serializedData = make_shared<vector<uint8_t> >(listOfLists.encode());
 }
 
-BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data, bool _doRealCrypto) {
+BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data, bool _useRealCrypto) {
     CHECK_STATE(_data);
 
     // parse RLP-encoded tx data field
@@ -66,7 +66,7 @@ BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data
     CHECK_STATE2(keyPlusEncryptedData->size() >= BITE_ENCRYPTED_AES_KEY_LEN,
         "Incorrectly formatted BITE transaction: Encrypted data size is not at least " + to_string(BITE_ENCRYPTED_AES_KEY_LEN) + " bytes, found: " + to_string(keyPlusEncryptedData->size()));
     
-    if (_doRealCrypto) {
+    if (_useRealCrypto) {
         // get & validate encrypted key part
         auto aesKey = libBLS::Ciphertext::fromBytes(*keyPlusEncryptedData).key.toBytes();
         auto aesKeyPtr = make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>>(aesKey);
@@ -95,7 +95,7 @@ uint64_t BiteDataField::getEpoch() {
 }
 
 
-ptr<BiteDataField> BiteDataField::createIfMagicMatches(ptr<vector<uint8_t> > &_data, ptr<vector<uint8_t> > &_to, bool _doRealCrypto) {
+ptr<BiteDataField> BiteDataField::createIfMagicMatches(ptr<vector<uint8_t> > &_data, ptr<vector<uint8_t> > &_to, bool _useRealCrypto) {
     CHECK_STATE(_data)
     CHECK_STATE(_to)
 
@@ -105,7 +105,7 @@ ptr<BiteDataField> BiteDataField::createIfMagicMatches(ptr<vector<uint8_t> > &_d
         return nullptr;
     }
 
-    return ptr<BiteDataField>(new BiteDataField(_data, _doRealCrypto));
+    return ptr<BiteDataField>(new BiteDataField(_data, _useRealCrypto));
 }
 
 

--- a/bite/BiteDataField.cpp
+++ b/bite/BiteDataField.cpp
@@ -28,9 +28,13 @@ BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusD
     std::vector<uint8_t> epochBytes(reinterpret_cast<uint8_t*>(&epochBE),
                                 reinterpret_cast<uint8_t*>(&epochBE) + sizeof(epochBE));
 
-    RLPStream rlpStream;
-    rlpStream << epochBytes << *_encryptedKeyPlusData;
-    serializedData = make_shared<vector<uint8_t> >(rlpStream.encode());
+    RLPStream list;
+    list << epochBytes << *_encryptedKeyPlusData;
+
+    RLPStream listOfLists;
+    listOfLists << list;
+
+    serializedData = make_shared<vector<uint8_t> >(listOfLists.encode());
 }
 
 BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data) {
@@ -39,15 +43,16 @@ BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data
     // parse RLP-encoded tx data field
     RLPItem rlp(*_data);
     CHECK_STATE2(rlp.isList(), "RLP item is not a list");
-    CHECK_STATE2(rlp.size() == 2, "RLP item should have at least 2 fields - EPOCH_ID, and bite encrypted data");
+    CHECK_STATE2(rlp.size() >= 1, "RLP item should have at least 1 item");
     
-    // validate EPOCH ID
-    const auto epoch_id = rlp[0].asBytes();
-    CHECK_STATE2(epoch_id.size() == BITE_EPOCH_ID_LEN,
-        "Incorrectly formatted BITE transaction: EPOCH_ID size is not " + to_string(BITE_EPOCH_ID_LEN) + " bytes, found: " + to_string(epoch_id.size()));
+    // Get 1st item from list
+    RLPItem rlp0 = rlp[0];
+
+    CHECK_STATE2(rlp0.isList(), "RLP item 0 is not a list");
+    CHECK_STATE2(rlp0.size() == 2, "RLP item 0 should have exactly 2 fields - EPOCH_ID, and bite encrypted data");
 
     // validate encrypted data
-    keyPlusEncryptedData = make_shared<std::vector<uint8_t>>(rlp[1].asBytes());
+    keyPlusEncryptedData = make_shared<std::vector<uint8_t>>(rlp0[1].asBytes());
     CHECK_STATE2(keyPlusEncryptedData->size() >= BITE_ENCRYPTED_AES_KEY_LEN,
         "Incorrectly formatted BITE transaction: Encrypted data size is not at least " + to_string(BITE_ENCRYPTED_AES_KEY_LEN) + " bytes, found: " + to_string(keyPlusEncryptedData->size()));
     // get encrypted key part

--- a/bite/BiteDataField.cpp
+++ b/bite/BiteDataField.cpp
@@ -28,9 +28,12 @@ BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusD
     std::vector<uint8_t> epochBytes(reinterpret_cast<uint8_t*>(&epochBE),
                                 reinterpret_cast<uint8_t*>(&epochBE) + sizeof(epochBE));
 
-    RLPStream rlpStream;
-    rlpStream << epochBytes << *_encryptedKeyPlusData;
-    serializedData = make_shared<vector<uint8_t> >(rlpStream.encode());
+    RLPStream list;
+    list << epochBytes << *_encryptedKeyPlusData;
+
+    RLPStream listOfLists;
+    listOfLists << list.encode(); 
+    serializedData = make_shared<vector<uint8_t> >(listOfLists.encode());
 }
 
 BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data) {
@@ -39,15 +42,20 @@ BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data
     // parse RLP-encoded tx data field
     RLPItem rlp(*_data);
     CHECK_STATE2(rlp.isList(), "RLP item is not a list");
-    CHECK_STATE2(rlp.size() == 2, "RLP item should have at least 2 fields - EPOCH_ID, and bite encrypted data");
+    CHECK_STATE2(rlp.size() >= 1, "RLP item should have at least 1 item");
+
+    // Get 1st item from list
+    RLPItem rlp0 = rlp[0];
+    CHECK_STATE2(rlp0.isList(), "RLP item 0 is not a list");
+    CHECK_STATE2(rlp0.size() == 2, "RLP item 0 should have exactly 2 fields - EPOCH_ID, and bite encrypted data");
     
     // validate EPOCH ID
-    const auto epoch_id = rlp[0].asBytes();
-    CHECK_STATE2(epoch_id.size() == BITE_EPOCH_ID_LEN,
-        "Incorrectly formatted BITE transaction: EPOCH_ID size is not " + to_string(BITE_EPOCH_ID_LEN) + " bytes, found: " + to_string(epoch_id.size()));
+    const auto epoch_id = rlp0[0].asBytes();
+    CHECK_STATE2(epoch_id.size() <= BITE_EPOCH_ID_LEN,
+        "Incorrectly formatted BITE transaction: EPOCH_ID size is not <= " + to_string(BITE_EPOCH_ID_LEN) + " bytes, found: " + to_string(epoch_id.size()));
 
     // validate encrypted data
-    keyPlusEncryptedData = make_shared<std::vector<uint8_t>>(rlp[1].asBytes());
+    keyPlusEncryptedData = make_shared<std::vector<uint8_t>>(rlp0[1].asBytes());
     CHECK_STATE2(keyPlusEncryptedData->size() >= BITE_ENCRYPTED_AES_KEY_LEN,
         "Incorrectly formatted BITE transaction: Encrypted data size is not at least " + to_string(BITE_ENCRYPTED_AES_KEY_LEN) + " bytes, found: " + to_string(keyPlusEncryptedData->size()));
     // get encrypted key part

--- a/bite/BiteDataFiled.h
+++ b/bite/BiteDataFiled.h
@@ -11,15 +11,15 @@ class BiteDataField {
     std::shared_ptr<EncryptedData> keyPlusEncryptedData;
     uint64_t epoch = 0;
     ptr<vector<uint8_t >> serializedData;
-    explicit BiteDataField( const shared_ptr< vector< std::uint8_t > >& data );
+    explicit BiteDataField( const shared_ptr< vector< std::uint8_t > >& data, bool _doRealCrypto = true );
 
 public:
-    BiteDataField( const shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch);
+    BiteDataField( const shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch, bool _doRealCrypto = true );
 
     [[nodiscard]] ptr<EncryptedAESKey> & getEncryptedAESKey();
     [[nodiscard]] const ptr< EncryptedData >& getKeyPlusEncryptedData() const;
     [[nodiscard]] uint64_t getEpoch();
     [[nodiscard]] ptr< vector< uint8_t > >& getSerializedData();
 
-    [[nodiscard]] static ptr<BiteDataField> createIfMagicMatches(ptr<vector<uint8_t >>& _data, ptr<vector<uint8_t>>& _to);
+    [[nodiscard]] static ptr<BiteDataField> createIfMagicMatches(ptr<vector<uint8_t >>& _data, ptr<vector<uint8_t>>& _to, bool _doRealCrypto = true);
 };

--- a/bite/BiteDataFiled.h
+++ b/bite/BiteDataFiled.h
@@ -11,15 +11,15 @@ class BiteDataField {
     std::shared_ptr<EncryptedData> keyPlusEncryptedData;
     uint64_t epoch = 0;
     ptr<vector<uint8_t >> serializedData;
-    explicit BiteDataField( const shared_ptr< vector< std::uint8_t > >& data, bool _doRealCrypto = true );
+    explicit BiteDataField( const shared_ptr< vector< std::uint8_t > >& data, bool _useRealCrypto = true );
 
 public:
-    BiteDataField( const shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch, bool _doRealCrypto = true );
+    BiteDataField( const shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch, bool _useRealCrypto = true );
 
     [[nodiscard]] ptr<EncryptedAESKey> & getEncryptedAESKey();
     [[nodiscard]] const ptr< EncryptedData >& getKeyPlusEncryptedData() const;
     [[nodiscard]] uint64_t getEpoch();
     [[nodiscard]] ptr< vector< uint8_t > >& getSerializedData();
 
-    [[nodiscard]] static ptr<BiteDataField> createIfMagicMatches(ptr<vector<uint8_t >>& _data, ptr<vector<uint8_t>>& _to, bool _doRealCrypto = true);
+    [[nodiscard]] static ptr<BiteDataField> createIfMagicMatches(ptr<vector<uint8_t >>& _data, ptr<vector<uint8_t>>& _to, bool _useRealCrypto = true);
 };

--- a/bite/BiteDataFiled.h
+++ b/bite/BiteDataFiled.h
@@ -8,7 +8,6 @@ class EncryptedAESKey;
 class BiteDataField {
 
     ptr<EncryptedAESKey> encryptedAESKey;
-    std::shared_ptr<EncryptedData> encryptedData;
     std::shared_ptr<EncryptedData> keyPlusEncryptedData;
     uint64_t epoch = 0;
     ptr<vector<uint8_t >> serializedData;
@@ -18,10 +17,9 @@ public:
     BiteDataField( const shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch);
 
     [[nodiscard]] ptr<EncryptedAESKey> & getEncryptedAESKey();
-    [[nodiscard]] ptr< EncryptedData >& getEncryptedData();
+    [[nodiscard]] const ptr< EncryptedData >& getKeyPlusEncryptedData() const;
     [[nodiscard]] uint64_t getEpoch();
     [[nodiscard]] ptr< vector< uint8_t > >& getSerializedData();
 
     [[nodiscard]] static ptr<BiteDataField> createIfMagicMatches(ptr<vector<uint8_t >>& _data, ptr<vector<uint8_t>>& _to);
-    const shared_ptr< EncryptedData >& getKeyPlusEncryptedData() const;
 };

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -251,28 +251,31 @@ DecryptedTransactionFields
 BiteManager::decryptFields(const ptr<BiteDataField> &_bite, DecryptedAESKey &_decryptedAESKey) const {
     CHECK_STATE(_bite);
 
-    ptr< vector< uint8_t > > dataField = nullptr;
+    ptr< vector< uint8_t > > biteDataField = nullptr;
 
     if (doRealCrypto) {
         auto encryptedData = _bite->getKeyPlusEncryptedData();
         CHECK_STATE(encryptedData != nullptr);
 
         libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes(*encryptedData);
-        dataField = make_shared<vector<uint8_t>>(libBLS::ThresholdEncryption::decrypt(ciphertext, _decryptedAESKey.getAesKey()));
+        biteDataField = make_shared<vector<uint8_t>>(libBLS::ThresholdEncryption::decrypt(ciphertext, _decryptedAESKey.getAesKey()));
     } else {
         auto keyPlusEncryptedData = _bite->getKeyPlusEncryptedData();
         CHECK_STATE(keyPlusEncryptedData);
         auto decryptedOriginalDataField =
                 libBLS::ThresholdEncryption::mockupDecrypt(*keyPlusEncryptedData);
-        dataField = make_shared<vector<uint8_t> >(decryptedOriginalDataField);
+        biteDataField = make_shared<vector<uint8_t> >(decryptedOriginalDataField);
     }
 
-    CHECK_STATE2(dataField->size() >= ADDRESS_SIZE, "Decrypted data is not long enough to include the original tx.to field!");
+    CHECK_STATE2(biteDataField->size() >= ADDRESS_SIZE, "Decrypted data is not long enough to include the original tx.to field!");
 
-    // extract the last 20 bytes from dataField into toField
-    ptr< vector< uint8_t > > toField = make_shared< std::vector< uint8_t >>(dataField->end() - ADDRESS_SIZE, dataField->end());
-    // remove the to address from dataField
-    dataField->erase(dataField->end() - ADDRESS_SIZE, dataField->end());
+    RLPItem decryptedDataRlp( *biteDataField );
+    CHECK_STATE2( decryptedDataRlp.isList(), "Encrypted data rlp size must be a list" );
+    CHECK_STATE2( decryptedDataRlp.size() == 2,
+                  "Encrypted data rlp lsit must have exactly 2 elements" );
+    // extract decrypted data and to fields
+    ptr< vector< uint8_t > > dataField = make_shared< std::vector< uint8_t > >( decryptedDataRlp[0].asBytes() );
+    ptr< vector< uint8_t > > toField = make_shared< std::vector< uint8_t > >( decryptedDataRlp[1].asBytes() );
 
     auto decryptedFields = DecryptedTransactionFields {
         .data = dataField,

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -58,7 +58,7 @@ map<transaction_index, ConnectionSubStatus> BiteManager::verifyAndCreateDecrypti
     for (auto &tx: *transactions) {
         try {
             tx->parseAndValidate();
-            auto biteDataField = tx->tryGetBiteData();
+            auto biteDataField = tx->tryGetBiteData(doRealCrypto);
             if (biteDataField) {
                 biteDataFields.emplace(index, biteDataField);
                 encryptedAESKeyList->emplace(index, biteDataField->getEncryptedAESKey());
@@ -226,7 +226,7 @@ ptr<DecryptedTransactionFieldsMap> BiteManager::verifyAndDecryptTransactionList(
         for (uint64_t i = 0; i < _transactionList.size(); i++) {
             auto tx = txs->at(i);
             tx->parseAndValidate();
-            auto bite = tx->tryGetBiteData();
+            auto bite = tx->tryGetBiteData(doRealCrypto);
             if (bite) {
                 auto decryptedAESKey = _aesKeys.getKey(i);
                 CHECK_STATE(decryptedAESKey);
@@ -344,4 +344,8 @@ ptr<AESKeyDecryptionShareSet> BiteManager::createAESDecryptionShareSet(
         return make_shared<MockupAESKeyDecryptionShareSet>(
             _blockId, _transactionIndex, schain.getTotalSigners(), schain.getRequiredSigners());
     }
+}
+
+bool BiteManager::isRealCrypto() const {
+    return doRealCrypto;
 }

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -22,6 +22,7 @@
 #include <monitoring/LivelinessMonitor.h>
 
 #include "BLSPublicKey.h"
+#include "rlp/RLPStream.h"
 
 BiteManager::BiteManager(Schain &_schain) : schain(_schain) {
     doRealCrypto = _schain.getNode()->verifyRealSignatures();
@@ -253,7 +254,7 @@ BiteManager::decryptFields(const ptr<BiteDataField> &_bite, DecryptedAESKey &_de
     ptr< vector< uint8_t > > dataField = nullptr;
 
     if (doRealCrypto) {
-        auto encryptedData = _bite->getEncryptedData();
+        auto encryptedData = _bite->getKeyPlusEncryptedData();
         CHECK_STATE(encryptedData != nullptr);
 
         libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes(*encryptedData);
@@ -299,9 +300,9 @@ void BiteManager::corruptFromTimeToTime(shared_ptr<vector<unsigned char> >) {
 }
 
 ptr<vector<uint8_t> > BiteManager::teEncryptDataAndToAddress(const vector<uint8_t> &_data, const vector<uint8_t> &_to) {
-    // copy content of _data, and append _to to end of it
-    auto data = _data;
-    data.insert(data.end(), _to.begin(), _to.end());
+    // RLP encode
+    RLPStream stream;
+    stream << _data << _to;
 
     if (this->doRealCrypto) {
         auto [primaryKey, secondaryKey] = schain.getCryptoManager()->getSgxBlsPublicKey();
@@ -310,14 +311,14 @@ ptr<vector<uint8_t> > BiteManager::teEncryptDataAndToAddress(const vector<uint8_
         CHECK_STATE(blsKey);
         libBLS::TEPublicKey teKey(*blsKey);
 
-        auto cipherText = libBLS::ThresholdEncryption::encrypt(data, teKey);
+        auto cipherText = libBLS::ThresholdEncryption::encrypt(stream.encode(), teKey);
         auto bytes = std::make_shared<vector<uint8_t>>(cipherText.toBytes());
 
         corruptFromTimeToTime(bytes);
 
         return bytes;
     } else {
-        return make_shared<vector<uint8_t> >(libBLS::ThresholdEncryption::mockupEncrypt(data));
+        return make_shared<vector<uint8_t> >(libBLS::ThresholdEncryption::mockupEncrypt(stream.encode()));
     }
 }
 

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -349,6 +349,6 @@ ptr<AESKeyDecryptionShareSet> BiteManager::createAESDecryptionShareSet(
     }
 }
 
-bool BiteManager::isRealCrypto() const {
+bool BiteManager::isRealCryptoEnabled() const {
     return doRealCrypto;
 }

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -60,5 +60,5 @@ public:
     [[nodiscard]]  ptr<vector<uint8_t> > teEncryptDataAndToAddress(const vector<uint8_t> &_data, const vector<uint8_t> &_to);
 
     
-    bool isRealCrypto() const;
+    bool isRealCryptoEnabled() const;
 };

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -53,10 +53,12 @@ public:
 
     [[nodiscard]]  ptr<AESKeyDecryptionShareSet> createAESDecryptionShareSet(block_id _blockId, transaction_index _transactionIndex);
 
-    // TODO - change the name of this method
     [[nodiscard]]  DecryptedTransactionFields decryptFields(const ptr<BiteDataField> &bite,  DecryptedAESKey& _key) const;
 
     void corruptFromTimeToTime(shared_ptr<vector<unsigned char>> result);
 
     [[nodiscard]]  ptr<vector<uint8_t> > teEncryptDataAndToAddress(const vector<uint8_t> &_data, const vector<uint8_t> &_to);
+
+    
+    bool isRealCrypto() const;
 };

--- a/datastructures/Transaction.cpp
+++ b/datastructures/Transaction.cpp
@@ -188,7 +188,7 @@ void Transaction::parseAndValidate() {
 }
 
 
-ptr< BiteDataField > Transaction::tryGetBiteData() {
+ptr< BiteDataField > Transaction::tryGetBiteData(bool _doRealCrypto) const {
     auto tx = std::atomic_load(&parsedAndValidatedEthTransaction );
 
     ptr< BiteDataField > result = nullptr;
@@ -196,7 +196,7 @@ ptr< BiteDataField > Transaction::tryGetBiteData() {
     if (tx->hasToField()) {
         auto dataField = tx->getTransactionDataField();
         auto to = tx->getToField();
-        result = BiteDataField::createIfMagicMatches(dataField, to);
+        result = BiteDataField::createIfMagicMatches(dataField, to, _doRealCrypto);
     }
 
     return result;

--- a/datastructures/Transaction.h
+++ b/datastructures/Transaction.h
@@ -90,7 +90,7 @@ public:
     ptr<ParsedEthTransaction> parsedAndValidatedEthTransaction = nullptr;
 
     // this returns nullptr for non-BITE transactions
-    ptr<BiteDataField> tryGetBiteData();
+    ptr<BiteDataField> tryGetBiteData(bool _doRealCrypto = true) const;
     ptr<vector<uint8_t>> emplaceAndReencodeTransaction(vector<uint8_t>& _originalDataField );
 #endif
 

--- a/pendingqueue/PendingTransactionsAgent.cpp
+++ b/pendingqueue/PendingTransactionsAgent.cpp
@@ -212,7 +212,7 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
 #ifdef BITE
         try {
             pt->parseAndValidate();
-            pt->tryGetBiteData(sChain->getBiteManager()->isRealCrypto());
+            pt->tryGetBiteData(sChain->getBiteManager()->isRealCryptoEnabled());
             result->push_back(pt);
             pushKnownTransaction(pt);
         } catch (std::exception &e) {

--- a/pendingqueue/PendingTransactionsAgent.cpp
+++ b/pendingqueue/PendingTransactionsAgent.cpp
@@ -212,7 +212,7 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
 #ifdef BITE
         try {
             pt->parseAndValidate();
-            pt->tryGetBiteData();
+            pt->tryGetBiteData(sChain->getBiteManager()->isRealCrypto());
             result->push_back(pt);
             pushKnownTransaction(pt);
         } catch (std::exception &e) {

--- a/rlp/EthTransaction.cpp
+++ b/rlp/EthTransaction.cpp
@@ -14,14 +14,15 @@
 #include "crypto/EncryptedAESKey.h"
 #include "ParsedEthTransaction.h"
 #include "EthTransactionEncoder.h"
+#include "RLPStream.h"
 
 #pragma GCC diagnostic pop
 
 
 Signature::Signature(const uint256& _v, const uint256& _r, const uint256& _s) :
-    v(EthTransaction::bytesToU256(_v)),
-    r(EthTransaction::bytesToU256(_r)),
-    s(EthTransaction::bytesToU256(_s)) {}
+    v(RLPStream::bytesToU256(_v)),
+    r(RLPStream::bytesToU256(_r)),
+    s(RLPStream::bytesToU256(_s)) {}
 
 // -----------------------------------------------------------------------------------
 //                                  EthTransaction base
@@ -30,128 +31,22 @@ Signature::Signature(const uint256& _v, const uint256& _r, const uint256& _s) :
 
 /// --------------------------- RLP Encoding --------------------------- ///
 
-void EthTransaction::addEncodedFieldUint256(std::vector< std::vector< uint8_t > >& fields, const uint256& val) {
-    std::vector< uint8_t > tmp;
-    rlpEncodeUint256(tmp, val);
-    fields.push_back(tmp);
-}
-
-void EthTransaction::addEncodedFieldBytes(std::vector< std::vector< uint8_t > >& fields, const std::vector< uint8_t >& val) {
-    std::vector< uint8_t > tmp;
-    rlpEncodeBytes(tmp, val);
-    fields.push_back(tmp);
-}
-
-void EthTransaction::addEncodedFieldList(std::vector< std::vector< uint8_t > >& fields, const std::vector< std::vector< uint8_t > >& val) {
-    std::vector< uint8_t > tmp;
-    rlpEncodeList(tmp, val);
-    fields.push_back(tmp);
-}
-
-void EthTransaction::rlpEncodeBytes(
-    std::vector< uint8_t >& out, const std::vector< uint8_t >& data ) {
-    const size_t len = data.size();
-
-    // Explicitly handle empty string
-    if ( len == 0 ) {
-        out.push_back( 0x80 );
-        return;
-    }
-
-    // Single byte < 0x80 is encoded directly (no prefix)
-    if ( len == 1 && data[0] < 0x80 ) {
-        out.push_back( data[0] );
-        return;
-    }
-
-    if ( len < 56 ) {
-        // Short string: prefix = 0x80 + len
-        out.push_back( static_cast< uint8_t >( 0x80 + len ) );
-    } else {
-        // Long string: prefix = 0xb7 + len-of-len, then len, then data
-        std::vector< uint8_t > len_bytes;
-        size_t sz = len;
-        while ( sz > 0 ) {
-            len_bytes.insert( len_bytes.begin(), static_cast< uint8_t >( sz & 0xFF ) );
-            sz >>= 8;
-        }
-
-        CHECK_STATE2( len_bytes.size() <= 8, "rlpEncodeBytes: data too large (exceeds 2^64-1)" );
-
-        out.push_back( static_cast< uint8_t >( 0xb7 + len_bytes.size() ) );
-        out.insert( out.end(), len_bytes.begin(), len_bytes.end() );
-    }
-
-    // Append actual data
-    out.insert( out.end(), data.begin(), data.end() );
-}
-
-
-void EthTransaction::rlpEncodeUint256(
-    std::vector< uint8_t >& out, const std::vector< uint8_t >& value ) {
-    // Skip leading zeros
-    size_t start = 0;
-    while ( start < value.size() && value[start] == 0 ) {
-        ++start;
-    }
-
-    // Extract minimal non-zero representation (or empty)
-    std::vector< uint8_t > stripped( value.begin() + start, value.end() );
-
-    // Delegate to rlp_encode_bytes
-    rlpEncodeBytes( out, stripped );
-}
-
-void EthTransaction::rlpEncodeList(
-    std::vector< uint8_t >& out, const std::vector< std::vector< uint8_t > >& elements ) {
-    std::vector< uint8_t > payload;
-    for ( const auto& e : elements ) {
-        payload.insert( payload.end(), e.begin(), e.end() );
-    }
-    if ( payload.size() < 56 ) {
-        out.push_back( 0xc0 + payload.size() );
-    } else {
-        std::vector< uint8_t > len;
-        size_t sz = payload.size();
-        while ( sz ) {
-            len.insert( len.begin(), static_cast< uint8_t >( sz & 0xFF ) );
-            sz >>= 8;
-        }
-        out.push_back( 0xf7 + len.size() );
-        out.insert( out.end(), len.begin(), len.end() );
-    }
-    out.insert( out.end(), payload.begin(), payload.end() );
-}
-
 std::vector< uint8_t > EthTransaction::rlpEncode(const std::optional< Signature > &signature) const {
     // get tx fields encoded in order as a vec of byte vectors
-    std::vector< std::vector< uint8_t > > fields = encode();
+    RLPStream fields = encode();
 
     if ( signature ) {
-        std::vector< uint8_t > v_encoded, r_encoded, s_encoded;
-        rlpEncodeUint256( v_encoded, u256toBytes(signature->v) );
-        rlpEncodeUint256( r_encoded, u256toBytes(signature->r) );
-        rlpEncodeUint256( s_encoded, u256toBytes(signature->s) );
-
-        fields.push_back( v_encoded );
-        fields.push_back( r_encoded );
-        fields.push_back( s_encoded );
+        fields << signature->v
+                << signature->r
+                << signature->s;
     } else {
-        std::vector< uint8_t > tmp;
-        std::vector< uint8_t > ZERO;
-        rlpEncodeUint256( tmp, ZERO );
-        fields.push_back( tmp );
-        tmp.clear();
-        rlpEncodeUint256( tmp, ZERO );
-        fields.push_back( tmp );
-        tmp.clear();
-        rlpEncodeUint256( tmp, ZERO );
-        fields.push_back( tmp );
-        tmp.clear();
+        u256 ZERO = 0;
+        fields << ZERO // v
+                << ZERO // r
+                << ZERO; // s
     }
 
-    std::vector< uint8_t > encoded;
-    rlpEncodeList( encoded, fields );
+    std::vector< uint8_t > encoded = fields.encode();
 
     // insert tx prefix at beginning if any
     auto prefix = getBytePrefix();
@@ -168,32 +63,20 @@ std::vector< uint8_t > EthTransaction::rlpEncode(const std::optional< Signature 
 
 std::vector< uint8_t > AccessTuple::encode() const {
     // encode address
-    std::vector< uint8_t > rlpAddress;
-    EthTransaction::rlpEncodeBytes( rlpAddress, address );
+    RLPStream rlpAddress;
+    rlpAddress << address;
 
     // encode each item inside list of storage keys
-    std::vector<std::vector<uint8_t>> rlpKeys;
+    RLPStream rlpKeys;
     for (const auto& key : storageKeys) {
-        std::vector<uint8_t> rlpKey;
-        EthTransaction::rlpEncodeBytes(rlpKey, key);
-        rlpKeys.push_back(rlpKey);
+        rlpKeys << key;
     }
 
-    // encode list of storage keys
-    std::vector<uint8_t> rlpStorageKeys;
-    EthTransaction::rlpEncodeList(rlpStorageKeys, rlpKeys);
+    RLPStream rlpAccessTuple;
+    rlpAccessTuple << rlpAddress.encode() // encode the address
+                   << rlpKeys.encode(); // encode the list of storage keys
 
-    // create new list with encoded address and encoded list of storage keys
-    const std::vector< std::vector< uint8_t > > rlpStorageKeysEncoded = {
-        rlpAddress,
-        rlpStorageKeys
-    };
-
-    // encode the final access tuple
-    std::vector< uint8_t > rlpAccessTuple;
-    EthTransaction::rlpEncodeList(rlpAccessTuple, rlpStorageKeysEncoded);
-
-    return rlpAccessTuple;
+    return rlpAccessTuple.encode();
 }
 
 
@@ -262,8 +145,8 @@ Signature EthTransaction::sign(std::vector< uint8_t > privateKey) const {
 
     return Signature {
         computeSignatureV(rec_id),
-        bytesToU256(r_bytes),
-        bytesToU256(s_bytes)
+        RLPStream::bytesToU256(r_bytes),
+        RLPStream::bytesToU256(s_bytes)
     };
 }
 
@@ -287,8 +170,8 @@ void EthTransaction::verifySignature(Signature &sig) const {
     validateSignatureDomain(sig);
 
     // Create recoverable signature
-    std::vector< uint8_t > r = u256toBytes(sig.r);
-    std::vector< uint8_t > s = u256toBytes(sig.s);
+    std::vector< uint8_t > r = RLPStream::u256toBytes(sig.r);
+    std::vector< uint8_t > s = RLPStream::u256toBytes(sig.s);
     uint8_t sig64[64];
     std::copy(r.begin(), r.end(), sig64);
     std::copy(s.begin(), s.end(), sig64 + 32);
@@ -311,49 +194,18 @@ void EthTransaction::verifySignature(Signature &sig) const {
         "Failed to recover public key from signature");
 }
 
-
-/// @brief  Convert a vector of bytes in big endian order to a u256 value.
-/// @param bytes May be of any size. If > 32, then we only get the first 32 bytes.
-/// If < 32, then we only read the first bytes
-/// @return u256
-u256 EthTransaction::bytesToU256(const std::vector<uint8_t>& bytes) {
-    u256 val = 0;
-    size_t bytes_size = bytes.size();
-    
-    for (size_t i = 0; i < bytes_size; ++i) {
-        if (i >= 32) {
-            // If more than 32 bytes, ignore the rest
-            break;
-        }
-        val = (val << 8) | bytes[i];
-    }
-    return val;
-}
-
-/**
- * @brief Convert a u256 value to a vector of bytes in big-endian order.
- */
-std::vector< uint8_t> EthTransaction::u256toBytes( u256 v_value ) {
-    std::vector<uint8_t> bytes(32);
-    for (size_t i = 0; i < 32; i++) {
-        bytes[31 - i] = static_cast<uint8_t>(v_value & 0xFF);
-        v_value >>= 8;
-    }
-    return bytes;
-}
-
 // -----------------------------------------------------------------------------------
 //                                      Legacy
 // -----------------------------------------------------------------------------------
 
-std::vector< std::vector< uint8_t > > LegacyTx::encode() const {
-    std::vector< std::vector< uint8_t > > fields;
-    addEncodedFieldUint256(fields, nonce);
-    addEncodedFieldUint256(fields, gasPrice);
-    addEncodedFieldUint256(fields, gasLimit);
-    addEncodedFieldBytes  (fields, to);
-    addEncodedFieldUint256(fields, value);
-    addEncodedFieldBytes  (fields, data);
+RLPStream LegacyTx::encode() const {
+    RLPStream fields;
+    fields << nonce
+           << gasPrice
+           << gasLimit
+           << to
+           << value
+           << data;
 
     return fields;
 }
@@ -367,19 +219,12 @@ u256 LegacyTx::recoverSignatureV(const Signature &sig) const {
         return 0;
     }
     else {
-        CHECK_STATE2(sig.v > 36 || ( sig.v == 27 || sig.v == 28 ),
-                     "Invalid signature. Expected <= 36 or 27 or 28, got: " + sig.v.str());
+        CHECK_STATE2(sig.v > 36, "Invalid signature. Expected <= 36, got: " + sig.v.str());
 
-        u256 recoveryId;
-        if ( sig.v == 27 || sig.v == 28 )
-            recoveryId = sig.v - 27;
-        else {
-            u256 const chain = ( sig.v - 35 ) / 2;
-            CHECK_STATE2( chain <= std::numeric_limits< uint64_t >::max(),
-                "Invalid signature: Legacy Tx chainID overflow" );
-            recoveryId = sig.v - ( chain * 2 + 35 );
-        }
-
+        u256 const chain = ( sig.v - 35 ) / 2;
+        CHECK_STATE2( chain <= std::numeric_limits< uint64_t >::max(),
+            "Invalid signature: Legacy Tx chainID overflow" );
+        u256 recoveryId = sig.v - ( chain * 2 + 35 );        
         return recoveryId;
     }
 }
@@ -398,23 +243,24 @@ u256 LegacyTx::computeSignatureV(int rec_id) const {
 //                                      Type 1
 // -----------------------------------------------------------------------------------
 
-std::vector< std::vector< uint8_t > > Type1Tx::encode() const {
-    std::vector< std::vector< uint8_t > > fields;
-    addEncodedFieldUint256(fields, chainId);   // new field for EIP-2930
-    addEncodedFieldUint256(fields, nonce);
-    addEncodedFieldUint256(fields, gasPrice);
-    addEncodedFieldUint256(fields, gasLimit);
-    addEncodedFieldBytes  (fields, to);
-    addEncodedFieldUint256(fields, value);
-    addEncodedFieldBytes  (fields, data);
+RLPStream Type1Tx::encode() const {
+    RLPStream fields;
+    fields << chainId
+            << nonce
+            << gasPrice
+            << gasLimit
+            << to
+            << value
+            << data;
 
     // encode access list - new field for EIP-2930
-    std::vector< std::vector< uint8_t > > rlpAccessList;
+    RLPStream rlpAccessList;
     for ( const auto& accessTuple : accessList ) {
         std::vector< uint8_t > rlpAccessTuple = accessTuple.encode();
-        rlpAccessList.push_back( rlpAccessTuple );
+        rlpAccessList << rlpAccessTuple;
     }
-    addEncodedFieldBytes(fields, std::vector<uint8_t>{});
+
+    fields << rlpAccessList.encode();
 
     return fields;
 }
@@ -435,23 +281,24 @@ u256 Type1Tx::computeSignatureV(int rec_id) const {
 //                                      Type 2
 // -----------------------------------------------------------------------------------
 
-std::vector< std::vector< uint8_t > > Type2Tx::encode() const {
-    std::vector< std::vector< uint8_t > > fields;
-    addEncodedFieldUint256(fields, chainId);
-    addEncodedFieldUint256(fields, nonce);
-    addEncodedFieldUint256(fields, maxPriorityFeePerGas);   // new field for EIP-1559
-    addEncodedFieldUint256(fields, maxFeePerGas);           // new field for EIP-1559
-    addEncodedFieldUint256(fields, gasLimit);
-    addEncodedFieldBytes  (fields, to);
-    addEncodedFieldUint256(fields, value);
-    addEncodedFieldBytes  (fields, data);
+RLPStream Type2Tx::encode() const {
+    RLPStream fields;
+    fields << chainId
+            << nonce
+            << maxPriorityFeePerGas   // new field for EIP-1559
+            << maxFeePerGas           // new field for EIP-1559
+            << gasLimit
+            << to
+            << value
+            << data;
 
-    std::vector< std::vector< uint8_t > > rlpAccessList;
+    RLPStream rlpAccessList;
     for ( const auto& accessTuple : accessList ) {
         std::vector< uint8_t > rlpAccessTuple = accessTuple.encode();
-        rlpAccessList.push_back( rlpAccessTuple );
+        rlpAccessList << rlpAccessTuple;
     }
-    addEncodedFieldList(fields, rlpAccessList);
+
+    fields << rlpAccessList.encode();
 
     return fields;
 }

--- a/rlp/EthTransaction.cpp
+++ b/rlp/EthTransaction.cpp
@@ -219,12 +219,18 @@ u256 LegacyTx::recoverSignatureV(const Signature &sig) const {
         return 0;
     }
     else {
-        CHECK_STATE2(sig.v > 36, "Invalid signature. Expected <= 36, got: " + sig.v.str());
+        CHECK_STATE2(sig.v > 36 || ( sig.v == 27 || sig.v == 28 ),
+        "Invalid signature. Expected <= 36 or 27 or 28, got: " + sig.v.str());
 
-        u256 const chain = ( sig.v - 35 ) / 2;
-        CHECK_STATE2( chain <= std::numeric_limits< uint64_t >::max(),
+        u256 recoveryId;
+        if ( sig.v == 27 || sig.v == 28 )
+            recoveryId = sig.v - 27;
+        else {
+            u256 const chain = ( sig.v - 35 ) / 2;
+            CHECK_STATE2( chain <= std::numeric_limits< uint64_t >::max(),
             "Invalid signature: Legacy Tx chainID overflow" );
-        u256 recoveryId = sig.v - ( chain * 2 + 35 );        
+            recoveryId = sig.v - ( chain * 2 + 35 );
+        }  
         return recoveryId;
     }
 }

--- a/rlp/EthTransaction.cpp
+++ b/rlp/EthTransaction.cpp
@@ -219,18 +219,13 @@ u256 LegacyTx::recoverSignatureV(const Signature &sig) const {
         return 0;
     }
     else {
-        CHECK_STATE2(sig.v > 36 || ( sig.v == 27 || sig.v == 28 ),
-        "Invalid signature. Expected <= 36 or 27 or 28, got: " + sig.v.str());
+        CHECK_STATE2(sig.v > 36, "Invalid signature. Expected <= 36, got: " + sig.v.str());
 
-        u256 recoveryId;
-        if ( sig.v == 27 || sig.v == 28 )
-            recoveryId = sig.v - 27;
-        else {
-            u256 const chain = ( sig.v - 35 ) / 2;
-            CHECK_STATE2( chain <= std::numeric_limits< uint64_t >::max(),
+        u256 const chain = ( sig.v - 35 ) / 2;
+        CHECK_STATE2( chain <= std::numeric_limits< uint64_t >::max(),
             "Invalid signature: Legacy Tx chainID overflow" );
-            recoveryId = sig.v - ( chain * 2 + 35 );
-        }
+        u256 recoveryId = sig.v - ( chain * 2 + 35 );        
+        return recoveryId;
     }
 }
 

--- a/rlp/EthTransaction.cpp
+++ b/rlp/EthTransaction.cpp
@@ -219,13 +219,18 @@ u256 LegacyTx::recoverSignatureV(const Signature &sig) const {
         return 0;
     }
     else {
-        CHECK_STATE2(sig.v > 36, "Invalid signature. Expected <= 36, got: " + sig.v.str());
+        CHECK_STATE2(sig.v > 36 || ( sig.v == 27 || sig.v == 28 ),
+        "Invalid signature. Expected <= 36 or 27 or 28, got: " + sig.v.str());
 
-        u256 const chain = ( sig.v - 35 ) / 2;
-        CHECK_STATE2( chain <= std::numeric_limits< uint64_t >::max(),
+        u256 recoveryId;
+        if ( sig.v == 27 || sig.v == 28 )
+            recoveryId = sig.v - 27;
+        else {
+            u256 const chain = ( sig.v - 35 ) / 2;
+            CHECK_STATE2( chain <= std::numeric_limits< uint64_t >::max(),
             "Invalid signature: Legacy Tx chainID overflow" );
-        u256 recoveryId = sig.v - ( chain * 2 + 35 );        
-        return recoveryId;
+            recoveryId = sig.v - ( chain * 2 + 35 );
+        }
     }
 }
 

--- a/rlp/EthTransaction.h
+++ b/rlp/EthTransaction.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <vector>
 #include <cstdint>
+#include "RLPStream.h"
+#include "RLP.h"
 
 // Suppress deprecated-copy warning caused by Boost.Multiprecision (cpp_int)
 // Boost defines a user-provided copy constructor but no copy assignment operator,
@@ -161,16 +163,16 @@ struct LegacyTx : EthTransaction {
     gasPrice(_gasPrice)
     {}
 
-    LegacyTx(std::vector< std::vector< uint8_t > >& fields) :
+    LegacyTx(RLPItem& fields) :
         EthTransaction(
-            fields.at( 0 ), // nonce
-            fields.at( 2 ), // gasLimit
-            fields.at( 3 ), // to
-            fields.at( 4 ), // value
-            fields.at( 5 ), // data
+            fields[ 0 ].asBytes(), // nonce
+            fields[ 2 ].asBytes(), // gasLimit
+            fields[ 3 ].asBytes(), // to
+            fields[ 4 ].asBytes(), // value
+            fields[ 5 ].asBytes(), // data
             {} // chainId
         ),
-        gasPrice(fields.at( 1 ))
+        gasPrice(fields[ 1 ].asBytes())
     {}
 
     RLPStream encode() const override;
@@ -210,16 +212,16 @@ struct Type1Tx : EthTransaction {
         gasPrice(_gasPrice), accessList(_accessList)
     {}
 
-    Type1Tx(std::vector< std::vector< uint8_t > >& fields) :
+    Type1Tx(RLPItem& fields) :
         EthTransaction(
-            fields.at( 1 ), // nonce
-            fields.at( 3 ), // gasLimit
-            fields.at( 4 ), // to
-            fields.at( 5 ), // value
-            fields.at( 6 ), // data
-            fields.at( 0 )  // chainId
+            fields[ 1 ].asBytes(), // nonce
+            fields[ 3 ].asBytes(), // gasLimit
+            fields[ 4 ].asBytes(), // to
+            fields[ 5 ].asBytes(), // value
+            fields[ 6 ].asBytes(), // data
+            fields[ 0 ].asBytes()  // chainId
         ),
-        gasPrice(fields.at( 2 )),
+        gasPrice(fields[ 2 ].asBytes()),
         accessList({})
     {}
 
@@ -252,17 +254,17 @@ struct Type2Tx : EthTransaction {
         maxPriorityFeePerGas(_maxPriorityFeePerGas), maxFeePerGas(_maxFeePerGas), accessList(_accessList)
     {}
 
-    Type2Tx(std::vector< std::vector< uint8_t > >& fields) :
+    Type2Tx(RLPItem& fields) :
     EthTransaction(
-        fields.at( 1 ), // nonce
-        fields.at( 4 ), // gasLimit
-        fields.at( 5 ), // to
-        fields.at( 6 ), // value
-        fields.at( 7 ), // data
-        fields.at( 0 ) // chainId
+        fields[ 1 ].asBytes(), // nonce
+        fields[ 4 ].asBytes(), // gasLimit
+        fields[ 5 ].asBytes(), // to
+        fields[ 6 ].asBytes(), // value
+        fields[ 7 ].asBytes(), // data
+        fields[ 0 ].asBytes() // chainId
         ),
-        maxPriorityFeePerGas(fields.at( 2 )),
-        maxFeePerGas(fields.at( 3 )),
+        maxPriorityFeePerGas(fields[ 2 ].asBytes()),
+        maxFeePerGas(fields[ 3 ].asBytes()),
         accessList({})
     {}
 

--- a/rlp/EthTransaction.h
+++ b/rlp/EthTransaction.h
@@ -79,8 +79,6 @@ struct EthTransaction {
         : nonce(nonce), gasLimit(gasLimit), to(to), value(value), data(data), chainId(chainId)
     {}
     
-    virtual ~EthTransaction() {}
-
     /**
      * @brief Signs a transaction, returning the resulting signature.
      */

--- a/rlp/EthTransaction.h
+++ b/rlp/EthTransaction.h
@@ -20,13 +20,6 @@
 #include <secp256k1_recovery.h>
 
 
-
-
-using uint256 = std::vector< uint8_t >;
-
-using u256 = boost::multiprecision::number< boost::multiprecision::cpp_int_backend< 256, 256,
-boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void > >;
-
 enum class TxType {
     LEGACY = 0,
     TYPE1 = 1,
@@ -83,8 +76,6 @@ struct EthTransaction {
         const uint256& chainId)
         : nonce(nonce), gasLimit(gasLimit), to(to), value(value), data(data), chainId(chainId)
     {}
-
-    virtual ~EthTransaction() {}
     
     /**
      * @brief Signs a transaction, returning the resulting signature.
@@ -115,31 +106,7 @@ struct EthTransaction {
     virtual TxPrefix getBytePrefix() const = 0;
 
 protected:
-    
-    //  ----------------------- Helper functions for RLP encoding -------------------------------//
-
-    inline static void rlpEncodeBytes( std::vector< uint8_t >& out, const std::vector< uint8_t >& data );
-
-    inline static void rlpEncodeUint256( std::vector< uint8_t >& out, const std::vector< uint8_t >& value );
-
-    inline static void rlpEncodeList(std::vector< uint8_t >& out, const std::vector< std::vector< uint8_t > >& elements );
-
-    inline static void addEncodedFieldUint256(std::vector< std::vector< uint8_t > >& fields, const uint256& val);
-
-    inline static void addEncodedFieldBytes(std::vector< std::vector< uint8_t > >& fields, const std::vector< uint8_t >& val);
-
-    inline static void addEncodedFieldList(std::vector< std::vector< uint8_t > >& fields, const std::vector< std::vector< uint8_t > >& val);
-
-    /**
-     * @brief Convert a vector of bytes to a u256 value in big-endian order.
-     */
-    static u256 bytesToU256(const std::vector<uint8_t>& bytes);
-
-    /**
-     * @brief Convert a u256 value to a vector of bytes in big-endian order.
-     */
-    static std::vector< uint8_t> u256toBytes( u256 v_value );
-    
+        
     //  -------------------- Helper functions for transaction signing ---------------------------//
 
     #pragma GCC diagnostic push
@@ -158,11 +125,11 @@ protected:
     
     //  -------------------------- Type-specific functionality ----------------------------------//
     /**
-     * @brief Encode the object into RLP format. Return a vector of each encoded field.
+     * @brief Encode the object into RLP format.
      * Field order is enforced by this function. Does not include signature fields in the rlp encoding.
      * Used by the `Transacition::rlpEncode` function.
      */
-    virtual std::vector< std::vector< uint8_t > > encode() const = 0;
+    virtual RLPStream encode() const = 0;
 
     /**
      * @brief Signs the transaction using type-specific logic of either LegacyTx, Type1Tx or Type2Tx.
@@ -206,7 +173,7 @@ struct LegacyTx : EthTransaction {
         gasPrice(fields.at( 1 ))
     {}
 
-    std::vector< std::vector< uint8_t > > encode() const override;
+    RLPStream encode() const override;
     u256 computeSignatureV(int rec_id) const override;
     u256 recoverSignatureV(const Signature& sig) const override;
     TxPrefix getBytePrefix() const override;
@@ -256,7 +223,7 @@ struct Type1Tx : EthTransaction {
         accessList({})
     {}
 
-    std::vector< std::vector< uint8_t > > encode() const override;
+    RLPStream encode() const override;
     u256 computeSignatureV(int rec_id) const override;
     u256 recoverSignatureV(const Signature& sig) const override;
     TxPrefix getBytePrefix() const override;
@@ -299,7 +266,7 @@ struct Type2Tx : EthTransaction {
         accessList({})
     {}
 
-    std::vector< std::vector< uint8_t > > encode() const override;
+    RLPStream encode() const override;
     u256 computeSignatureV(int rec_id) const override;
     u256 recoverSignatureV(const Signature& sig) const override;
     TxPrefix getBytePrefix() const override;

--- a/rlp/EthTransaction.h
+++ b/rlp/EthTransaction.h
@@ -78,6 +78,8 @@ struct EthTransaction {
         const uint256& chainId)
         : nonce(nonce), gasLimit(gasLimit), to(to), value(value), data(data), chainId(chainId)
     {}
+
+    virtual ~EthTransaction() {}
     
     /**
      * @brief Signs a transaction, returning the resulting signature.

--- a/rlp/EthTransaction.h
+++ b/rlp/EthTransaction.h
@@ -79,6 +79,8 @@ struct EthTransaction {
         : nonce(nonce), gasLimit(gasLimit), to(to), value(value), data(data), chainId(chainId)
     {}
     
+    virtual ~EthTransaction() {}
+
     /**
      * @brief Signs a transaction, returning the resulting signature.
      */

--- a/rlp/EthTransactionEncoder.cpp
+++ b/rlp/EthTransactionEncoder.cpp
@@ -114,7 +114,7 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
     }
 
     EthTransaction& txRef = *tx;
-    txRef.nonce = EthTransaction::u256toBytes( static_cast<u256>( currentNonce ) );
+    txRef.nonce = RLPStream::u256toBytes( static_cast<u256>( currentNonce ) );
 
     if ( _isByte ) {
         auto encryptedKeyPlusData = _biteManager->teEncryptDataAndToAddress(txRef.data, txRef.to);

--- a/rlp/EthTransactionEncoder.cpp
+++ b/rlp/EthTransactionEncoder.cpp
@@ -35,11 +35,15 @@ std::vector< uint8_t > EthTransactionEncoder::generateRandomPrivateKey() {
 
 
 ptr< vector< uint8_t > > EthTransactionEncoder::signAndEncodeTx( const EthTransaction& tx ) {
+    std::cout << "F1" << std::endl;
     std::vector< uint8_t > privkey = generateRandomPrivateKey();
     Signature signature = tx.sign(privkey);
+    std::cout << "F2" << std::endl;
 
     std::vector< uint8_t > encodedTx = tx.rlpEncode( std::make_optional( signature ) );
+    std::cout << "F3" << std::endl;
     tx.verifySignature(signature);
+    std::cout << "F4" << std::endl;
     return make_shared< vector< uint8_t > >( std::move( encodedTx ) );
 }
 
@@ -97,6 +101,8 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
     TxType txType = static_cast< TxType >( currentTxType );
     auto currentNonce = nonce.fetch_add( 1 );
 
+    std::cout << "E0" << std::endl;
+
     // generate the tx from sample templates
     std::unique_ptr<EthTransaction> tx;
     switch ( txType ) {
@@ -112,9 +118,11 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
         default:
             throw std::invalid_argument( "Unknown transaction type" );
     }
+    std::cout << "E0.1" << std::endl;
 
     EthTransaction& txRef = *tx;
     txRef.nonce = RLPStream::u256toBytes( static_cast<u256>( currentNonce ) );
+    std::cout << "E0.2" << std::endl;
 
     if ( _isByte ) {
         auto encryptedKeyPlusData = _biteManager->teEncryptDataAndToAddress(txRef.data, txRef.to);
@@ -127,7 +135,9 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
                      0x59, 0x50, 0x54, 0x44 };
     }
 
+    std::cout << "E3" << std::endl;
     auto encodedTx = signAndEncodeTx( txRef );
+    std::cout << "E4" << std::endl;
     CHECK_STATE( encodedTx );
 
     return encodedTx;

--- a/rlp/EthTransactionEncoder.cpp
+++ b/rlp/EthTransactionEncoder.cpp
@@ -35,15 +35,11 @@ std::vector< uint8_t > EthTransactionEncoder::generateRandomPrivateKey() {
 
 
 ptr< vector< uint8_t > > EthTransactionEncoder::signAndEncodeTx( const EthTransaction& tx ) {
-    std::cout << "F1" << std::endl;
     std::vector< uint8_t > privkey = generateRandomPrivateKey();
     Signature signature = tx.sign(privkey);
-    std::cout << "F2" << std::endl;
 
     std::vector< uint8_t > encodedTx = tx.rlpEncode( std::make_optional( signature ) );
-    std::cout << "F3" << std::endl;
     tx.verifySignature(signature);
-    std::cout << "F4" << std::endl;
     return make_shared< vector< uint8_t > >( std::move( encodedTx ) );
 }
 
@@ -101,7 +97,6 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
     TxType txType = static_cast< TxType >( currentTxType );
     auto currentNonce = nonce.fetch_add( 1 );
 
-    std::cout << "E0" << std::endl;
 
     // generate the tx from sample templates
     std::unique_ptr<EthTransaction> tx;
@@ -118,11 +113,9 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
         default:
             throw std::invalid_argument( "Unknown transaction type" );
     }
-    std::cout << "E0.1" << std::endl;
 
     EthTransaction& txRef = *tx;
     txRef.nonce = RLPStream::u256toBytes( static_cast<u256>( currentNonce ) );
-    std::cout << "E0.2" << std::endl;
 
     if ( _isByte ) {
         auto encryptedKeyPlusData = _biteManager->teEncryptDataAndToAddress(txRef.data, txRef.to);
@@ -135,9 +128,7 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
                      0x59, 0x50, 0x54, 0x44 };
     }
 
-    std::cout << "E3" << std::endl;
     auto encodedTx = signAndEncodeTx( txRef );
-    std::cout << "E4" << std::endl;
     CHECK_STATE( encodedTx );
 
     return encodedTx;

--- a/rlp/EthTransactionEncoder.cpp
+++ b/rlp/EthTransactionEncoder.cpp
@@ -119,7 +119,8 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
 
     if ( _isByte ) {
         auto encryptedKeyPlusData = _biteManager->teEncryptDataAndToAddress(txRef.data, txRef.to);
-        BiteDataField biteDataField(encryptedKeyPlusData , 0);
+        bool doRealCrypto = false;
+        BiteDataField biteDataField(encryptedKeyPlusData , 0, doRealCrypto);
         // set data
         txRef.data = *biteDataField.getSerializedData();
         // set to field with BITE magic number

--- a/rlp/ParsedEthTransaction.cpp
+++ b/rlp/ParsedEthTransaction.cpp
@@ -21,141 +21,11 @@
 #include "EthTransactionEncoder.h"
 #include "ParsedEthTransaction.h"
 #include "EthTransaction.h"
+#include "RLP.h"
 
 
 bool ParsedEthTransaction::isTypedTransaction( uint8_t prefix ) {
     return prefix == 0x01 || prefix == 0x02;
-}
-
-size_t ParsedEthTransaction::readLen(
-    const std::vector< uint8_t >& _tx, size_t _offset, size_t _len ) {
-    CHECK_STATE2( _offset + _len <= _tx.size(), "readLen: out of bounds");
-    
-    size_t val = 0;
-    for ( size_t i = 0; i < _len; ++i ) {
-        val = ( val << 8 ) | _tx.at( _offset + i );
-    }
-    return val;
-}
-
-void ParsedEthTransaction::skipRlpListHeader(
-    const std::vector< uint8_t >& _tx, uint64_t& _offset ) {
-    CHECK_STATE2( _offset < _tx.size(), "skipRlpListHeader: no bytes left" );
-    uint8_t prefix = _tx.at( _offset );
-    if ( prefix <= 0xf7 ) {
-        _offset += 1;
-    } else {
-        size_t lenOfLen = prefix - 0xf7;
-        CHECK_STATE2( _offset + 1 + lenOfLen <= _tx.size(), "skipRlpListHeader: out of bounds" );
-        
-        _offset += 1 + lenOfLen;
-    }
-}
-
-std::vector< uint8_t > ParsedEthTransaction::parseSingleByteVector(
-    const std::vector< uint8_t >& _tx, uint64_t& _offset ) {
-    CHECK_STATE2( _offset < _tx.size(), "Short element: out of bounds" );
-    return { _tx.at( _offset++ ) };
-}
-
-std::vector< uint8_t > ParsedEthTransaction::parseShortByteVector(
-    const std::vector< uint8_t >& _tx, uint64_t& _offset, uint8_t _prefix ) {
-    size_t len = _prefix - 0x80;
-    _offset += 1;
-    CHECK_STATE2( _offset + len <= _tx.size(), "parseShortByteVector: slice out of bounds" );
-    
-    std::vector< uint8_t > out( _tx.begin() + _offset, _tx.begin() + _offset + len );
-    _offset += len;
-    return out;
-}
-
-
-std::vector< uint8_t > ParsedEthTransaction::parseLongByteVector(
-    const std::vector< uint8_t >& _tx, uint64_t& _offset, uint8_t _prefix ) {
-    size_t lenOfLen = _prefix - 0xb7;
-
-    CHECK_STATE2( _offset + 1 + lenOfLen <= _tx.size(), "parseLongByteVector: lenOfLen out of bounds" );
-    
-    size_t len = readLen( _tx, _offset + 1, lenOfLen );
-    _offset += 1 + lenOfLen;
-
-    CHECK_STATE2( _offset + len <= _tx.size(), "parseLongByteVector: slice out of bounds" );
-    
-    std::vector< uint8_t > out( _tx.begin() + _offset, _tx.begin() + _offset + len );
-    _offset += len;
-    return out;
-}
-
-
-std::vector<uint8_t> ParsedEthTransaction::parseLongList(
-    const std::vector<uint8_t>& tx, uint64_t& offset, uint8_t prefix) {
-    
-    size_t lenOfLen = prefix - 0xf7;
-
-    CHECK_STATE2( offset + 1 + lenOfLen <= tx.size(), "parseLongList: lenOfLen out of bounds");
-    
-    size_t len = readLen(tx, offset + 1, lenOfLen);
-    offset += 1 + lenOfLen;
-    
-    CHECK_STATE2( offset + len <= tx.size(), "parseLongList: slice out of bounds");
-    
-    std::vector<uint8_t> result;
-    const uint64_t endOffset = offset + len;
-    // last item from list will be returned - will never be used
-    while (offset < endOffset) {
-        result = parseBytes(tx, offset);
-    }
-    
-    CHECK_STATE2(offset == endOffset, "parseLongList: invalid list encoding");
-    
-    return result;
-}
-
-
-std::vector<uint8_t> ParsedEthTransaction::parseShortList(
-    const std::vector<uint8_t>& tx, uint64_t& offset, uint8_t prefix) {
-    
-    size_t len = prefix - 0xc0;
-    CHECK_STATE2(offset + 1 + len <= tx.size(), "parseShortList: slice out of bounds");
-    
-    std::vector<uint8_t> result;
-    const uint64_t startOffset = offset + 1;
-    const uint64_t endOffset = startOffset + len;
-    
-    offset = startOffset;
-    // last item from list will be returned - will never be used
-    while (offset < endOffset) {
-        result = parseBytes(tx, offset);
-    }
-    
-    CHECK_STATE2(offset == endOffset, "parseShortList: invalid list encoding");
-    
-    return result;
-}
-
-std::vector< uint8_t > ParsedEthTransaction::parseBytes(
-    const std::vector< uint8_t >& _tx, uint64_t& _offset ) {
-
-    CHECK_STATE2( _offset < _tx.size(), "parseByteVector: no data left" );
-    uint8_t prefix = _tx.at( _offset );
-    if ( prefix <= 0x7f )
-        return parseSingleByteVector( _tx, _offset );
-    else if ( prefix <= 0xb7 )
-        return parseShortByteVector( _tx, _offset, prefix );
-    else if ( prefix <= 0xbf )
-        return parseLongByteVector( _tx, _offset, prefix );
-    else if (prefix <= 0xf7)
-        return parseShortList(_tx, _offset, prefix);
-    else
-        return parseLongList(_tx, _offset, prefix);
-}
-
-void ParsedEthTransaction::parseTransactionFields(
-    const std::vector< uint8_t >& _tx, size_t& _offset, int fieldCount ) {
-    for ( int i = 0; i < fieldCount; ++i ) {
-        fields.push_back( parseBytes( _tx, _offset ) );
-    }
-    CHECK_STATE2( _offset == _tx.size(), "Too many fields in transaction" );
 }
 
 ptr< ParsedEthTransaction > ParsedEthTransaction::parse( const std::vector< uint8_t >& _rawTx ) {
@@ -168,13 +38,20 @@ ptr< ParsedEthTransaction > ParsedEthTransaction::parse( const std::vector< uint
     if ( isTypedTransaction( prefix ) ) {
         result->type = prefix;
         offset += 1;
-        skipRlpListHeader( _rawTx, offset );
         int fieldCount = ( prefix == 0x01 ) ? 11 : 12;
-        result->parseTransactionFields( _rawTx, offset, fieldCount );
+        RLPItem rlpItem( _rawTx, offset );
+        CHECK_STATE2( rlpItem.isList(), "RLP item is not a list" );
+        CHECK_STATE2( rlpItem.size() == fieldCount, "Expected " + std::to_string(fieldCount) +
+                      " fields, found: " + std::to_string(rlpItem.size()) );
+        result->fields = std::move(rlpItem);
     } else if ( prefix >= 0xc0 ) {
         result->type = 0;
-        skipRlpListHeader( _rawTx, offset );
-        result->parseTransactionFields( _rawTx, offset, 9 );
+        RLPItem rlpItem( _rawTx, offset );
+        size_t parsedItems = rlpItem.size();
+        CHECK_STATE2( rlpItem.isList(), "RLP item is not a list" );
+        CHECK_STATE2( rlpItem.size() == 9, "Expected " + std::to_string(9) +
+                      " fields, found: " + std::to_string(rlpItem.size()) );
+        result->fields = std::move(rlpItem);
     } else {
         throw invalid_argument( "Invalid transaction prefix" );
     }
@@ -215,7 +92,7 @@ void ParsedEthTransaction::validateToField() {
     // if type 2, then idx is 5
     auto toFieldIdx = 3 + type;
 
-    const auto& toField = fields.at( toFieldIdx );
+    const auto toField = fields[ toFieldIdx ].asBytes();
     // toField is empty when deploying a contract
     CHECK_STATE2( toField.empty() || toField.size() == 20, "Invalid 'to' address length");
 }
@@ -240,9 +117,9 @@ std::vector< uint8_t > padTo32Bytes( const std::vector< uint8_t >& input ) {
 }
 
 void ParsedEthTransaction::validateSignature() {
-    const auto& v = fields.at( fields.size() - 3 );
-    const auto& r = fields.at( fields.size() - 2 );
-    const auto& s = fields.at( fields.size() - 1 );
+    const auto v = fields[ fields.size() - 3 ].asBytes();
+    const auto r = fields[ fields.size() - 2 ].asBytes();
+    const auto s = fields[ fields.size() - 1 ].asBytes();
 
     CHECK_STATE2( r.size() <= 32, "Invalid r size. Should be <= 32 bytes, found: " + std::to_string(r.size()) );
     CHECK_STATE2( s.size() <= 32, "Invalid s size. Should be <= 32 bytes, found: " + std::to_string(s.size()) );
@@ -281,24 +158,24 @@ ptr< std::vector< uint8_t > > ParsedEthTransaction::getToField() const {
     if ( !hasToField() ) {
         throw invalid_argument( "Transaction missing to field" );
     }
-    return make_shared< vector< uint8_t > >( fields.at( getToFieldIndex() ) );
+    return make_shared< vector< uint8_t > >( fields[ getToFieldIndex() ].asBytes() );
 }
 
 bool ParsedEthTransaction::hasToField() const {
     size_t index = getToFieldIndex();
-    return fields.size() > index && !fields.at( index ).empty();    
+    return fields.size() > index && !fields[index].asBytes().empty();    
 }
 
 ptr< std::vector< uint8_t > > ParsedEthTransaction::getTransactionDataField() {
     size_t index = getDataFieldIndex();
     CHECK_STATE2( fields.size() > index, "Transaction missing data field" );
-    return make_shared< vector< uint8_t > >( fields.at( index ) );
+    return make_shared< vector< uint8_t > >( fields[ index ].asBytes() );
 }
 
 void ParsedEthTransaction::setTransactionDataField(vector<uint8_t>&  _dataField) {
     size_t index = getDataFieldIndex();
     CHECK_STATE2( fields.size() > index, "Transaction missing data field" );
-    fields.at( index )  = _dataField;
+    fields[ index ].setRawData(_dataField);
 }
 
 
@@ -337,7 +214,7 @@ void ParsedEthTransaction::testEthereumTxParser() {
         }
     }
 }
-const vector< std::vector< uint8_t > >& ParsedEthTransaction::getFields() const {
+const RLPItem& ParsedEthTransaction::getFields() const {
     return fields;
 }
 uint8_t ParsedEthTransaction::getType() const {

--- a/rlp/ParsedEthTransaction.h
+++ b/rlp/ParsedEthTransaction.h
@@ -4,44 +4,24 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include "RLP.h"
 
 class ParsedEthTransaction {
     uint8_t type = 0;  // 0 = legacy
-    std::vector< std::vector< uint8_t > > fields;
+    RLPItem fields;
 
 
     inline void parseTransactionFields( const std::vector< uint8_t >& _tx, size_t& _offset, int fieldCount);
 
 public:
-    const std::vector< std::vector< uint8_t > >& getFields() const;
+    const RLPItem& getFields() const;
     uint8_t getType() const;
 
 private:
     inline void validateAll();
     inline void validateSignature();
     inline bool isZero(const std::vector<uint8_t>& _data );
-
-    static inline std::vector< uint8_t > parseSingleByteVector(
-        const std::vector< uint8_t >& _tx, size_t& _offset );
-    static inline std::vector< uint8_t > parseShortByteVector(
-        const std::vector< uint8_t >& _tx, size_t& _offset, uint8_t _prefix );
-    static inline std::vector< uint8_t > parseLongByteVector(
-        const std::vector< uint8_t >& _tx, size_t& _offset, uint8_t _prefix );
-
-    /// The 2 methods below do not return the actual decoded value representing the lists,
-    /// but actually only the last decoded value within that list (or list of lists, and so on).
-    /// This is because we only care about the structure, not the content. These methods are used to
-    /// parse the RLP structure.
-    static inline std::vector<uint8_t> parseShortList(
-        const std::vector<uint8_t>& tx, uint64_t& offset, uint8_t prefix );
-    static inline std::vector<uint8_t> parseLongList(
-        const std::vector<uint8_t>& tx, uint64_t& offset, uint8_t prefix);
-
-    static inline size_t readLen( const std::vector< uint8_t >& _tx, size_t _offset, size_t _len );
     static inline bool isTypedTransaction( uint8_t prefix );
-    static inline void skipRlpListHeader( const std::vector< uint8_t >& _tx, size_t& _offset );
-    static inline std::vector< uint8_t > parseBytes(
-        const std::vector< uint8_t >& _tx, size_t& _offset );
 
     size_t getToFieldIndex() const;
     size_t getDataFieldIndex() const;

--- a/rlp/RLP.cpp
+++ b/rlp/RLP.cpp
@@ -142,6 +142,10 @@ RLPItem::RLPItem(const std::vector<uint8_t> &data, size_t& offset) {
     parseBytes(data, offset, 0);
 }
 
+RLPItem::RLPItem(const std::vector<uint8_t> &data, size_t& offset, size_t depth) {
+    parseBytes(data, offset, depth);
+}
+
 bool RLPItem::isList() const {
     return m_isList;
 }

--- a/rlp/RLP.cpp
+++ b/rlp/RLP.cpp
@@ -3,11 +3,16 @@
 size_t RLPItem::readLen(
     const std::vector< uint8_t >& _rlp, size_t _offset, size_t _len ) const {
     CHECK_STATE2( _offset + _len <= _rlp.size(), "readLen: out of bounds");
+    CHECK_STATE2( _len <= 8, "readLen: length field too large" );
     
     size_t val = 0;
     for ( size_t i = 0; i < _len; ++i ) {
         val = ( val << 8 ) | _rlp.at( _offset + i );
     }
+    
+    // Check for reasonable size limits
+    CHECK_STATE2( val <= MAX_RLP_DATA_SIZE, "readLen: decoded length exceeds maximum allowed size" );
+    
     return val;
 }
 
@@ -34,41 +39,49 @@ void RLPItem::parseLongByteVector(
     size_t lenOfLen = _prefix - 0xb7;
 
     CHECK_STATE2( _offset + 1 + lenOfLen <= _rlp.size(), "parseLongByteVector: lenOfLen out of bounds" );
+    CHECK_STATE2( lenOfLen <= 8, "parseLongByteVector: length-of-length too large" );
     
     size_t len = readLen( _rlp, _offset + 1, lenOfLen );
     _offset += 1 + lenOfLen;
 
     CHECK_STATE2( _offset + len <= _rlp.size(), "parseLongByteVector: slice out of bounds" );
+    CHECK_STATE2( len > 55, "parseLongByteVector: should use short encoding for this length" );
     
-    std::vector< uint8_t > out( _rlp.begin() + _offset, _rlp.begin() + _offset + len );
+    std::vector< uint8_t > out;
+    out.reserve(len);
+    out.assign( _rlp.begin() + _offset, _rlp.begin() + _offset + len );
     _offset += len;
     m_rawData = std::move(out);
 }
 
 
 void RLPItem::parseLongList(
-    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix) {
+    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth) {
     
     size_t lenOfLen = prefix - 0xf7;
 
     CHECK_STATE2( offset + 1 + lenOfLen <= _rlp.size(), "parseLongList: lenOfLen out of bounds");
+    CHECK_STATE2( lenOfLen <= 8, "parseLongList: length-of-length too large" );
     
     size_t len = readLen(_rlp, offset + 1, lenOfLen);
     offset += 1 + lenOfLen;
     
     CHECK_STATE2( offset + len <= _rlp.size(), "parseLongList: slice out of bounds");
+    CHECK_STATE2( len > 55, "parseLongList: should use short encoding for this length" );
     
     const uint64_t endOffset = offset + len;
+    
     // last item from list will be returned - will never be used
     while (offset < endOffset) {
-        children.push_back(RLPItem(_rlp, offset));
+        CHECK_STATE2( children.size() < MAX_RLP_RECURSION_DEPTH, "parseLongList: too many list items (potential DoS)" );
+        children.push_back(RLPItem(_rlp, offset, depth + 1));
     }
     CHECK_STATE2(offset == endOffset, "parseLongList: invalid list encoding");   
 }
 
 
 void RLPItem::parseShortList(
-    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix) {
+    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth) {
     
     size_t len = prefix - 0xc0;
     CHECK_STATE2(offset + 1 + len <= _rlp.size(), "parseShortList: slice out of bounds");
@@ -77,15 +90,26 @@ void RLPItem::parseShortList(
     const uint64_t endOffset = startOffset + len;
     
     offset = startOffset;
+    
+    // Reserve space to avoid repeated reallocations
+    children.reserve(std::min(len, static_cast<size_t>(100))); // Reasonable estimate for short lists
+    
     // last item from list will be returned - will never be used
     while (offset < endOffset) {
-        children.push_back(RLPItem(_rlp, offset));
+        CHECK_STATE2( children.size() < MAX_RLP_RECURSION_DEPTH, "parseShortList: too many list items (potential DoS)" );
+        children.push_back(RLPItem(_rlp, offset, depth + 1));
     }
     
     CHECK_STATE2(offset == endOffset, "parseShortList: invalid list encoding");   
 }
 
 void RLPItem::parseBytes( const std::vector< uint8_t >& _rlp, uint64_t& _offset ) {
+    parseBytes(_rlp, _offset, 0);
+}
+
+void RLPItem::parseBytes( const std::vector< uint8_t >& _rlp, uint64_t& _offset, size_t _depth ) {
+
+    CHECK_STATE2( _depth < MAX_RLP_RECURSION_DEPTH, "parseBytes: recursion depth exceeded. RLP data has too many nested lists" );
 
     if ( _offset >= _rlp.size() ) return;
 
@@ -102,20 +126,20 @@ void RLPItem::parseBytes( const std::vector< uint8_t >& _rlp, uint64_t& _offset 
         parseLongByteVector( _rlp, _offset, prefix );
     }
     else if (prefix <= 0xf7) {
-        parseShortList(_rlp, _offset, prefix);
+        parseShortList(_rlp, _offset, prefix, _depth);
     }
     else {
-        parseLongList(_rlp, _offset, prefix);
+        parseLongList(_rlp, _offset, prefix, _depth);
     }
 }
 
 RLPItem::RLPItem(const std::vector<uint8_t> &data) {
     uint64_t offset = 0;
-    parseBytes(data, offset);
+    parseBytes(data, offset, 0);
 }
 
 RLPItem::RLPItem(const std::vector<uint8_t> &data, size_t& offset) {
-    parseBytes(data, offset);
+    parseBytes(data, offset, 0);
 }
 
 bool RLPItem::isList() const {

--- a/rlp/RLP.cpp
+++ b/rlp/RLP.cpp
@@ -1,0 +1,140 @@
+#include "RLP.h"
+
+size_t RLPItem::readLen(
+    const std::vector< uint8_t >& _rlp, size_t _offset, size_t _len ) const {
+    CHECK_STATE2( _offset + _len <= _rlp.size(), "readLen: out of bounds");
+    
+    size_t val = 0;
+    for ( size_t i = 0; i < _len; ++i ) {
+        val = ( val << 8 ) | _rlp.at( _offset + i );
+    }
+    return val;
+}
+
+void RLPItem::parseSingleByteVector(
+    const std::vector< uint8_t >& _rlp, uint64_t& _offset ) {
+    CHECK_STATE2( _offset < _rlp.size(), "Short element: out of bounds" );
+    m_rawData = { _rlp.at( _offset++ ) };
+}
+
+void RLPItem::parseShortByteVector(
+    const std::vector< uint8_t >& _rlp, uint64_t& _offset, uint8_t _prefix ) {
+    size_t len = _prefix - 0x80;
+    _offset += 1;
+    CHECK_STATE2( _offset + len <= _rlp.size(), "parseShortByteVector: slice out of bounds" );
+    
+    std::vector< uint8_t > out( _rlp.begin() + _offset, _rlp.begin() + _offset + len );
+    _offset += len;
+    m_rawData = std::move(out);
+}
+
+
+void RLPItem::parseLongByteVector(
+    const std::vector< uint8_t >& _rlp, uint64_t& _offset, uint8_t _prefix ) {
+    size_t lenOfLen = _prefix - 0xb7;
+
+    CHECK_STATE2( _offset + 1 + lenOfLen <= _rlp.size(), "parseLongByteVector: lenOfLen out of bounds" );
+    
+    size_t len = readLen( _rlp, _offset + 1, lenOfLen );
+    _offset += 1 + lenOfLen;
+
+    CHECK_STATE2( _offset + len <= _rlp.size(), "parseLongByteVector: slice out of bounds" );
+    
+    std::vector< uint8_t > out( _rlp.begin() + _offset, _rlp.begin() + _offset + len );
+    _offset += len;
+    m_rawData = std::move(out);
+}
+
+
+void RLPItem::parseLongList(
+    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix) {
+    
+    size_t lenOfLen = prefix - 0xf7;
+
+    CHECK_STATE2( offset + 1 + lenOfLen <= _rlp.size(), "parseLongList: lenOfLen out of bounds");
+    
+    size_t len = readLen(_rlp, offset + 1, lenOfLen);
+    offset += 1 + lenOfLen;
+    
+    CHECK_STATE2( offset + len <= _rlp.size(), "parseLongList: slice out of bounds");
+    
+    const uint64_t endOffset = offset + len;
+    // last item from list will be returned - will never be used
+    while (offset < endOffset) {
+        children.push_back(RLPItem(_rlp, offset));
+    }
+    CHECK_STATE2(offset == endOffset, "parseLongList: invalid list encoding");   
+}
+
+
+void RLPItem::parseShortList(
+    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix) {
+    
+    size_t len = prefix - 0xc0;
+    CHECK_STATE2(offset + 1 + len <= _rlp.size(), "parseShortList: slice out of bounds");
+    
+    const uint64_t startOffset = offset + 1;
+    const uint64_t endOffset = startOffset + len;
+    
+    offset = startOffset;
+    // last item from list will be returned - will never be used
+    while (offset < endOffset) {
+        children.push_back(RLPItem(_rlp, offset));
+    }
+    
+    CHECK_STATE2(offset == endOffset, "parseShortList: invalid list encoding");   
+}
+
+void RLPItem::parseBytes( const std::vector< uint8_t >& _rlp, uint64_t& _offset ) {
+
+    if ( _offset >= _rlp.size() ) return;
+
+    uint8_t prefix = _rlp.at( _offset );
+    m_isList = prefix > 0xbf;
+
+    if ( prefix <= 0x7f ){
+        parseSingleByteVector( _rlp, _offset );
+    }
+    else if ( prefix <= 0xb7 ) {
+        parseShortByteVector( _rlp, _offset, prefix );
+    }
+    else if ( prefix <= 0xbf ) {
+        parseLongByteVector( _rlp, _offset, prefix );
+    }
+    else if (prefix <= 0xf7) {
+        parseShortList(_rlp, _offset, prefix);
+    }
+    else {
+        parseLongList(_rlp, _offset, prefix);
+    }
+}
+
+RLPItem::RLPItem(const std::vector<uint8_t> &data) {
+    uint64_t offset = 0;
+    parseBytes(data, offset);
+}
+
+RLPItem::RLPItem(const std::vector<uint8_t> &data, size_t& offset) {
+    parseBytes(data, offset);
+}
+
+bool RLPItem::isList() const {
+    return m_isList;
+}
+
+const std::vector<uint8_t>& RLPItem::asBytes() const {
+    CHECK_STATE2(!m_isList, "RLPItem is a list, cannot return asBytes");
+    return m_rawData;
+}
+
+RLPItem RLPItem::fromRawBytes(const std::vector<uint8_t> &data) {
+    auto rlp = RLPItem();
+    rlp.m_rawData = data;
+    return rlp;
+}
+
+void RLPItem::setRawData(const std::vector<uint8_t> &data) {
+    m_rawData = data;
+    m_isList = false; // reset the list state
+    children.clear(); // clear any previous children
+}

--- a/rlp/RLP.cpp
+++ b/rlp/RLP.cpp
@@ -3,16 +3,11 @@
 size_t RLPItem::readLen(
     const std::vector< uint8_t >& _rlp, size_t _offset, size_t _len ) const {
     CHECK_STATE2( _offset + _len <= _rlp.size(), "readLen: out of bounds");
-    CHECK_STATE2( _len <= 8, "readLen: length field too large" );
     
     size_t val = 0;
     for ( size_t i = 0; i < _len; ++i ) {
         val = ( val << 8 ) | _rlp.at( _offset + i );
     }
-    
-    // Check for reasonable size limits
-    CHECK_STATE2( val <= MAX_RLP_DATA_SIZE, "readLen: decoded length exceeds maximum allowed size" );
-    
     return val;
 }
 
@@ -39,49 +34,41 @@ void RLPItem::parseLongByteVector(
     size_t lenOfLen = _prefix - 0xb7;
 
     CHECK_STATE2( _offset + 1 + lenOfLen <= _rlp.size(), "parseLongByteVector: lenOfLen out of bounds" );
-    CHECK_STATE2( lenOfLen <= 8, "parseLongByteVector: length-of-length too large" );
     
     size_t len = readLen( _rlp, _offset + 1, lenOfLen );
     _offset += 1 + lenOfLen;
 
     CHECK_STATE2( _offset + len <= _rlp.size(), "parseLongByteVector: slice out of bounds" );
-    CHECK_STATE2( len > 55, "parseLongByteVector: should use short encoding for this length" );
     
-    std::vector< uint8_t > out;
-    out.reserve(len);
-    out.assign( _rlp.begin() + _offset, _rlp.begin() + _offset + len );
+    std::vector< uint8_t > out( _rlp.begin() + _offset, _rlp.begin() + _offset + len );
     _offset += len;
     m_rawData = std::move(out);
 }
 
 
 void RLPItem::parseLongList(
-    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth) {
+    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix) {
     
     size_t lenOfLen = prefix - 0xf7;
 
     CHECK_STATE2( offset + 1 + lenOfLen <= _rlp.size(), "parseLongList: lenOfLen out of bounds");
-    CHECK_STATE2( lenOfLen <= 8, "parseLongList: length-of-length too large" );
     
     size_t len = readLen(_rlp, offset + 1, lenOfLen);
     offset += 1 + lenOfLen;
     
     CHECK_STATE2( offset + len <= _rlp.size(), "parseLongList: slice out of bounds");
-    CHECK_STATE2( len > 55, "parseLongList: should use short encoding for this length" );
     
     const uint64_t endOffset = offset + len;
-    
     // last item from list will be returned - will never be used
     while (offset < endOffset) {
-        CHECK_STATE2( children.size() < MAX_RLP_RECURSION_DEPTH, "parseLongList: too many list items (potential DoS)" );
-        children.push_back(RLPItem(_rlp, offset, depth + 1));
+        children.push_back(RLPItem(_rlp, offset));
     }
     CHECK_STATE2(offset == endOffset, "parseLongList: invalid list encoding");   
 }
 
 
 void RLPItem::parseShortList(
-    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth) {
+    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix) {
     
     size_t len = prefix - 0xc0;
     CHECK_STATE2(offset + 1 + len <= _rlp.size(), "parseShortList: slice out of bounds");
@@ -90,26 +77,15 @@ void RLPItem::parseShortList(
     const uint64_t endOffset = startOffset + len;
     
     offset = startOffset;
-    
-    // Reserve space to avoid repeated reallocations
-    children.reserve(std::min(len, static_cast<size_t>(100))); // Reasonable estimate for short lists
-    
     // last item from list will be returned - will never be used
     while (offset < endOffset) {
-        CHECK_STATE2( children.size() < MAX_RLP_RECURSION_DEPTH, "parseShortList: too many list items (potential DoS)" );
-        children.push_back(RLPItem(_rlp, offset, depth + 1));
+        children.push_back(RLPItem(_rlp, offset));
     }
     
     CHECK_STATE2(offset == endOffset, "parseShortList: invalid list encoding");   
 }
 
 void RLPItem::parseBytes( const std::vector< uint8_t >& _rlp, uint64_t& _offset ) {
-    parseBytes(_rlp, _offset, 0);
-}
-
-void RLPItem::parseBytes( const std::vector< uint8_t >& _rlp, uint64_t& _offset, size_t _depth ) {
-
-    CHECK_STATE2( _depth < MAX_RLP_RECURSION_DEPTH, "parseBytes: recursion depth exceeded. RLP data has too many nested lists" );
 
     if ( _offset >= _rlp.size() ) return;
 
@@ -126,24 +102,20 @@ void RLPItem::parseBytes( const std::vector< uint8_t >& _rlp, uint64_t& _offset,
         parseLongByteVector( _rlp, _offset, prefix );
     }
     else if (prefix <= 0xf7) {
-        parseShortList(_rlp, _offset, prefix, _depth);
+        parseShortList(_rlp, _offset, prefix);
     }
     else {
-        parseLongList(_rlp, _offset, prefix, _depth);
+        parseLongList(_rlp, _offset, prefix);
     }
 }
 
 RLPItem::RLPItem(const std::vector<uint8_t> &data) {
     uint64_t offset = 0;
-    parseBytes(data, offset, 0);
+    parseBytes(data, offset);
 }
 
 RLPItem::RLPItem(const std::vector<uint8_t> &data, size_t& offset) {
-    parseBytes(data, offset, 0);
-}
-
-RLPItem::RLPItem(const std::vector<uint8_t> &data, size_t& offset, size_t depth) {
-    parseBytes(data, offset, depth);
+    parseBytes(data, offset);
 }
 
 bool RLPItem::isList() const {

--- a/rlp/RLP.h
+++ b/rlp/RLP.h
@@ -13,21 +13,10 @@
  * If you need to convert RLP data into vector of bytes, use RLPStream instead.
  */
 class RLPItem {
-public:
-    // Maximum allowed RLP data size (64MB) 
-    static const size_t MAX_RLP_DATA_SIZE = 64 * 1024 * 1024;
-    // Maximum recursion depth to prevent stack overflow
-    static const size_t MAX_RLP_RECURSION_DEPTH = 1000;
-    
 private:
     std::vector<uint8_t> m_rawData; // full raw RLP bytes of this item
     bool m_isList;
     std::vector<RLPItem> children; // only if is_list
-
-    /**
-     * Used internallt to parse RLP data limiting the recursion depth.
-     */
-    RLPItem(const std::vector<uint8_t> &data, size_t &offset, size_t depth);
 
     /**
      * Reads length of an RLP long list
@@ -44,18 +33,15 @@ private:
 
     void parseLongByteVector(
         const std::vector< uint8_t >& _rlp, uint64_t& _offset, uint8_t _prefix );
-        
+
     void parseLongList(
-        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth);
-        
+        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix);
+
     void parseShortList(
-        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth);
+        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix);
 
     void parseBytes(
         const std::vector< uint8_t >& _rlp, uint64_t& _offset );
-        
-    void parseBytes(
-        const std::vector< uint8_t >& _rlp, uint64_t& _offset, size_t _depth );
 
 public:
     /**

--- a/rlp/RLP.h
+++ b/rlp/RLP.h
@@ -13,10 +13,21 @@
  * If you need to convert RLP data into vector of bytes, use RLPStream instead.
  */
 class RLPItem {
+public:
+    // Maximum allowed RLP data size (64MB) 
+    static const size_t MAX_RLP_DATA_SIZE = 64 * 1024 * 1024;
+    // Maximum recursion depth to prevent stack overflow
+    static const size_t MAX_RLP_RECURSION_DEPTH = 1000;
+    
 private:
     std::vector<uint8_t> m_rawData; // full raw RLP bytes of this item
     bool m_isList;
     std::vector<RLPItem> children; // only if is_list
+
+    /**
+     * Used internallt to parse RLP data limiting the recursion depth.
+     */
+    RLPItem(const std::vector<uint8_t> &data, size_t &offset, size_t depth);
 
     /**
      * Reads length of an RLP long list
@@ -33,15 +44,18 @@ private:
 
     void parseLongByteVector(
         const std::vector< uint8_t >& _rlp, uint64_t& _offset, uint8_t _prefix );
-
+        
     void parseLongList(
-        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix);
-
+        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth);
+        
     void parseShortList(
-        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix);
+        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth);
 
     void parseBytes(
         const std::vector< uint8_t >& _rlp, uint64_t& _offset );
+        
+    void parseBytes(
+        const std::vector< uint8_t >& _rlp, uint64_t& _offset, size_t _depth );
 
 public:
     /**

--- a/rlp/RLP.h
+++ b/rlp/RLP.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <vector>
+#include <cstdint>
+#include <SkaleCommon.h>
+#include <cstddef>
+
+
+/**
+ * Represents a RLP list of RLP-encoded items.
+ * Used to parse RLP data from bytes.
+ * 
+ * If you need to convert RLP data into vector of bytes, use RLPStream instead.
+ */
+class RLPItem {
+private:
+    std::vector<uint8_t> m_rawData; // full raw RLP bytes of this item
+    bool m_isList;
+    std::vector<RLPItem> children; // only if is_list
+
+    /**
+     * Reads length of an RLP long list
+     */
+    size_t readLen(
+        const std::vector< uint8_t >& _rlp, size_t _offset, size_t _len ) const;
+
+
+    void parseSingleByteVector(
+        const std::vector< uint8_t >& _rlp, uint64_t& _offset );
+
+    void parseShortByteVector(
+        const std::vector< uint8_t >& _rlp, uint64_t& _offset, uint8_t _prefix ); 
+
+    void parseLongByteVector(
+        const std::vector< uint8_t >& _rlp, uint64_t& _offset, uint8_t _prefix );
+
+    void parseLongList(
+        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix);
+
+    void parseShortList(
+        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix);
+
+    void parseBytes(
+        const std::vector< uint8_t >& _rlp, uint64_t& _offset );
+
+public:
+    /**
+     * @brief Constructs an RLPItem from a raw RLP-encoded byte vector.
+     * This should be the base entry point for parsing RLP data.
+     */
+    RLPItem(const std::vector<uint8_t> &data);
+
+    RLPItem(const std::vector<uint8_t> &data, size_t &offset);
+
+    RLPItem() = default;
+
+
+    /**
+     * Used to set some raw data directly, bypassing the RLP parsing
+     */
+    RLPItem static fromRawBytes(const std::vector<uint8_t> &data);
+
+    /**
+     * Sets the raw data for this RLPItem.
+     */
+    void setRawData(const std::vector<uint8_t> &data);
+
+    /**
+     * Can only be used if the RLPItem is a list.
+     */
+    RLPItem& operator[](size_t index) {
+        CHECK_STATE2(m_isList, "RLP is not a list");
+        return children.at(index);
+    }
+
+    /**
+     * Same as above, but for const RLPItem.
+     */
+    const RLPItem& operator[](size_t index) const {
+        CHECK_STATE2(m_isList, "RLP is not a list");
+        return children.at(index);
+    }
+
+    bool isList() const;
+
+    size_t size() const {
+        return m_isList ? children.size() : 1;
+    }
+
+    /**
+     * @brief Returns the raw byte data.
+     * Can only be used if the RLPItem is not a list.
+     */
+    const std::vector<uint8_t>& asBytes() const;
+
+   
+
+};
+
+
+

--- a/rlp/RLPStream.cpp
+++ b/rlp/RLPStream.cpp
@@ -9,9 +9,6 @@ std::vector< uint8_t > RLPStream::rlpEncodeBytes(const std::vector< uint8_t >& d
     std::vector< uint8_t > out;
     const size_t len = data.size();
 
-    // Check for excessively large data
-    CHECK_STATE2( len <= RLPItem::MAX_RLP_DATA_SIZE, "rlpEncodeBytes: input data too large" );
-
     // Explicitly handle empty string
     if ( len == 0 ) {
         out.push_back( 0x80 );
@@ -94,22 +91,9 @@ u256 RLPStream::bytesToU256(const std::vector<uint8_t>& bytes) {
 std::vector<uint8_t> RLPStream::encode() const {
     std::vector< uint8_t > out;
     std::vector< uint8_t > payload;
-    
-    // Calculate total payload size first to avoid repeated reallocations
-    size_t total_payload_size = 0;
-    for ( const auto& e : data ) {
-        total_payload_size += e.size();
-        // Check for overflow and excessive size
-        CHECK_STATE2( total_payload_size <= RLPItem::MAX_RLP_DATA_SIZE, "RLPStream::encode: payload too large" );
-    }
-    
-    // Reserve capacity to avoid multiple reallocations
-    payload.reserve(total_payload_size);
-    
     for ( const auto& e : data ) {
         payload.insert( payload.end(), e.begin(), e.end() );
     }
-    
     if ( payload.size() < 56 ) {
         out.push_back( 0xc0 + payload.size() );
     } else {

--- a/rlp/RLPStream.cpp
+++ b/rlp/RLPStream.cpp
@@ -12,13 +12,13 @@ std::vector< uint8_t > RLPStream::rlpEncodeBytes(const std::vector< uint8_t >& d
     // Explicitly handle empty string
     if ( len == 0 ) {
         out.push_back( 0x80 );
-        return;
+        return out;
     }
 
     // Single byte < 0x80 is encoded directly (no prefix)
     if ( len == 1 && data[0] < 0x80 ) {
         out.push_back( data[0] );
-        return;
+        return out;
     }
 
     if ( len < 56 ) {
@@ -41,6 +41,7 @@ std::vector< uint8_t > RLPStream::rlpEncodeBytes(const std::vector< uint8_t >& d
 
     // Append actual data
     out.insert( out.end(), data.begin(), data.end() );
+    return out;
 }
 
 std::vector< uint8_t> RLPStream::rlpEncodeUint256(const std::vector< uint8_t >& value ) {

--- a/rlp/RLPStream.cpp
+++ b/rlp/RLPStream.cpp
@@ -1,0 +1,110 @@
+#include "RLPStream.h"
+#include <SkaleCommon.h>
+
+/// ------------------ Private methods ------------------ ///
+
+/// ------- RLP encoding methods ------- ///
+
+std::vector< uint8_t > RLPStream::rlpEncodeBytes(const std::vector< uint8_t >& data ) {
+    std::vector< uint8_t > out;
+    const size_t len = data.size();
+
+    // Explicitly handle empty string
+    if ( len == 0 ) {
+        out.push_back( 0x80 );
+        return;
+    }
+
+    // Single byte < 0x80 is encoded directly (no prefix)
+    if ( len == 1 && data[0] < 0x80 ) {
+        out.push_back( data[0] );
+        return;
+    }
+
+    if ( len < 56 ) {
+        // Short string: prefix = 0x80 + len
+        out.push_back( static_cast< uint8_t >( 0x80 + len ) );
+    } else {
+        // Long string: prefix = 0xb7 + len-of-len, then len, then data
+        std::vector< uint8_t > len_bytes;
+        size_t sz = len;
+        while ( sz > 0 ) {
+            len_bytes.insert( len_bytes.begin(), static_cast< uint8_t >( sz & 0xFF ) );
+            sz >>= 8;
+        }
+
+        CHECK_STATE2( len_bytes.size() <= 8, "rlpEncodeBytes: data too large (exceeds 2^64-1)" );
+
+        out.push_back( static_cast< uint8_t >( 0xb7 + len_bytes.size() ) );
+        out.insert( out.end(), len_bytes.begin(), len_bytes.end() );
+    }
+
+    // Append actual data
+    out.insert( out.end(), data.begin(), data.end() );
+}
+
+std::vector< uint8_t> RLPStream::rlpEncodeUint256(const std::vector< uint8_t >& value ) {
+    std::vector< uint8_t > out;
+    // Skip leading zeros
+    size_t start = 0;
+    while ( start < value.size() && value[start] == 0 ) {
+        ++start;
+    }
+
+    // Extract minimal non-zero representation (or empty)
+    std::vector< uint8_t > stripped( value.begin() + start, value.end() );
+
+    // Delegate to rlp_encode_bytes
+    return rlpEncodeBytes( stripped );
+}
+
+
+/// ------------------ Public methods ------------------ ///
+
+
+/// ------- Byte-type Conversion methods ------- ///
+
+std::vector< uint8_t> RLPStream::u256toBytes( u256 v_value ) {
+    std::vector<uint8_t> bytes(32);
+    for (size_t i = 0; i < 32; i++) {
+        bytes[31 - i] = static_cast<uint8_t>(v_value & 0xFF);
+        v_value >>= 8;
+    }
+    return bytes;
+}
+
+u256 RLPStream::bytesToU256(const std::vector<uint8_t>& bytes) {
+    u256 val = 0;
+    size_t bytes_size = bytes.size();
+    
+    for (size_t i = 0; i < bytes_size; ++i) {
+        if (i >= 32) {
+            // If more than 32 bytes, ignore the rest
+            break;
+        }
+        val = (val << 8) | bytes[i];
+    }
+    return val;
+}
+
+std::vector<uint8_t> RLPStream::encode() const {
+    std::vector< uint8_t > out;
+    std::vector< uint8_t > payload;
+    for ( const auto& e : data ) {
+        payload.insert( payload.end(), e.begin(), e.end() );
+    }
+    if ( payload.size() < 56 ) {
+        out.push_back( 0xc0 + payload.size() );
+    } else {
+        std::vector< uint8_t > len;
+        size_t sz = payload.size();
+        while ( sz ) {
+            len.insert( len.begin(), static_cast< uint8_t >( sz & 0xFF ) );
+            sz >>= 8;
+        }
+        out.push_back( 0xf7 + len.size() );
+        out.insert( out.end(), len.begin(), len.end() );
+    }
+    out.insert( out.end(), payload.begin(), payload.end() );
+    return out;
+}

--- a/rlp/RLPStream.cpp
+++ b/rlp/RLPStream.cpp
@@ -9,6 +9,9 @@ std::vector< uint8_t > RLPStream::rlpEncodeBytes(const std::vector< uint8_t >& d
     std::vector< uint8_t > out;
     const size_t len = data.size();
 
+    // Check for excessively large data
+    CHECK_STATE2( len <= RLPItem::MAX_RLP_DATA_SIZE, "rlpEncodeBytes: input data too large" );
+
     // Explicitly handle empty string
     if ( len == 0 ) {
         out.push_back( 0x80 );
@@ -91,9 +94,22 @@ u256 RLPStream::bytesToU256(const std::vector<uint8_t>& bytes) {
 std::vector<uint8_t> RLPStream::encode() const {
     std::vector< uint8_t > out;
     std::vector< uint8_t > payload;
+    
+    // Calculate total payload size first to avoid repeated reallocations
+    size_t total_payload_size = 0;
+    for ( const auto& e : data ) {
+        total_payload_size += e.size();
+        // Check for overflow and excessive size
+        CHECK_STATE2( total_payload_size <= RLPItem::MAX_RLP_DATA_SIZE, "RLPStream::encode: payload too large" );
+    }
+    
+    // Reserve capacity to avoid multiple reallocations
+    payload.reserve(total_payload_size);
+    
     for ( const auto& e : data ) {
         payload.insert( payload.end(), e.begin(), e.end() );
     }
+    
     if ( payload.size() < 56 ) {
         out.push_back( 0xc0 + payload.size() );
     } else {

--- a/rlp/RLPStream.h
+++ b/rlp/RLPStream.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <cstdint>
+#include <cstddef>
 #include <boost/multiprecision/cpp_int.hpp>
 
 using uint256 = std::vector< uint8_t >;
@@ -8,16 +9,19 @@ using uint256 = std::vector< uint8_t >;
 using u256 = boost::multiprecision::number< boost::multiprecision::cpp_int_backend< 256, 256,
 boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void > >;
 
+/**
+ * @brief RLPStream is a class for encoding data in the Recursive Length Prefix (RLP) format.
+ * It is only used for encoding, not decoding.
+ * For decoding, refer to the RLP class.
+ */
 class RLPStream {
 private:
 
     //  ----------------------- Helper functions for RLP encoding -------------------------------//
 
-    inline static std::vector< uint8_t > rlpEncodeBytes( const std::vector< uint8_t >& data );
+    static std::vector< uint8_t > rlpEncodeBytes( const std::vector< uint8_t >& data );
 
-    inline static std::vector< uint8_t > rlpEncodeUint256( const std::vector< uint8_t >& value );
-
-    inline static std::vector< uint8_t > rlpEncodeList( const std::vector< std::vector< uint8_t > >& elements );
+    static std::vector< uint8_t > rlpEncodeUint256( const std::vector< uint8_t >& value );
 
 public:
     RLPStream() = default;
@@ -36,6 +40,7 @@ public:
 
     std::vector<uint8_t> encode() const;
 
+    // Appending operators
     RLPStream& operator<<(const std::vector<uint8_t>& bytes) {
         data.push_back(rlpEncodeBytes(bytes));
         return *this;
@@ -52,4 +57,8 @@ public:
         }
         return *this;
     }
+
+
+
+
 };

--- a/rlp/RLPStream.h
+++ b/rlp/RLPStream.h
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <cstddef>
 #include <boost/multiprecision/cpp_int.hpp>
-#include "rlp/RLP.h"
 
 using uint256 = std::vector< uint8_t >;
 

--- a/rlp/RLPStream.h
+++ b/rlp/RLPStream.h
@@ -1,0 +1,55 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+#include <boost/multiprecision/cpp_int.hpp>
+
+using uint256 = std::vector< uint8_t >;
+
+using u256 = boost::multiprecision::number< boost::multiprecision::cpp_int_backend< 256, 256,
+boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void > >;
+
+class RLPStream {
+private:
+
+    //  ----------------------- Helper functions for RLP encoding -------------------------------//
+
+    inline static std::vector< uint8_t > rlpEncodeBytes( const std::vector< uint8_t >& data );
+
+    inline static std::vector< uint8_t > rlpEncodeUint256( const std::vector< uint8_t >& value );
+
+    inline static std::vector< uint8_t > rlpEncodeList( const std::vector< std::vector< uint8_t > >& elements );
+
+public:
+    RLPStream() = default;
+
+    std::vector<std::vector<uint8_t>> data;
+
+    /**
+     * @brief Convert a u256 value to a vector of bytes in big-endian order.
+     */
+    static std::vector< uint8_t> u256toBytes( u256 v_value );
+
+    /**
+     * @brief Convert a vector of bytes to a u256 value in big-endian order.
+     */
+    static u256 bytesToU256(const std::vector<uint8_t>& bytes);
+
+    std::vector<uint8_t> encode() const;
+
+    RLPStream& operator<<(const std::vector<uint8_t>& bytes) {
+        data.push_back(rlpEncodeBytes(bytes));
+        return *this;
+    }
+
+    RLPStream& operator<<(const u256& value) {
+        data.push_back(rlpEncodeUint256(u256toBytes(value)));
+        return *this;
+    }
+
+    RLPStream& operator<<(const RLPStream& other) {
+        for (const auto& e : other.data) {
+            data.push_back(e);
+        }
+        return *this;
+    }
+};

--- a/rlp/RLPStream.h
+++ b/rlp/RLPStream.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <boost/multiprecision/cpp_int.hpp>
+#include "rlp/RLP.h"
 
 using uint256 = std::vector< uint8_t >;
 

--- a/rlp/RLPStream.h
+++ b/rlp/RLPStream.h
@@ -52,9 +52,7 @@ public:
     }
 
     RLPStream& operator<<(const RLPStream& other) {
-        for (const auto& e : other.data) {
-            data.push_back(e);
-        }
+        data.push_back(other.encode());
         return *this;
     }
 


### PR DESCRIPTION
## Description
- Got rid of `encryptedData` field of BiteDataField class. Both `encryptedData` and `keyPlusEncryptedData` stored the exact same data. Only need one of them.
- Refactored EthTransaction parsing and serialization in consensus side:
     - RLP logic is now generic, and not tied to EthTransaction parsing/serialization
     - Added `RLPItem` class - used for parsing RLP-encoded data. We can now build RLP-encoded data using the `<<` operator - just as in SKALED.
     - Added `RLPStream` class - used to build RLP-encoded byte data. We can now index an RLP-encoded list with `[]`, as well as get the actual byte data from each index more easily.
- Added RLP-encoding support for consensus
     From consensus perspective, we still receive tx data as:
     ```
     tx_data = {
     uint8_t[] EPOCH_ID,
     uint8_t[] LibBLS_encrypted_data, // <- includes both key + encrypted data
     }
     ```
     But this (`tx_data`) is now RLP-encoded.
     - RLP-encoding of the actual encrypted data that goes inside `LibBLS_encrypted_data` is only relevant at SKALED level.
     
     
## Tests

- Updated tx encoding to also RLP-encode the `tx_data` struct.

Fixes #897 