### PR TITLE
Add rlp security checks and unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,8 +313,8 @@ file(GLOB_RECURSE ALL_TEST_SOURCES "unittests/*.cpp")
 
 # Common test folders (non-rlp)
 file(GLOB_RECURSE COMMON_TEST_SOURCES
-    "datastructures/SerializationTests.cpp"
-    "db/DBTests.cpp"
+    "unittests/datastructures/*.cpp"
+    "unittests/db/*.cpp"
     "unittests/consensus_tests.cpp"
     "unittests/sgx_tests.cpp"
     # Add other folders as needed, excluding rlp/
@@ -332,8 +332,6 @@ endif()
 # Note: Consensust.h is not needed here as it's a header file.
 add_executable(consensust 
     Consensust.cpp 
-    datastructures/SerializationTests.cpp 
-    db/DBTests.cpp 
     ${TEST_SOURCES}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,12 +305,39 @@ target_compile_options(consensusd PRIVATE -Wno-error=unused-variable)
 target_link_libraries(consensusd consensus)
 # endif ()
 
+
+### consensust executable
+
 # Automatically discover all test source files in the unittests directory and its subdirectories.
 file(GLOB_RECURSE ALL_TEST_SOURCES "unittests/*.cpp")
 
+# Common test folders (non-rlp)
+file(GLOB_RECURSE COMMON_TEST_SOURCES
+    "datastructures/SerializationTests.cpp"
+    "db/DBTests.cpp"
+    "unittests/consensus_tests.cpp"
+    "unittests/sgx_tests.cpp"
+    # Add other folders as needed, excluding rlp/
+)
+
+set(TEST_SOURCES ${COMMON_TEST_SOURCES})
+
+# Conditionally add rlp test sources if BITE is enabled
+if(DEFINED BITE)
+    file(GLOB_RECURSE RLP_TEST_SOURCES "unittests/rlp/*.cpp")
+    list(APPEND TEST_SOURCES ${RLP_TEST_SOURCES})
+endif()
+
 # Create the test executable from the main driver and all discovered test files.
 # Note: Consensust.h is not needed here as it's a header file.
-add_executable(consensust Consensust.cpp datastructures/SerializationTests.cpp db/DBTests.cpp ${ALL_TEST_SOURCES})
+add_executable(consensust 
+    Consensust.cpp 
+    datastructures/SerializationTests.cpp 
+    db/DBTests.cpp 
+    ${TEST_SOURCES}
+)
+
+target_link_libraries(consensust PRIVATE consensus)
 
 target_compile_options(consensust PRIVATE -Wno-error=unused-variable)
 
@@ -319,5 +346,4 @@ target_compile_options(consensust PRIVATE -Wno-error=unused-variable)
 #     #  sudo apt-get install -qq -yy libgoogle-perftools-dev
 #     target_link_libraries(consensust consensus tcmalloc)
 # else ()
-target_link_libraries(consensust consensus)
 # endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,12 @@ target_compile_options(consensusd PRIVATE -Wno-error=unused-variable)
 target_link_libraries(consensusd consensus)
 # endif ()
 
-add_executable(consensust Consensust.h Consensust.cpp datastructures/SerializationTests.cpp db/DBTests.cpp)
+# Automatically discover all test source files in the unittests directory and its subdirectories.
+file(GLOB_RECURSE ALL_TEST_SOURCES "unittests/*.cpp")
+
+# Create the test executable from the main driver and all discovered test files.
+# Note: Consensust.h is not needed here as it's a header file.
+add_executable(consensust Consensust.cpp datastructures/SerializationTests.cpp db/DBTests.cpp ${ALL_TEST_SOURCES})
 
 target_compile_options(consensust PRIVATE -Wno-error=unused-variable)
 

--- a/Consensust.cpp
+++ b/Consensust.cpp
@@ -57,38 +57,7 @@
 #include <gperftools/heap-profiler.h>
 #endif
 
-
-ConsensusEngine* engine;
-
-
-class DontCleanup {
-public:
-    DontCleanup() { Consensust::setConfigDirPath( boost::filesystem::system_complete( "." ) ); };
-
-    ~DontCleanup() {}
-};
-
-
-class StartFromScratch {
-public:
-    StartFromScratch() {
-        int i = system( "rm -rf /tmp/*.db.*" );
-        i = system( "rm -rf /tmp/*.db" );
-        i++;  // make compiler happy
-        Consensust::setConfigDirPath( boost::filesystem::system_complete( "." ) );
-
-#ifdef GOOGLE_PROFILE
-        HeapProfilerStart( "/tmp/consensusd.profile" );
-        HeapProfilerStart( "/tmp/consensusd.profile" );
-#endif
-    };
-
-    ~StartFromScratch() {
-#ifdef GOOGLE_PROFILE
-        HeapProfilerStop();
-#endif
-    }
-};
+ConsensusEngine* engine;  // definition
 
 uint64_t Consensust::getRunningTimeS() {
     if ( runningTimeS == 0 ) {
@@ -132,7 +101,7 @@ void abort_handler( int ) {
     exit( 0 );
 }
 
-block_id basicRun( int64_t _lastId = 0 ) {
+block_id basicRun( int64_t _lastId ) {
     try {
         REQUIRE( ConsensusEngine::getEngineVersion().size() > 0 );
 
@@ -191,7 +160,3 @@ void exit_check() {
         usleep( 100 * 1000 );
     }
 }
-
-
-#include "unittests/consensus_tests.cpp"
-#include "unittests/sgx_tests.cpp"

--- a/Consensust.h
+++ b/Consensust.h
@@ -23,8 +23,13 @@
 
 #pragma once
 
+#include "SkaleCommon.h"
+#include "node/ConsensusEngine.h"
+
 #define DEFAULT_RUNNING_TIME_S 30
 #define STUCK_TEST_TIME 5
+
+extern ConsensusEngine* engine;
 
 class Consensust {
     static uint64_t runningTimeS;
@@ -44,3 +49,36 @@ public:
 
     static void testFinalize();
 };
+
+class StartFromScratch {
+public:
+    StartFromScratch() {
+        int i = system( "rm -rf /tmp/*.db.*" );
+        i = system( "rm -rf /tmp/*.db" );
+        i++;  // make compiler happy
+        Consensust::setConfigDirPath( boost::filesystem::system_complete( "." ) );
+
+#ifdef GOOGLE_PROFILE
+        HeapProfilerStart( "/tmp/consensusd.profile" );
+        HeapProfilerStart( "/tmp/consensusd.profile" );
+#endif
+    };
+
+    ~StartFromScratch() {
+#ifdef GOOGLE_PROFILE
+        HeapProfilerStop();
+#endif
+    }
+};
+
+class DontCleanup {
+public:
+    DontCleanup() { Consensust::setConfigDirPath( boost::filesystem::system_complete( "." ) ); };
+
+    ~DontCleanup() {}
+};
+
+block_id basicRun( int64_t _lastId = 0 );
+void exit_check();
+void abort_handler( int );
+void testLog( const char* message );

--- a/README.md
+++ b/README.md
@@ -66,119 +66,46 @@ cd .. && cmake . -Bbuild -DCMAKE_BUILD_TYPE=Debug
 cmake --build build -- -j$(nproc) 
 ```
 
-## Running tests
+---
 
-After the build completes, the *build* directory contains a test binary named **consensust**,  
-which can run a number of consensus tests.
+## Testing
 
-The test subdirectories are located in the **tests** directory.  
-To run a specific test, navigate to its corresponding subdirectory.
+SKALE Consensus includes comprehensive test suites covering unit tests, integration tests, and end-to-end scenarios.
 
-Examples:
+### Quick Test Run
 
+After building, you can run a basic test:
 
-To run one node
-
-```
+```bash
 cd test/onenode
-sudo NO_ULIMIT_CHECK=1 TEST_TIME_S=180 TEST_TRANSACTIONS_PER_BLOCK=10 ../../build/consensust [consensus-basic]  
+sudo NO_ULIMIT_CHECK=1 TEST_TIME_S=60 TEST_TRANSACTIONS_PER_BLOCK=10 ../../build/consensust [consensus-basic]
 ```
 
+### Running Specific Tests
 
-
-
-## Running SGX simulation test
-
-You can run four and 16 nodes test  using sgx simulation and 
-test keys.
-
-First install docker and docker compose, since the test runs sgxwallet in a docker container
+Tests are organized with a multi-dimensional tagging system:
 
 ```bash
-sudo apt update
-sudo apt install -y \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-    sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-echo \
-  "deb [arch=$(dpkg --print-architecture) \
-  signed-by=/etc/apt/keyrings/docker.gpg] \
-  https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | \
-  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-  sudo apt update
-  sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin             
+# Run RLP unit tests
+./build/consensust [rlp][unit][correctness]
+
+# Run all crypto tests
+./build/consensust [crypto]
+
+# Run performance tests
+./build/consensust [performance]
 ```
 
-Now start sgx server in a docker container 
+### Multi-Node Testing
 
-```bash
-cd run_sgx_test
-sudo ./run.bash
-```
+For advanced testing scenarios including 4-node and 16-node tests with SGX simulation, see our comprehensive **[Testing Guide](TESTING.md)**.
 
-Check that sgxwallet has successfully started (it takes several minutes)
-
-You can check progress by doing 
-
-```bash
-docker logs run_sgx_test-sgxwallet-1
-```
-When the sgxwallet is up and running, you will see the following message in the log
-
-```
-[2025-05-20 12:49:43.323] [info] Started ZMQ worker thread 14
-[2025-05-20 12:49:43.323] [info] Starting ZMQ worker thread 15
-[2025-05-20 12:49:43.323] [info] Started ZMQ worker thread 15
-[2025-05-20 12:49:43.323] [info] Created thread pool
-[2025-05-20 12:49:43.323] [info] Releasing SGX worker threads  ...
-[2025-05-20 12:49:43.323] [info] Starting zmq server on port 1031 ...
-Completed initAll.
-[2025-05-20 12:49:43.323] [info] Released SGX worker threads.
-[2025-05-20 12:49:43.323] [info] Inited zmq server.
-Found test keys.
-[2025-05-20 12:49:43.323] [info] ZMQ server socket created and bound.
-[2025-05-20 12:49:43.323] [info] Started zmq read loop.
-```
-
-
-Now you can check that test keys are available by running the following command:
-
-```bash
-cd sgx_data
-ls
-```
-
-You should see, in particular, the following files:
-
-```
-16node.json  
-4node.json 
-```
-
-These files are config files for 4 and 16 nodes respectively used by the test.
-
-Now you can run the test with 4 nodes or 16 nodes.
-
-```
-cd ../test/fournodes
-sudo TEST_TIME_S=180 TEST_TRANSACTIONS_PER_BLOCK=10 ../../build/consensust [consensus-basic]
-```
-
-or
-
-```
-cd ../test/sixteennodes
-sudo TEST_TIME_S=180 TEST_TRANSACTIONS_PER_BLOCK=10 ../../build/consensust [consensus-basic]
-```
-
-
-The test checks if the config files ```4node.json and 16node.json ``` are present, and runs the tests against the wallet. If the files are not present,
-the test runs in a mockup mode. 
+The testing guide covers:
+- Detailed test organization and tagging
+- SGX simulation setup with Docker
+- Performance testing procedures
+- Troubleshooting common issues
+- Advanced testing configurations
 
 
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ sudo NO_ULIMIT_CHECK=1 TEST_TIME_S=60 TEST_TRANSACTIONS_PER_BLOCK=10 ../../build
 Tests are organized with a multi-dimensional tagging system:
 
 ```bash
-# Run RLP unit tests
+# Run RLP unit tests that only test correctness (ignores safety and performance tests)
 ./build/consensust [rlp][unit][correctness]
 
 # Run all crypto tests
@@ -98,14 +98,12 @@ Tests are organized with a multi-dimensional tagging system:
 
 ### Multi-Node Testing
 
-For advanced testing scenarios including 4-node and 16-node tests with SGX simulation, see our comprehensive **[Testing Guide](TESTING.md)**.
+For more detailed testing scenarios, including 4-node and 16-node tests with SGX simulation, see our comprehensive **[Testing Guide](TESTING.md)**.
 
 The testing guide covers:
 - Detailed test organization and tagging
 - SGX simulation setup with Docker
 - Performance testing procedures
-- Troubleshooting common issues
-- Advanced testing configurations
 
 
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,187 @@
+# SKALE Consensus Testing Guide
+
+This document provides comprehensive testing instructions for SKALE Consensus, including unit tests, integration tests, and end-to-end testing scenarios.
+
+## Table of Contents
+
+- [Test Organization](#test-organization)
+- [Running Tests](#running-tests)
+- [End-to-end tests](#end-to-end-tests)
+- [SGX Simulation Testing](#sgx-simulation-testing)
+
+---
+
+## Test Organization Guidelines
+
+Tests in the SKALE Consensus codebase follow a **multi-dimensional tagging and directory structure** that promotes clarity, modularity, and scalability. The tagging system is structured along three main dimensions: **Component**, **Test Type**, and **Scope**. 
+
+  
+  
+#### 1. Component-Based Structure and Tagging
+
+**Directory Structure**  
+Each unit test must reside in a directory named after the component it tests. For example:
+- `rlp/` for RLP-related tests
+- `crypto/` for cryptographic component tests
+- `consensus/` for consensus algorithm logic
+- `network/` for network-level functionality
+
+**Tagging Rules**:
+- All tests within a given directory must be tagged with the corresponding component tag, e.g., `[rlp]`, `[crypto]`.
+- Tests targeting specific internal classes or modules should include a **sub-component tag**, typically matching the tested class or submodule name.
+
+**Examples**:
+- `[rlp][rlp-stream]` for tests in `rlp/RLPStreamTests.cpp`
+- `[rlp][rlp-item]` for tests in `rlp/RLPItemTests.cpp`
+
+#### 2. Test Type Tags
+
+These tags describe the **purpose or concern** of the test:
+
+- `[correctness]`: Ensures functional correctness and semantic compliance of the component under test.  
+  _Example: Validating that RLP-encoded data decodes back to the original form._
+
+- `[security]`: Verifies enforcement of **non-functional safety constraints** that prevent potential abuse or misuse.  
+  _Example: Checking input size bounds, nesting depth limits, or overflow protections._
+
+- `[performance]`: Benchmarks throughput, latency, or resource usage of specific operations.  
+  _Example: Measuring cryptographic signing speed or RLP parsing time for large inputs._
+
+> **Note:** Security tests focus on constraints that **do not affect correctness**, but are critical to system safety (e.g., limiting input data size or computational cost).
+
+
+#### 3. Scope Tags
+
+These tags define the **granularity** of the test:
+
+- `[unit]`: Isolated testing of a single component or class, independent of external systems.
+- `[integration]`: Tests the interaction between multiple components or subsystems.
+- `[end-to-end]`: Tests the complete consensus pipeline or system behavior under realistic or simulated conditions.
+
+
+---
+## Running Tests
+
+```bash
+# Run all RLP correctness unit tests
+./build/consensust [rlp][unit][correctness]
+
+# Run all security RLP tests (any scope)
+./build/consensust [rlp][security]
+
+# Run all performance tests
+./build/consensust [performance]
+
+# Run all non-performance tests
+./build/consensust ~[performance]
+```
+
+---
+
+## End-to-End Tests
+
+End-to-end tests simulate real network conditions with multiple nodes.
+
+### Single Node Test
+
+```bash
+cd test/onenode
+sudo NO_ULIMIT_CHECK=1 TEST_TIME_S=180 TEST_TRANSACTIONS_PER_BLOCK=10 ../../build/consensust [consensus-basic]
+```
+
+### Multi-Node Tests (Requires SGX Setup)
+
+For 4-node and 16-node tests, you need to set up SGX simulation first (see [SGX Simulation Testing](#sgx-simulation-testing)).
+
+```bash
+# 4-node test
+cd test/fournodes
+sudo TEST_TIME_S=180 TEST_TRANSACTIONS_PER_BLOCK=10 ../../build/consensust [consensus-basic]
+
+# 16-node test
+cd test/sixteennodes
+sudo TEST_TIME_S=180 TEST_TRANSACTIONS_PER_BLOCK=10 ../../build/consensust [consensus-basic]
+```
+
+### Test Parameters
+
+- `TEST_TIME_S` - Test duration in seconds
+- `TEST_TRANSACTIONS_PER_BLOCK` - Number of transactions per block
+- `NO_ULIMIT_CHECK=1` - Bypass ulimit checks (for single-node tests)
+
+## SGX Simulation Testing
+
+Multi-node tests require SGX wallet simulation using Docker.
+
+### Prerequisites
+
+Install Docker and Docker Compose:
+
+```bash
+sudo apt update
+sudo apt install -y ca-certificates curl gnupg lsb-release
+
+# Add Docker's official GPG key
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+    sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Set up the repository
+echo \
+  "deb [arch=$(dpkg --print-architecture) \
+  signed-by=/etc/apt/keyrings/docker.gpg] \
+  https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Install Docker
+sudo apt update
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+### Starting SGX Wallet
+
+```bash
+cd run_sgx_test
+sudo ./run.bash
+```
+
+### Monitoring SGX Wallet Startup
+
+The SGX wallet takes several minutes to initialize. Monitor progress:
+
+```bash
+docker logs run_sgx_test-sgxwallet-1
+```
+
+**Ready when you see:**
+```
+[2025-05-20 12:49:43.323] [info] Started zmq read loop.
+Found test keys.
+```
+
+### Verifying Test Keys
+
+Check that configuration files are available:
+
+```bash
+cd sgx_data
+ls
+```
+
+You should see:
+- `4node.json` - Configuration for 4-node tests
+- `16node.json` - Configuration for 16-node tests
+
+
+## Contributing Test Cases
+
+When adding new tests:
+
+1. **Use appropriate tags** following the component/type/scope convention
+2. **Place tests in correct directories** matching the component tag
+3. **Include both positive and negative test cases**
+4. **Add performance tests for critical paths**
+5. **Document any special setup requirements**
+
+For more information on contributing, see the main [README.md](README.md#contributing).

--- a/rlp/RLP.cpp
+++ b/rlp/RLP.cpp
@@ -1,13 +1,52 @@
 #include "RLP.h"
 
+// ----------- Security validation methods ---------------- //
+
+void RLPItem::validateDataSize(size_t size) const {
+    CHECK_STATE2(size <= MAX_RLP_DATA_SIZE, 
+        "RLP data size " + std::to_string(size) + " exceeds maximum " + std::to_string(MAX_RLP_DATA_SIZE));
+}
+
+void RLPItem::validateListLength(size_t length) const {
+    CHECK_STATE2(length <= MAX_RLP_LIST_LENGTH,
+        "RLP list length " + std::to_string(length) + " exceeds maximum " + std::to_string(MAX_RLP_LIST_LENGTH));
+}
+
+void RLPItem::validateNestingDepth(size_t depth) const {
+    CHECK_STATE2(depth <= MAX_RLP_NESTING_DEPTH,
+        "RLP nesting depth " + std::to_string(depth) + " exceeds maximum " + std::to_string(MAX_RLP_NESTING_DEPTH));
+}
+
+void RLPItem::validateItemSize(size_t size) const {
+    CHECK_STATE2(size <= MAX_RLP_ITEM_SIZE,
+        "RLP item size " + std::to_string(size) + " exceeds maximum " + std::to_string(MAX_RLP_ITEM_SIZE));
+}
+
+void RLPItem::validateLengthBytes(size_t lengthBytes) const {
+    CHECK_STATE2(lengthBytes <= MAX_LENGTH_BYTES,
+        "RLP length encoding " + std::to_string(lengthBytes) + " bytes exceeds maximum " + std::to_string(MAX_LENGTH_BYTES));
+}
+
+
+// ----------- Parsing methods ---------------- //
+
 size_t RLPItem::readLen(
     const std::vector< uint8_t >& _rlp, size_t _offset, size_t _len ) const {
     CHECK_STATE2( _offset + _len <= _rlp.size(), "readLen: out of bounds");
     
+    // Security: validate length encoding size
+    validateLengthBytes(_len);
+    
     size_t val = 0;
     for ( size_t i = 0; i < _len; ++i ) {
+        // Security: check for integer overflow
+        CHECK_STATE2(val <= (SIZE_MAX >> 8), "readLen: integer overflow in length calculation");
         val = ( val << 8 ) | _rlp.at( _offset + i );
     }
+    
+    // Security: validate computed length
+    validateItemSize(val);
+    
     return val;
 }
 
@@ -20,6 +59,10 @@ void RLPItem::parseSingleByteVector(
 void RLPItem::parseShortByteVector(
     const std::vector< uint8_t >& _rlp, uint64_t& _offset, uint8_t _prefix ) {
     size_t len = _prefix - 0x80;
+    
+    // Security: validate item size
+    validateItemSize(len);
+    
     _offset += 1;
     CHECK_STATE2( _offset + len <= _rlp.size(), "parseShortByteVector: slice out of bounds" );
     
@@ -33,9 +76,16 @@ void RLPItem::parseLongByteVector(
     const std::vector< uint8_t >& _rlp, uint64_t& _offset, uint8_t _prefix ) {
     size_t lenOfLen = _prefix - 0xb7;
 
+    // Security: validate length encoding size
+    validateLengthBytes(lenOfLen);
+    
     CHECK_STATE2( _offset + 1 + lenOfLen <= _rlp.size(), "parseLongByteVector: lenOfLen out of bounds" );
     
     size_t len = readLen( _rlp, _offset + 1, lenOfLen );
+    
+    // Security: additional validation for long byte vectors
+    CHECK_STATE2(len >= 56, "parseLongByteVector: length must be >= 56 for long encoding");
+    
     _offset += 1 + lenOfLen;
 
     CHECK_STATE2( _offset + len <= _rlp.size(), "parseLongByteVector: slice out of bounds" );
@@ -45,47 +95,73 @@ void RLPItem::parseLongByteVector(
     m_rawData = std::move(out);
 }
 
-
-void RLPItem::parseLongList(
-    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix) {
-    
-    size_t lenOfLen = prefix - 0xf7;
-
-    CHECK_STATE2( offset + 1 + lenOfLen <= _rlp.size(), "parseLongList: lenOfLen out of bounds");
-    
-    size_t len = readLen(_rlp, offset + 1, lenOfLen);
-    offset += 1 + lenOfLen;
-    
-    CHECK_STATE2( offset + len <= _rlp.size(), "parseLongList: slice out of bounds");
-    
-    const uint64_t endOffset = offset + len;
-    // last item from list will be returned - will never be used
-    while (offset < endOffset) {
-        children.push_back(RLPItem(_rlp, offset));
-    }
-    CHECK_STATE2(offset == endOffset, "parseLongList: invalid list encoding");   
-}
-
-
-void RLPItem::parseShortList(
-    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix) {
+void RLPItem::parseShortListWithDepth(
+    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth) {
     
     size_t len = prefix - 0xc0;
-    CHECK_STATE2(offset + 1 + len <= _rlp.size(), "parseShortList: slice out of bounds");
+    CHECK_STATE2(offset + 1 + len <= _rlp.size(), "parseShortListWithDepth: slice out of bounds");
     
     const uint64_t startOffset = offset + 1;
     const uint64_t endOffset = startOffset + len;
     
     offset = startOffset;
-    // last item from list will be returned - will never be used
+    size_t itemCount = 0;
+    
+    // Security: validate list won't exceed maximum items
     while (offset < endOffset) {
-        children.push_back(RLPItem(_rlp, offset));
+        CHECK_STATE2(itemCount < MAX_RLP_LIST_LENGTH, 
+            "parseShortListWithDepth: list item count exceeds maximum");
+        
+        RLPItem child;
+        child.parseBytesWithDepth(_rlp, offset, depth);
+        children.push_back(std::move(child));
+        itemCount++;
     }
     
-    CHECK_STATE2(offset == endOffset, "parseShortList: invalid list encoding");   
+    CHECK_STATE2(offset == endOffset, "parseShortListWithDepth: invalid list encoding");   
 }
 
-void RLPItem::parseBytes( const std::vector< uint8_t >& _rlp, uint64_t& _offset ) {
+void RLPItem::parseLongListWithDepth(
+    const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth) {
+    
+    size_t lenOfLen = prefix - 0xf7;
+
+    // Security: validate length encoding size
+    validateLengthBytes(lenOfLen);
+
+    CHECK_STATE2( offset + 1 + lenOfLen <= _rlp.size(), "parseLongListWithDepth: lenOfLen out of bounds");
+    
+    size_t len = readLen(_rlp, offset + 1, lenOfLen);
+    
+    // Security: additional validation for long lists
+    CHECK_STATE2(len >= 56, "parseLongListWithDepth: length must be >= 56 for long encoding");
+    
+    offset += 1 + lenOfLen;
+    
+    CHECK_STATE2( offset + len <= _rlp.size(), "parseLongListWithDepth: slice out of bounds");
+    
+    const uint64_t endOffset = offset + len;
+    size_t itemCount = 0;
+    
+    // Security: validate list won't exceed maximum items
+    while (offset < endOffset) {
+        CHECK_STATE2(itemCount < MAX_RLP_LIST_LENGTH, 
+            "parseLongListWithDepth: list item count exceeds maximum");
+        
+        RLPItem child;
+        child.parseBytesWithDepth(_rlp, offset, depth);
+        children.push_back(std::move(child));
+        itemCount++;
+    }
+    CHECK_STATE2(offset == endOffset, "parseLongListWithDepth: invalid list encoding");   
+}
+
+void RLPItem::parseBytesWithDepth( const std::vector< uint8_t >& _rlp, uint64_t& _offset, size_t depth ) {
+
+    // Security: validate nesting depth to prevent stack overflow
+    validateNestingDepth(depth);
+
+    m_nestingDepth = depth;
 
     if ( _offset >= _rlp.size() ) return;
 
@@ -102,20 +178,25 @@ void RLPItem::parseBytes( const std::vector< uint8_t >& _rlp, uint64_t& _offset 
         parseLongByteVector( _rlp, _offset, prefix );
     }
     else if (prefix <= 0xf7) {
-        parseShortList(_rlp, _offset, prefix);
+        parseShortListWithDepth(_rlp, _offset, prefix, depth + 1);
     }
     else {
-        parseLongList(_rlp, _offset, prefix);
+        parseLongListWithDepth(_rlp, _offset, prefix, depth + 1);
     }
 }
 
 RLPItem::RLPItem(const std::vector<uint8_t> &data) {
+    // Security: validate total data size
+    validateDataSize(data.size());
+    
     uint64_t offset = 0;
-    parseBytes(data, offset);
+    parseBytesWithDepth(data, offset, 0);
 }
 
 RLPItem::RLPItem(const std::vector<uint8_t> &data, size_t& offset) {
-    parseBytes(data, offset);
+    // Security: validate total data size
+    validateDataSize(data.size() - offset);
+    parseBytesWithDepth(data, offset, 0);
 }
 
 bool RLPItem::isList() const {

--- a/rlp/RLP.h
+++ b/rlp/RLP.h
@@ -5,6 +5,12 @@
 #include <SkaleCommon.h>
 #include <cstddef>
 
+// Security constants to prevent attacks
+static constexpr size_t MAX_RLP_DATA_SIZE = 64 * 1024 * 1024; // 64 MB max total data
+static constexpr size_t MAX_RLP_LIST_LENGTH = 1024 * 1024;    // 1M max list items
+static constexpr size_t MAX_RLP_NESTING_DEPTH = 1024;         // Max recursion depth
+static constexpr size_t MAX_RLP_ITEM_SIZE = 32 * 1024 * 1024; // 32 MB max single item
+static constexpr size_t MAX_LENGTH_BYTES = 8;                 // Max bytes for length encoding
 
 /**
  * Represents a RLP list of RLP-encoded items.
@@ -17,6 +23,9 @@ private:
     std::vector<uint8_t> m_rawData; // full raw RLP bytes of this item
     bool m_isList;
     std::vector<RLPItem> children; // only if is_list
+    
+    // Security: track parsing depth to prevent stack overflow
+    mutable size_t m_nestingDepth = 0;
 
     /**
      * Reads length of an RLP long list
@@ -24,6 +33,12 @@ private:
     size_t readLen(
         const std::vector< uint8_t >& _rlp, size_t _offset, size_t _len ) const;
 
+    // Security validation methods
+    void validateDataSize(size_t size) const;
+    void validateListLength(size_t length) const;
+    void validateNestingDepth(size_t depth) const;
+    void validateItemSize(size_t size) const;
+    void validateLengthBytes(size_t lengthBytes) const;
 
     void parseSingleByteVector(
         const std::vector< uint8_t >& _rlp, uint64_t& _offset );
@@ -33,23 +48,29 @@ private:
 
     void parseLongByteVector(
         const std::vector< uint8_t >& _rlp, uint64_t& _offset, uint8_t _prefix );
-
-    void parseLongList(
-        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix);
-
-    void parseShortList(
-        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix);
-
-    void parseBytes(
-        const std::vector< uint8_t >& _rlp, uint64_t& _offset );
+    
+    // Depth-aware parsing methods to prevent stack overflow
+    void parseShortListWithDepth(
+        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth);
+    
+    void parseLongListWithDepth(
+        const std::vector<uint8_t>& _rlp, uint64_t& offset, uint8_t prefix, size_t depth);
+    
+    void parseBytesWithDepth(
+        const std::vector< uint8_t >& _rlp, uint64_t& _offset, size_t depth );
 
 public:
     /**
      * @brief Constructs an RLPItem from a raw RLP-encoded byte vector.
      * This should be the base entry point for parsing RLP data.
+     * @throws InvalidStateException if data exceeds security limits
      */
     RLPItem(const std::vector<uint8_t> &data);
 
+    /**
+     * @brief Constructs an RLPItem from a raw RLP-encoded byte vector with offset.
+     * @throws InvalidStateException if data exceeds security limits
+     */
     RLPItem(const std::vector<uint8_t> &data, size_t &offset);
 
     RLPItem() = default;

--- a/rlp/RLPStream.cpp
+++ b/rlp/RLPStream.cpp
@@ -91,9 +91,11 @@ u256 RLPStream::bytesToU256(const std::vector<uint8_t>& bytes) {
 std::vector<uint8_t> RLPStream::encode() const {
     std::vector< uint8_t > out;
     std::vector< uint8_t > payload;
+    
     for ( const auto& e : data ) {
         payload.insert( payload.end(), e.begin(), e.end() );
     }
+    
     if ( payload.size() < 56 ) {
         out.push_back( 0xc0 + payload.size() );
     } else {
@@ -103,6 +105,10 @@ std::vector<uint8_t> RLPStream::encode() const {
             len.insert( len.begin(), static_cast< uint8_t >( sz & 0xFF ) );
             sz >>= 8;
         }
+        
+        // Basic sanity check for length encoding
+        CHECK_STATE2(len.size() <= 8, "RLPStream encode: payload length too large");
+        
         out.push_back( 0xf7 + len.size() );
         out.insert( out.end(), len.begin(), len.end() );
     }

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -66,6 +66,9 @@ run("ccache -M 20G")
 
 consensustExecutive = getConsensustExecutive()
 
+# Run all non-end-to-end and non-performance unit tests
+unitTest(consensustExecutive, "~[end-to-end]~[performance]")
+
 #unitTest(consensustExecutive, "[sgx]")
 unitTest(consensustExecutive, "[tx-serialize]")
 unitTest(consensustExecutive, "[tx-list-serialize]")   
@@ -86,5 +89,3 @@ fullConsensusTest("fournodes", consensustExecutive, "[consensus-basic]")
 #fullConsensusTest("fournodes_catchup", consensustExecutive, "[consensus-basic]")
 #fullConsensusTest("three_out_of_four", consensustExecutive, "[consensus-basic]")
 
-unitTest(consensustExecutive, "[tx-serialize]")
-unitTest(consensustExecutive, "[tx-list-serialize]")

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -69,10 +69,6 @@ consensustExecutive = getConsensustExecutive()
 # Run all non-end-to-end and non-performance unit tests
 unitTest(consensustExecutive, "~[end-to-end]~[performance]")
 
-#unitTest(consensustExecutive, "[sgx]")
-unitTest(consensustExecutive, "[tx-serialize]")
-unitTest(consensustExecutive, "[tx-list-serialize]")   
-
 
 # fullConsensusTest("sixteennodes", consensustExecutive, "[consensus-finalization-download]")
 

--- a/scripts/tests_nightly.py
+++ b/scripts/tests_nightly.py
@@ -68,8 +68,7 @@ run ("ccache -M 20G")
 
 consensustExecutive = getConsensustExecutive()
 
-unitTest(consensustExecutive, "[tx-serialize]")
-unitTest(consensustExecutive, "[tx-list-serialize]")
+unitTest(consensustExecutive, "~[end-to-end]~[performance]")
 unitTest(consensustExecutive, "[committed-block-serialize]")
 
 try:

--- a/unittests/consensus_tests.cpp
+++ b/unittests/consensus_tests.cpp
@@ -2,32 +2,34 @@
 // Created by kladko on 17.06.20.
 //
 
+#include "thirdparty/catch.hpp"
+#include "Consensust.h"
 
-TEST_CASE_METHOD( StartFromScratch, "Run basic consensus", "[consensus-basic]" ) {
+TEST_CASE_METHOD( StartFromScratch, "Run basic consensus", "[consensus-basic][end-to-end]" ) {
     basicRun();
     SUCCEED();
 }
 
 TEST_CASE_METHOD(
-    DontCleanup, "Run basic consensus without cleanup", "[consensus-basic-no-cleanup]" ) {
+    DontCleanup, "Run basic consensus without cleanup", "[consensus-basic-no-cleanup][end-to-end]" ) {
     basicRun();
     SUCCEED();
 }
 
 TEST_CASE_METHOD(
-    DontCleanup, "Continue running basic consensus where stopped", "[consensus-basic-continue]" ) {
+    DontCleanup, "Continue running basic consensus where stopped", "[consensus-basic-continue][end-to-end]" ) {
     basicRun( -1 );
     SUCCEED();
 }
 
 
-TEST_CASE_METHOD( StartFromScratch, "Run two engines", "[consensus-two-engines]" ) {
+TEST_CASE_METHOD( StartFromScratch, "Run two engines", "[consensus-two-engines][end-to-end]" ) {
     auto lastId = basicRun();
     basicRun( ( int64_t )( uint64_t ) lastId );
     SUCCEED();
 }
 
-TEST_CASE_METHOD( StartFromScratch, "Change schain index", "[change-schain-index]" ) {
+TEST_CASE_METHOD( StartFromScratch, "Change schain index", "[change-schain-index][end-to-end]" ) {
     uint64_t lastId = ( uint64_t ) basicRun();
     Consensust::useCorruptConfigs();
     REQUIRE_THROWS( basicRun( lastId ) );
@@ -36,7 +38,7 @@ TEST_CASE_METHOD( StartFromScratch, "Change schain index", "[change-schain-index
 
 
 TEST_CASE_METHOD(
-    StartFromScratch, "Use finalization download only", "[consensus-finalization-download]" ) {
+    StartFromScratch, "Use finalization download only", "[consensus-finalization-download][end-to-end]" ) {
     setenv( "TEST_FINALIZATION_DOWNLOAD_ONLY", "1", 1 );
 
     engine = new ConsensusEngine( 0, 100000000 );
@@ -52,7 +54,7 @@ TEST_CASE_METHOD(
 }
 
 
-TEST_CASE_METHOD( StartFromScratch, "Get consensus to stuck", "[consensus-stuck]" ) {
+TEST_CASE_METHOD( StartFromScratch, "Get consensus to stuck", "[consensus-stuck][end-to-end]" ) {
     testLog( "Parsing configs" );
     std::thread timer( exit_check );
     try {
@@ -74,7 +76,7 @@ TEST_CASE_METHOD( StartFromScratch, "Get consensus to stuck", "[consensus-stuck]
 }
 
 TEST_CASE_METHOD(
-    StartFromScratch, "Issue different proposals to different nodes", "[corrupt-proposal]" ) {
+    StartFromScratch, "Issue different proposals to different nodes", "[corrupt-proposal][end-to-end]" ) {
     setenv( "CORRUPT_PROPOSAL_TEST", "1", 1 );
 
     try {

--- a/unittests/datastructures/SerializationTests.cpp
+++ b/unittests/datastructures/SerializationTests.cpp
@@ -38,15 +38,12 @@
 #endif
 #include "chains/Schain.h"
 
-#include "CommittedBlock.h"
-#include "CommittedBlockList.h"
-
-
-#include "Transaction.h"
-#include "TransactionList.h"
-
-#include "BlockProposalFragment.h"
-#include "BlockProposalFragmentList.h"
+#include "datastructures/CommittedBlock.h"
+#include "datastructures/CommittedBlockList.h"
+#include "datastructures/Transaction.h"
+#include "datastructures/TransactionList.h"
+#include "datastructures/BlockProposalFragment.h"
+#include "datastructures/BlockProposalFragmentList.h"
 
 
 #define BOOST_PENDING_INTEGER_LOG2_HPP
@@ -55,10 +52,7 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 
-
 #include "thirdparty/catch.hpp"
-
-#include "Transaction.h"
 
 
 void corrupt_byte_vector( const ptr< vector< uint8_t > >& _in, boost::random::mt19937& _gen,
@@ -291,7 +285,7 @@ void test_committed_block_list_serialize_deserialize() {
 }
 
 
-TEST_CASE( "Serialize/deserialize transaction", "[tx-serialize]" ) {
+TEST_CASE( "Serialize/deserialize transaction", "[tx-serialize][unit][correctness]" ) {
     SECTION( "Test successful serialize/deserialize" )
 
 
@@ -304,7 +298,7 @@ TEST_CASE( "Serialize/deserialize transaction", "[tx-serialize]" ) {
     // Test successful serialize/deserialize failure
 }
 
-TEST_CASE( "Serialize/deserialize transaction list", "[tx-list-serialize]" ) {
+TEST_CASE( "Serialize/deserialize transaction list", "[tx-list-serialize][unit][correctness]" ) {
     SECTION( "Test successful serialize/deserialize" )
 
 
@@ -316,7 +310,7 @@ TEST_CASE( "Serialize/deserialize transaction list", "[tx-list-serialize]" ) {
 }
 
 
-TEST_CASE( "Serialize/deserialize committed block", "[committed-block-serialize]" ) {
+TEST_CASE( "Serialize/deserialize committed block", "[committed-block-serialize][end-to-end][correctness]" ) {
     SECTION( "Test successful serialize/deserialize" )
 
     test_committed_block_serialize_deserialize( false );
@@ -329,7 +323,7 @@ TEST_CASE( "Serialize/deserialize committed block", "[committed-block-serialize]
 }
 
 
-TEST_CASE( "Serialize/deserialize committed block list", "[committed-block-list-serialize]" ) {
+TEST_CASE( "Serialize/deserialize committed block list", "[committed-block-list-serialize][end-to-end][correctness]" ) {
     SECTION( "Test successful serialize/deserialize" )
 
     test_committed_block_list_serialize_deserialize();
@@ -341,7 +335,7 @@ TEST_CASE( "Serialize/deserialize committed block list", "[committed-block-list-
     // Test successful serialize/deserialize failure
 }
 
-TEST_CASE( "Test committed block fragment/defragment", "[committed-block-defragment]" ) {
+TEST_CASE( "Test committed block fragment/defragment", "[committed-block-defragment][end-to-end][correctness]" ) {
     SECTION( "Test successful serialize/deserialize" )
 
     test_committed_block_fragment_defragment( false );

--- a/unittests/db/DBTests.cpp
+++ b/unittests/db/DBTests.cpp
@@ -39,7 +39,7 @@
 
 #include "chains/Schain.h"
 
-#include "BlockDB.h"
+#include "db/BlockDB.h"
 
 
 void test_committed_block_save() {
@@ -71,7 +71,7 @@ void test_committed_block_save() {
     REQUIRE( db->findMaxMinDBIndex().first > 10 );
 }
 
-TEST_CASE( "Save/read block", "[block-save-read-db]" ) {
+TEST_CASE( "Save/read block", "[block-save-read-db][end-to-end][correctness]" ) {
     SECTION( "Test successful save/read" )
     test_committed_block_save();
 }

--- a/unittests/rlp/RLPIntegrationTests.cpp
+++ b/unittests/rlp/RLPIntegrationTests.cpp
@@ -1,0 +1,242 @@
+//
+// RLP Integration Tests
+// Tests for interactions between RLP components and edge cases
+//
+
+#include "RLPTestUtils.h"
+#include "rlp/RLP.h"
+#include "rlp/RLPStream.h"
+
+using namespace RLP_Tests;
+
+// ===================== ROUNDTRIP INTEGRATION TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLP complete roundtrip - simple data", "[rlp][rlp-integration][correctness][integration]") {
+    // Test complete encode -> decode -> encode cycle
+    
+    std::vector<std::vector<uint8_t>> originalData = {
+        {0x01, 0x02, 0x03},
+        {0x04, 0x05},
+        {},  // empty
+        {0x42}
+    };
+    
+    // First encoding
+    RLPStream stream1;
+    for (const auto& data : originalData) {
+        stream1 << data;
+    }
+    auto encoded1 = stream1.encode();
+    
+    // Decode
+    RLPItem decoded(encoded1);
+    REQUIRE(decoded.isList());
+    
+    // Re-encode
+    RLPStream stream2;
+    for (size_t i = 0; i < decoded.size(); ++i) {
+        stream2 << decoded[i].asBytes();
+    }
+    auto encoded2 = stream2.encode();
+    
+    // Should be identical
+    REQUIRE(encoded1 == encoded2);
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLP roundtrip - complex nested data", "[rlp][rlp-integration][correctness][integration]") {
+    // Test with nested structures
+    
+    // Create complex nested structure: [[a, b], [c, [d, e]], f]
+    RLPStream innerStream1;
+    innerStream1 << std::vector<uint8_t>{'a'};
+    innerStream1 << std::vector<uint8_t>{'b'};
+    
+    RLPStream innerStream2;
+    innerStream2 << std::vector<uint8_t>{'d'};
+    innerStream2 << std::vector<uint8_t>{'e'};
+    
+    RLPStream middleStream;
+    middleStream << std::vector<uint8_t>{'c'};
+    middleStream << innerStream2;
+    
+    RLPStream outerStream;
+    outerStream << innerStream1;
+    outerStream << middleStream;
+    outerStream << std::vector<uint8_t>{'f'};
+    
+    auto encoded = outerStream.encode();
+    
+    // Decode and verify structure
+    RLPItem decoded(encoded);
+    
+    REQUIRE(decoded.isList());
+    REQUIRE(decoded.size() == 3);
+    
+    // Should maintain the nested structure
+    REQUIRE(decoded[0].isList());  // [a, b]
+    REQUIRE(decoded[0].size() == 2);
+    REQUIRE(decoded[0][0].asBytes() == std::vector<uint8_t>{'a'});
+    REQUIRE(decoded[0][1].asBytes() == std::vector<uint8_t>{'b'});
+
+    REQUIRE(decoded[1].isList());  // [c, [d, e]]
+    REQUIRE(decoded[1].size() == 2);
+    REQUIRE(decoded[1][0].asBytes() == std::vector<uint8_t>{'c'});
+    REQUIRE(decoded[1][1].isList());  // [d, e]
+    REQUIRE(decoded[1][1].size() == 2);
+    REQUIRE(decoded[1][1][0].asBytes() == std::vector<uint8_t>{'d'});
+    REQUIRE(decoded[1][1][1].asBytes() == std::vector<uint8_t>{'e'});
+
+    REQUIRE_FALSE(decoded[2].isList());  // f
+    REQUIRE(decoded[2].asBytes() == std::vector<uint8_t>{'f'});
+}
+
+// ===================== STRESS TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLP stress test - deep nesting at limit", "[rlp][rlp-integration][correctness][integration]") {
+    // Test nesting exactly at the security limit
+    const size_t maxDepth = 1000; // Just under MAX_RLP_NESTING_DEPTH
+    
+    auto deepData = SecurityTestData::createDeeplyNestedRLP(maxDepth);
+    
+    // Should parse successfully
+    REQUIRE_NOTHROW(RLPItem(deepData));
+    
+    RLPItem parsed(deepData);
+    
+    // Navigate to the deepest level
+    RLPItem* current = &parsed;
+    size_t depth = 0;
+    
+    while (current->isList() && current->size() > 0) {
+        current = &(*current)[0];
+        depth++;
+        if (depth > maxDepth + 10) break; // Safety break
+    }
+    
+    // Should have reached the expected depth
+    REQUIRE(depth <= maxDepth + 5); // Some tolerance for encoding overhead
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLP stress test - large list at limit", "[rlp][rlp-integration][correctness][integration]") {
+    // Test with many items approaching the limit
+    const size_t itemCount = 50000; // Well under MAX_RLP_LIST_LENGTH
+    
+    RLPStream stream;
+    for (size_t i = 0; i < itemCount; ++i) {
+        std::vector<uint8_t> data = {static_cast<uint8_t>(i % 256)};
+        stream << data;
+    }
+    
+    auto encoded = stream.encode();
+    RLPItem decoded(encoded);
+    
+    REQUIRE(decoded.isList());
+    REQUIRE(decoded.size() == itemCount);
+    
+    // Verify all items
+    for (size_t i = 0; i < itemCount; ++i) {
+        REQUIRE(decoded[i].asBytes() == std::vector<uint8_t>{static_cast<uint8_t>(i % 256)});
+    }
+}
+
+// ===================== EDGE CASE TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLP edge cases - boundary values", "[rlp][rlp-integration][correctness][integration]") {
+    // Test various boundary conditions
+    
+    // Empty list
+    {
+        RLPStream stream;
+        auto encoded = stream.encode();
+        
+        RLPItem decoded(encoded);
+        REQUIRE(decoded.isList());
+        REQUIRE(decoded.size() == 0);
+    }
+    
+    // Single empty item
+    {
+        RLPStream stream;
+        stream << std::vector<uint8_t>{};
+        auto encoded = stream.encode();
+        
+        RLPItem decoded(encoded);
+        REQUIRE(decoded.isList());
+        REQUIRE(decoded.size() == 1);
+        REQUIRE(decoded[0].asBytes().empty());
+    }
+    
+    // Maximum single byte value
+    {
+        RLPStream stream;
+        stream << std::vector<uint8_t>{0x7f};
+        auto encoded = stream.encode();
+        
+        RLPItem decoded(encoded);
+        REQUIRE(decoded[0].asBytes() == std::vector<uint8_t>{0x7f});
+    }
+    
+    // Minimum multi-byte string
+    {
+        RLPStream stream;
+        stream << std::vector<uint8_t>{0x80};
+        auto encoded = stream.encode();
+        
+        RLPItem decoded(encoded);
+        REQUIRE(decoded[0].asBytes() == std::vector<uint8_t>{0x80});
+    }
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLP edge cases - mixed data types", "[rlp][rlp-integration][correctness][integration]") {
+    // Test with various data patterns
+    
+    std::vector<std::vector<uint8_t>> testData;
+    
+    // Add various data types
+    testData.push_back({}); // Empty
+    testData.push_back({0x00}); // Zero byte
+    testData.push_back({0x7f}); // Max single byte
+    testData.push_back({0x80}); // Min multi-byte
+    testData.push_back({0xff}); // Max byte value
+    
+    // Pattern data
+    testData.push_back(createPatternData(100, {0xaa, 0xbb}));
+    testData.push_back(createPatternData(55, {0x01, 0x02, 0x03})); // Boundary length
+    testData.push_back(createPatternData(56, {0x04, 0x05, 0x06})); // Boundary + 1
+    
+    // Encode all
+    RLPStream stream;
+    for (const auto& data : testData) {
+        stream << data;
+    }
+    auto encoded = stream.encode();
+    
+    // Decode and verify
+    RLPItem decoded(encoded);
+    REQUIRE(decoded.isList());
+    REQUIRE(decoded.size() == testData.size());
+    
+    for (size_t i = 0; i < testData.size(); ++i) {
+        REQUIRE(decoded[i].asBytes() == testData[i]);
+    }
+}
+
+// ===================== ERROR RECOVERY TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLP error recovery - partial parsing", "[rlp][rlp-integration][correctness][integration]") {
+    // Test that errors don't corrupt state for subsequent operations
+    
+    // Create some malformed data
+    std::vector<uint8_t> malformed = {0x85, 0x01, 0x02}; // Claims 5 bytes, has 2
+    
+    // Should throw
+    REQUIRE_THROWS_AS(RLPItem(malformed), InvalidStateException);
+    
+    // Subsequent operations should still work
+    std::vector<uint8_t> validData = {0xc1, 0x42};
+    REQUIRE_NOTHROW(RLPItem(validData));
+    
+    RLPItem valid(validData);
+    REQUIRE(valid.isList());
+    REQUIRE(valid.size() == 1);
+}

--- a/unittests/rlp/RLPItemTests.cpp
+++ b/unittests/rlp/RLPItemTests.cpp
@@ -1,0 +1,219 @@
+//
+// RLPItem Unit Tests  
+// Tests for RLP decoding functionality and security
+//
+
+#include "RLPTestUtils.h"
+#include "rlp/RLP.h"
+
+using namespace RLP_Tests;
+
+// ===================== BASIC DECODING TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem decode empty string", "[rlp][rlp-item][unit][correctness]") {
+    std::vector<uint8_t> rlpData = {0xc1, 0x80}; // List with empty string
+    
+    RLPItem item(rlpData);
+    
+    REQUIRE(item.isList());
+    REQUIRE(item.size() == 1);
+    REQUIRE_FALSE(item[0].isList());
+    REQUIRE(item[0].asBytes().empty());
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem decode single byte", "[rlp][rlp-item][unit][correctness]") {
+    std::vector<uint8_t> rlpData = {0xc1, 0x42}; // List with single byte
+    
+    RLPItem item(rlpData);
+    
+    REQUIRE(item.isList());
+    REQUIRE(item.size() == 1);
+    REQUIRE_FALSE(item[0].isList());
+    REQUIRE(item[0].asBytes() == std::vector<uint8_t>{0x42});
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem decode all single byte values", "[rlp][rlp-item][unit][correctness]") {
+    // Test all bytes < 0x80 (should decode directly)
+    for (uint8_t i = 0; i < 0x80; ++i) {
+        std::vector<uint8_t> rlpData = {0xc1, i};
+        
+        RLPItem item(rlpData);
+        
+        REQUIRE(item.isList());
+        REQUIRE(item.size() == 1);
+        REQUIRE(item[0].asBytes() == std::vector<uint8_t>{i});
+    }
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem decode short string", "[rlp][rlp-item][unit][correctness]") {
+    std::vector<uint8_t> rlpData = {0xc6, 0x85, 0x68, 0x65, 0x6c, 0x6c, 0x6f}; // List with "hello"
+    
+    RLPItem item(rlpData);
+    
+    REQUIRE(item.isList());
+    REQUIRE(item.size() == 1);
+    REQUIRE_FALSE(item[0].isList());
+    
+    auto bytes = item[0].asBytes();
+    std::string result(bytes.begin(), bytes.end());
+    REQUIRE(result == "hello");
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem decode multiple items", "[rlp][rlp-item][unit][correctness]") {
+    // Create RLP list with multiple items: [0x01, [0x02, 0x03], ""]
+    std::vector<uint8_t> rlpData = {
+        0xc5,             // List of 5 bytes total
+        0x01,             // First item: single byte 0x01
+        0x82, 0x02, 0x03, // Second item: short string [0x02, 0x03]
+        0x80              // Third item: empty string
+    };
+    
+    RLPItem item(rlpData);
+    
+    REQUIRE(item.isList());
+    REQUIRE(item.size() == 3);
+    
+    // Check first item
+    REQUIRE_FALSE(item[0].isList());
+    REQUIRE(item[0].asBytes() == std::vector<uint8_t>{0x01});
+    
+    // Check second item
+    REQUIRE_FALSE(item[1].isList());
+    REQUIRE(item[1].asBytes() == std::vector<uint8_t>{0x02, 0x03});
+    
+    // Check third item
+    REQUIRE_FALSE(item[2].isList());
+    REQUIRE(item[2].asBytes().empty());
+}
+
+// ===================== LONG STRING DECODING TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem decode long string", "[rlp][rlp-item][unit][correctness]") {
+    std::vector<uint8_t> longData(100, 0x41); // 100 'A's
+
+    std::vector<uint8_t> rlpData;
+    rlpData.push_back(0xb8);     // 0xb7 + 1 (1-byte length field)
+    rlpData.push_back(100);      // 0x64 = 100 in decimal
+    rlpData.insert(rlpData.end(), longData.begin(), longData.end());
+
+    
+    RLPItem item(rlpData);
+    
+    REQUIRE(!item.isList());
+    REQUIRE(item.asBytes() == longData);
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem decode boundary lengths", "[rlp][rlp-item][unit][correctness]") {
+    // Test 55 bytes (last short string)
+    {
+        std::vector<uint8_t> data(54, 0x42);
+        std::vector<uint8_t> rlpData;
+
+        // Short string header
+        rlpData.push_back(0x80 + 54);
+
+        // Data bytes
+        rlpData.insert(rlpData.end(), data.begin(), data.end());
+
+        RLPItem item(rlpData);
+        REQUIRE(!item.isList());
+        REQUIRE(item.asBytes() == data);
+    }
+    
+    // Test 56 bytes (first long string)
+    {
+        std::vector<uint8_t> data(56, 0x42);
+        std::vector<uint8_t> rlpData; // List header (58 = 1 + 1 + 56)
+        rlpData.push_back(0xb8);                    // Long string prefix (0xb7 + 1)
+        rlpData.push_back(56);                      // Length
+        rlpData.insert(rlpData.end(), data.begin(), data.end());
+        
+        RLPItem item(rlpData);
+        REQUIRE(!item.isList());
+        REQUIRE(item.asBytes() == data);
+    }
+}
+
+// ===================== NESTED LIST TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem decode nested lists", "[rlp][rlp-item][unit][correctness]") {
+    // RLP encoding of: [[0x01, 0x02], [0x03], []]
+    std::vector<uint8_t> rlpData = {
+        0xc6,                   // Outer list (6 bytes payload)
+        0xc2, 0x01, 0x02,      // First inner list: [0x01, 0x02]
+        0xc1, 0x03,            // Second inner list: [0x03]
+        0xc0                   // Third inner list: []
+    };
+    
+    RLPItem item(rlpData);
+    
+    REQUIRE(item.isList());
+    REQUIRE(item.size() == 3);
+    
+    // First inner list
+    REQUIRE(item[0].isList());
+    REQUIRE(item[0].size() == 2);
+    REQUIRE(item[0][0].asBytes() == std::vector<uint8_t>{0x01});
+    REQUIRE(item[0][1].asBytes() == std::vector<uint8_t>{0x02});
+    
+    // Second inner list
+    REQUIRE(item[1].isList());
+    REQUIRE(item[1].size() == 1);
+    REQUIRE(item[1][0].asBytes() == std::vector<uint8_t>{0x03});
+    
+    // Third inner list (empty)
+    REQUIRE(item[2].isList());
+    REQUIRE(item[2].size() == 0);
+}
+
+
+// ===================== SECURITY TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem security - reject oversized data", "[rlp][rlp-item][unit][security]") {
+    // Create data larger than MAX_RLP_DATA_SIZE (64MB)
+    auto oversizedData = SecurityTestData::createLimitTestData(100 * 1024 * 1024); // 100MB
+    
+    // Should throw exception due to size limit
+    REQUIRE_THROWS_AS(RLPItem(oversizedData), InvalidStateException);
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem security - reject deep nesting", "[rlp][rlp-item][unit][security]") {
+    auto deeplyNested = SecurityTestData::createDeeplyNestedRLP(2000);
+    
+    // Should throw exception due to nesting depth limit
+    REQUIRE_THROWS_AS(RLPItem(deeplyNested), InvalidStateException);
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem security - handle malformed data", "[rlp][rlp-item][unit][security]") {
+    // Test truncated data
+    {
+        auto truncated = SecurityTestData::createTruncatedRLP();
+        REQUIRE_THROWS_AS(RLPItem(truncated), InvalidStateException);
+    }
+    
+    // Test oversized length encoding
+    {
+        auto oversized = SecurityTestData::createOversizedLengthRLP();
+        REQUIRE_THROWS_AS(RLPItem(oversized), InvalidStateException);
+    }
+    
+    // Test invalid list structure
+    {
+        std::vector<uint8_t> invalidList = {0xc5, 0x01, 0x02}; // Claims 5 bytes but only has 2
+        REQUIRE_THROWS_AS(RLPItem(invalidList), InvalidStateException);
+    }
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPItem security - validate nesting depth tracking", "[rlp][rlp-item][unit][security]") {
+    // Test that nesting depth is correctly tracked
+    const size_t maxDepth = MAX_RLP_NESTING_DEPTH; // Just under limit
+    
+    auto validNested = SecurityTestData::createDeeplyNestedRLP(maxDepth);
+    
+    // Should parse successfully
+    REQUIRE_NOTHROW(RLPItem(validNested));
+    
+    // Test just over the limit
+    auto invalidNested = SecurityTestData::createDeeplyNestedRLP(maxDepth + 1);
+    REQUIRE_THROWS_AS(RLPItem(invalidNested), InvalidStateException);
+}

--- a/unittests/rlp/RLPStreamTests.cpp
+++ b/unittests/rlp/RLPStreamTests.cpp
@@ -1,0 +1,260 @@
+//
+// RLPStream Unit Tests
+// Tests for RLP encoding functionality
+//
+
+#include "RLPTestUtils.h"
+#include "rlp/RLPStream.h"
+
+using namespace RLP_Tests;
+
+// ===================== BASIC ENCODING TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream encode empty string", "[rlp][rlp-stream][unit][correctness]") {
+    RLPStream stream;
+    stream << std::vector<uint8_t>{};
+    
+    auto encoded = stream.encode();
+    
+    // Empty string should encode as 0x80 in a list context
+    // List with one empty item: 0xc1 (list of 1 byte) + 0x80 (empty string)
+    REQUIRE(encoded.size() == 2);
+    REQUIRE(encoded[0] == 0xc1);
+    REQUIRE(encoded[1] == 0x80);
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream encode single byte", "[rlp][rlp-stream][unit][correctness]") {
+    RLPStream stream;
+    stream << std::vector<uint8_t>{0x42};
+    
+    auto encoded = stream.encode();
+    
+    // Single byte 0x42 in list: 0xc1 (list of 1 byte) + 0x42 (direct encoding)
+    REQUIRE(encoded.size() == 2);
+    REQUIRE(encoded[0] == 0xc1);
+    REQUIRE(encoded[1] == 0x42);
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream encode low byte values", "[rlp][rlp-stream][unit][correctness]") {
+    // Test bytes < 0x80 (should be encoded directly)
+    for (uint8_t i = 0; i < 0x80; ++i) {
+        RLPStream stream;
+        stream << std::vector<uint8_t>{i};
+        
+        auto encoded = stream.encode();
+        
+        REQUIRE(encoded.size() == 2);
+        REQUIRE(encoded[0] == 0xc1);  // List prefix
+        REQUIRE(encoded[1] == i);     // Direct encoding
+    }
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream encode short string", "[rlp][rlp-stream][unit][correctness]") {
+    RLPStream stream;
+    std::vector<uint8_t> data = {0x68, 0x65, 0x6c, 0x6c, 0x6f}; // "hello"
+    stream << data;
+    
+    auto encoded = stream.encode();
+    
+    // Expected: 0xc6 (list of 6 bytes) + 0x85 (string of 5 bytes) + "hello"
+    REQUIRE(encoded.size() == 7);
+    REQUIRE(encoded[0] == 0xc6);  // List prefix
+    REQUIRE(encoded[1] == 0x85);  // String prefix (0x80 + 5)
+    
+    // Verify the actual data
+    for (size_t i = 0; i < data.size(); ++i) {
+        REQUIRE(encoded[2 + i] == data[i]);
+    }
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream encode multiple items", "[rlp][rlp-stream][unit][correctness]") {
+    RLPStream stream;
+    stream << std::vector<uint8_t>{0x01};
+    stream << std::vector<uint8_t>{0x02, 0x03};
+    stream << std::vector<uint8_t>{};  // empty string
+    
+    auto encoded = stream.encode();
+    
+    // Should be a list containing three items
+    REQUIRE(encoded.size() >= 5);
+    REQUIRE(encoded[0] >= 0xc0);  // List prefix
+}
+
+// ===================== LONG STRING ENCODING TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream encode long string", "[rlp][rlp-stream][unit][correctness]") {
+    std::vector<uint8_t> longData(100, 0x41); // 100 'A's
+
+    RLPStream stream;
+    stream << longData;
+
+    auto encoded = stream.encode();
+
+    REQUIRE(encoded.size() == 2 + 102);  // 2 bytes list prefix + 102 bytes inner item
+
+    REQUIRE(encoded[0] == 0xf8);         // list prefix (long list)
+    REQUIRE(encoded[1] == 0x66);         // length of list payload = 102
+
+    REQUIRE(encoded[2] == 0xb8);         // long string prefix of inner element
+    REQUIRE(encoded[3] == 0x64);         // length = 100
+
+    // Check payload bytes match the original data
+    REQUIRE(std::equal(encoded.begin() + 4, encoded.end(), longData.begin()));
+}
+
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream encode boundary lengths", "[rlp][rlp-stream][unit][correctness]") {
+    // Short list (payload ≤ 55)
+    {
+        RLPStream stream;
+        stream << std::vector<uint8_t>{0x01};      // 1 byte item
+        stream << std::vector<uint8_t>{0x02, 0x03}; // 2 bytes item
+        auto encoded = stream.encode();
+
+        // Sum of encoded items ≤ 55 → short list prefix: 0xc0 + payload length
+        REQUIRE(encoded[0] >= 0xc0);
+        REQUIRE(encoded[0] <= 0xf7);
+    }
+
+    // Long list (payload > 55)
+    {
+        std::vector<uint8_t> largeData(56, 0x42);
+        RLPStream stream;
+        stream << largeData;
+        auto encoded = stream.encode();
+
+        // Payload length > 55 → long list prefix: 0xf7 + len(len)
+        REQUIRE(encoded[0] >= 0xf8);  // long list prefix range
+    }
+}
+
+// ===================== NESTED STREAM TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream encode nested streams", "[rlp][rlp-stream][unit][correctness]") {
+    RLPStream innerStream;
+    innerStream << std::vector<uint8_t>{'A', 'B'}; // will use 3 bytes
+    innerStream << std::vector<uint8_t>{'C', 'D'}; // will use 3 bytes
+
+    RLPStream outerStream;
+    outerStream << std::vector<uint8_t>{'X', 'Y'}; // will use 3 bytes
+    outerStream << innerStream;                    // will use 3 + 3 + 1 = 7 bytes
+    outerStream << std::vector<uint8_t>{'Z'};      // will use 1 byte
+
+    auto encoded = outerStream.encode();           // will use 3 + 7 + 1 + 1 = 12 bytes total 
+
+    // Validate full structure
+    REQUIRE(encoded.size() == 12);
+    REQUIRE(encoded[0] == 0xcb);
+
+    // "XY" string
+    REQUIRE(encoded[1] == 0x82);
+    REQUIRE(encoded[2] == 'X');
+    REQUIRE(encoded[3] == 'Y');
+
+    // Inner list ["AB", "CD"]
+    REQUIRE(encoded[4] == 0xc6);
+
+    REQUIRE(encoded[5] == 0x82);
+    REQUIRE(encoded[6] == 'A');
+    REQUIRE(encoded[7] == 'B');
+
+    REQUIRE(encoded[8] == 0x82);
+    REQUIRE(encoded[9] == 'C');
+    REQUIRE(encoded[10] == 'D');
+
+    // "Z" single byte encoded without prefix
+    REQUIRE(encoded[11] == 'Z');
+}
+
+
+// ===================== U256 ENCODING TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream encode u256 values", "[rlp][rlp-stream][unit][correctness]") {
+    RLPStream stream;
+
+    u256 zero = 0;
+    u256 small = 42;
+    u256 large = u256(1) << 64;
+
+    stream << zero << small << large;
+    auto encoded = stream.encode();
+
+    // === Validate top-level structure ===
+    REQUIRE(encoded.size() >= 1);
+    REQUIRE(encoded[0] >= 0xc0);  // List prefix
+
+    size_t offset = 1;
+
+    // === Decode and validate zero ===
+    REQUIRE(encoded[offset] == 0x80); // empty string for zero
+    offset += 1;
+
+    // === Decode and validate small ===
+    REQUIRE(encoded[offset] == 0x2A); // direct single-byte encoding
+    offset += 1;
+
+    // === Decode and validate large ===
+    REQUIRE(encoded[offset] == 0x89); // 9-byte long string
+    offset += 1;
+    REQUIRE(encoded.size() >= offset + 9);
+    
+    // Should start with 0x01 followed by 8x 0x00
+    REQUIRE(encoded[offset] == 0x01);
+    for (size_t i = 1; i < 9; ++i) {
+        REQUIRE(encoded[offset + i] == 0x00);
+    }
+
+    offset += 9;
+
+    // === Final size should match ===
+    REQUIRE(encoded.size() == offset);
+}
+
+
+// ===================== PERFORMANCE TESTS =====================
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream performance - many small items", "[rlp][rlp-stream][unit][performance]") {
+    const size_t itemCount = 10000;
+    
+    auto duration = measureTime([&]() {
+        RLPStream stream;
+        for (size_t i = 0; i < itemCount; ++i) {
+            std::vector<uint8_t> data = {static_cast<uint8_t>(i % 256)};
+            stream << data;
+        }
+        auto encoded = stream.encode();
+        
+        // Verify basic properties
+        REQUIRE(encoded.size() > itemCount);
+        REQUIRE(encoded[0] >= 0xc0);
+    });
+    
+    // Should complete in reasonable time
+    REQUIRE(duration.count() < 100);  // Less than 100 ms
+    
+    std::cout << "RLPStream performance: " << itemCount 
+              << " items encoded in " << duration.count() << "ms" << std::endl;
+}
+
+TEST_CASE_METHOD(RLPTestFixture, "RLPStream performance - large items", "[rlp][rlp-stream][unit][performance]") {
+    const size_t itemSize = 1024 * 1024; // 1MB items
+    const size_t itemCount = 10;
+    
+    auto duration = measureTime([&]() {
+        RLPStream stream;
+        for (size_t i = 0; i < itemCount; ++i) {
+            auto data = createTestData(itemSize, static_cast<uint8_t>(i));
+            stream << data;
+        }
+        auto encoded = stream.encode();
+        
+        // Verify basic properties
+        REQUIRE(encoded.size() > itemCount * itemSize);
+    });
+    
+    // Should complete in reasonable time
+    REQUIRE(duration.count() < 200);  // Less than 200ms
+    
+    std::cout << "RLPStream large items: " << itemCount 
+              << " x " << itemSize << " bytes in " << duration.count() << "ms" << std::endl;
+}

--- a/unittests/rlp/RLPTestUtils.h
+++ b/unittests/rlp/RLPTestUtils.h
@@ -1,0 +1,129 @@
+//
+// RLP Test Suite - Common Test Utilities and Fixtures
+// Shared utilities for all RLP-related tests
+//
+
+#pragma once
+
+#include "thirdparty/catch.hpp"
+#include <vector>
+#include <string>
+#include <chrono>
+#include <iostream>
+#include <cstdio>
+
+namespace RLP_Tests {
+
+/**
+ * @brief Common test fixture for RLP tests
+ * Provides utilities used across all RLP test files
+ */
+class RLPTestFixture {
+public:
+    // Helper function to create byte vector from hex string
+    std::vector<uint8_t> hexToBytes(const std::string& hex) {
+        std::vector<uint8_t> bytes;
+        for (size_t i = 0; i < hex.length(); i += 2) {
+            std::string byteString = hex.substr(i, 2);
+            uint8_t byte = static_cast<uint8_t>(strtol(byteString.c_str(), nullptr, 16));
+            bytes.push_back(byte);
+        }
+        return bytes;
+    }
+    
+    // Helper function to convert bytes to hex string
+    std::string bytesToHex(const std::vector<uint8_t>& bytes) {
+        std::string hex;
+        char buf[3];
+        for (uint8_t byte : bytes) {
+            sprintf(buf, "%02x", byte);
+            hex += buf;
+        }
+        return hex;
+    }
+    
+    // Helper to create test data of specific size
+    std::vector<uint8_t> createTestData(size_t size, uint8_t fillByte = 0xAA) {
+        return std::vector<uint8_t>(size, fillByte);
+    }
+    
+    // Helper to create repeating pattern data
+    std::vector<uint8_t> createPatternData(size_t size, const std::vector<uint8_t>& pattern) {
+        std::vector<uint8_t> data;
+        data.reserve(size);
+        for (size_t i = 0; i < size; ++i) {
+            data.push_back(pattern[i % pattern.size()]);
+        }
+        return data;
+    }
+    
+    // Performance measurement helper
+    template<typename Func>
+    std::chrono::milliseconds measureTime(Func&& func) {
+        auto start = std::chrono::high_resolution_clock::now();
+        func();
+        auto end = std::chrono::high_resolution_clock::now();
+        return std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    }
+};
+
+/**
+ * @brief Security test data generator
+ */
+class SecurityTestData {
+public:
+    // Generate deeply nested structure for testing depth limits
+    static std::vector<uint8_t> createDeeplyNestedRLP(size_t depth) {
+        std::vector<uint8_t> data = {0x01}; // Innermost item
+
+        for (size_t i = 0; i < depth; ++i) {
+            std::vector<uint8_t> wrapped;
+
+            // Each layer wraps the previous one as a single-item list.
+            // Length of inner payload
+            size_t len = data.size();
+            if (len < 56) {
+                wrapped.push_back(static_cast<uint8_t>(0xc0 + len)); // Short list prefix
+            } else {
+                // For completeness (though not needed for small depth)
+                std::vector<uint8_t> lenBytes;
+                size_t tmp = len;
+                while (tmp > 0) {
+                    lenBytes.insert(lenBytes.begin(), static_cast<uint8_t>(tmp & 0xFF));
+                    tmp >>= 8;
+                }
+                wrapped.push_back(static_cast<uint8_t>(0xf7 + lenBytes.size()));
+                wrapped.insert(wrapped.end(), lenBytes.begin(), lenBytes.end());
+            }
+
+            wrapped.insert(wrapped.end(), data.begin(), data.end());
+            data = std::move(wrapped);
+        }
+
+        return data;
+    }
+
+    
+    // Generate malformed RLP data for security testing
+    static std::vector<uint8_t> createTruncatedRLP() {
+        return {0x85}; // Claims 5 bytes but provides none
+    }
+    
+    static std::vector<uint8_t> createOversizedLengthRLP() {
+        return {0xbf, 0xff, 0xff, 0xff, 0xff}; // Huge length encoding
+    }
+    
+    // Generate data just under/over security limits
+    static std::vector<uint8_t> createLimitTestData(size_t targetSize) {
+        std::vector<uint8_t> data;
+        data.reserve(targetSize);
+        
+        for (size_t i = 0; i < targetSize; ++i) {
+            data.push_back(static_cast<uint8_t>(i % 256));
+        }
+        
+        return data;
+    }
+};
+
+} // namespace RLP_Tests

--- a/unittests/sgx_tests.cpp
+++ b/unittests/sgx_tests.cpp
@@ -2,6 +2,13 @@
 // Created by kladko on 17.06.20.
 //
 
+#include "thirdparty/catch.hpp"
+#include "Consensust.h"
+#include "crypto/CryptoManager.h"
+#include "JsonStubClient.h"
+#include <jsonrpccpp/client/connectors/httpclient.h>
+
+
 TEST_CASE_METHOD( StartFromScratch, "Test sgx server connection", "[sgx]" ) {
     string certDir( "/tmp" );
 

--- a/unittests/sgx_tests.cpp
+++ b/unittests/sgx_tests.cpp
@@ -9,7 +9,7 @@
 #include <jsonrpccpp/client/connectors/httpclient.h>
 
 
-TEST_CASE_METHOD( StartFromScratch, "Test sgx server connection", "[sgx]" ) {
+TEST_CASE_METHOD( StartFromScratch, "Test sgx server connection", "[sgx][end-to-end][correctness]" ) {
     string certDir( "/tmp" );
 
 
@@ -63,7 +63,7 @@ TEST_CASE_METHOD( StartFromScratch, "Test sgx server connection", "[sgx]" ) {
 }
 
 
-TEST_CASE( "Parse sgx keys", "[sgx-parse]" ) {
+TEST_CASE( "Parse sgx keys", "[sgx-parse][end-to-end][correctness]" ) {
     auto serverURL = string( "http://localhost:1029" );
     auto eng = make_shared< ConsensusEngine >( 0, 100000000 );
     eng->setTestKeys( serverURL, "run_sgx_test/sgx_data/4node.json", 4, 1 );


### PR DESCRIPTION
## Description
- Added security checks to limit:
    - Max recursion when parsing lists of lists
    - Max RLP-item size in Mb
    - Max list size
    - Max total RLP size

- Updated unit tests setup - now we follow a tagged system:
     - Component tag - specifies the component being tested. Can also include subcomponents. Ex: `[rlp]`, `[rlp][rlp-stream]`.
     - Test type tag - specifies if is `[correctness]`, `[security]`, or `[performance]`.
     - Scope tag - specifies if is `[unit test]`, `[integration test]` or `[end-to-end]`.
- We can now easily add new unit tests under the `unittest` directory, and add the added unit tests folder to CMakeLists
- Updated readme and added dedicated `TESTING.md` to include all details regarding testing.

## Tests

- Added unit tests and integration tests to test both correctness and security of RLP encoding and decoding 
- Moved all tests to `unittests` folder
- Added tags to 'old' tests

Fixes #903 