### PR TITLE
IS 1277 add mutex

### DIFF
--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -293,18 +293,21 @@ ptr<BlockProposalFragment> BlockFinalizeDownloader::readBlockFragment(
     auto fragmentSize = readFragmentSize(_responseHeader);
     auto blockSize = readBlockSize(_responseHeader);
     auto h = readBlockHash(_responseHeader);
-    CHECK_STATE(!h.empty())
+    CHECK_STATE(!h.empty());
 
 
-    // if we did not receive block hash yet, set it. Otherwise, compare it to the known hash
-     if (this->blockHash.empty()) {
-         this->blockHash = h;
-     } else {
-         if (this->blockHash != h) {
-             getSchain()->addBlockErrorAnalyzer(make_shared<BlockErrorAnalyzer>());
-             CHECK_STATE(h == blockHash);
-         }
-     }
+    {
+        // if we did not receive block hash yet, set it. Otherwise, compare it to the known hash
+        LOCK(m);
+        if (this->blockHash.empty()) {
+            this->blockHash = h;
+        } else {
+            if (this->blockHash != h) {
+                getSchain()->addBlockErrorAnalyzer(make_shared<BlockErrorAnalyzer>());
+                CHECK_STATE(h == blockHash);
+            }
+        }
+    }
 
 #ifdef BITE
     if (needDAProof()) {
@@ -491,7 +494,8 @@ bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
             proposal = BlockProposal::makeFromNetworkSerialized(
                 fragmentList.serialize(), getSchain()->getCryptoManager());
             CHECK_STATE(proposal)
-            CHECK_STATE(proposal->getProposerIndex() == ( uint64_t ) proposerIndex); {
+            CHECK_STATE(proposal->getProposerIndex() == ( uint64_t ) proposerIndex);
+            {
                 LOCK(m)
                 if (!this->blockHash.empty()) {
                     auto h = BLAKE3Hash::fromHex(blockHash);

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -496,7 +496,7 @@ bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
             CHECK_STATE(proposal)
             CHECK_STATE(proposal->getProposerIndex() == ( uint64_t ) proposerIndex);
             {
-                LOCK(m)
+                LOCK(m);
                 if (!this->blockHash.empty()) {
                     auto h = BLAKE3Hash::fromHex(blockHash);
                     CHECK_STATE2(proposal->getHash().compare( h ) == 0, "Incorrect block hash");

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -229,9 +229,6 @@ ptr< AESKeyDecryptionShareList > TEDecryptionDB::getMyDecryptionShares(
 
 
 bool TEDecryptionDB::isEnoughDecryptions( block_id _blockID ) {
-    if ( requiredSigners == 0 )
-        return true;
-
     READ_LOCK(decryptionSetsMutex);
     const auto it = decryptionsStore.find(_blockID);
     if ( it == decryptionsStore.end() )
@@ -240,7 +237,8 @@ bool TEDecryptionDB::isEnoughDecryptions( block_id _blockID ) {
 };
 
 bool TEDecryptionDB::isEnoughForeignShares(block_id _blockID) {
-    if ( requiredSigners == 0 )
+    // if required signers < 2, we always have our own share
+    if ( requiredSigners < 2 )
         return true;
 
     READ_LOCK(decryptionSetsMutex);

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -108,6 +108,9 @@ bool TEDecryptionDB::haveDecryptionShares(block_id _blockID, schain_index _decry
     READ_LOCK(decryptionSetsMutex);
 
     const auto it = decryptionsStore.find(_blockID);
+    if ( it == decryptionsStore.end() )
+        return false;
+
     return it->second.count(_decryptorIndex) > 0;
 
 };

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -229,7 +229,7 @@ ptr< AESKeyDecryptionShareList > TEDecryptionDB::getMyDecryptionShares(
 
 
 bool TEDecryptionDB::isEnoughDecryptions( block_id _blockID ) {
-    if ( requireSigners == 0 )
+    if ( requiredSigners == 0 )
         return true;
 
     READ_LOCK(decryptionSetsMutex);
@@ -240,7 +240,7 @@ bool TEDecryptionDB::isEnoughDecryptions( block_id _blockID ) {
 };
 
 bool TEDecryptionDB::isEnoughForeignShares(block_id _blockID) {
-    if ( requireSigners == 0 )
+    if ( requiredSigners == 0 )
         return true;
 
     READ_LOCK(decryptionSetsMutex);

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -105,9 +105,10 @@ bool TEDecryptionDB::haveDecryptionShares(block_id _blockID, schain_index _decry
     CHECK_ARGUMENT(_decryptorIndex > 0);
     CHECK_ARGUMENT(_decryptorIndex <= totalSigners);
 
-    READ_LOCK(decryptionSetsMutex)
+    READ_LOCK(decryptionSetsMutex);
 
-    return decryptionsStore[_blockID].count(_decryptorIndex) > 0;
+    const auto it = decryptionsStore.find(_blockID);
+    return it->second.count(_decryptorIndex) > 0;
 
 };
 
@@ -225,14 +226,21 @@ ptr< AESKeyDecryptionShareList > TEDecryptionDB::getMyDecryptionShares(
 
 
 bool TEDecryptionDB::isEnoughDecryptions( block_id _blockID ) {
-    READ_LOCK(decryptionSetsMutex)
-    return decryptionsStore[_blockID].size() == requiredSigners;
+    READ_LOCK(decryptionSetsMutex);
+    const auto it = decryptionsStore.find(_blockID);
+    if ( it == decryptionsStore.end() )
+        return false;
+    return it->second.size() == requiredSigners;
 };
 
 bool TEDecryptionDB::isEnoughForeignShares(block_id _blockID) {
     READ_LOCK(decryptionSetsMutex);
 
-    const auto& shares = decryptionsStore[_blockID];
+    const auto it = decryptionsStore.find(_blockID);
+    if ( it == decryptionsStore.end() )
+        return false;
+
+    const auto& shares = it->second;
     bool hasOwnShare = shares.find(sChain->getSchainIndex()) != shares.end();
 
     // if the DB already has the own share, it needs to contain required shares
@@ -243,8 +251,11 @@ bool TEDecryptionDB::isEnoughForeignShares(block_id _blockID) {
 
 
 uint64_t TEDecryptionDB::getDecryptionsCount( block_id _blockID ) {
-    READ_LOCK(decryptionSetsMutex)
-    return decryptionsStore[_blockID].size();
+    READ_LOCK(decryptionSetsMutex);
+    const auto it = decryptionsStore.find(_blockID);
+    if ( it != decryptionsStore.end() )
+        return it->second.size();
+    return 0;
 };
 
 #endif

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -229,6 +229,9 @@ ptr< AESKeyDecryptionShareList > TEDecryptionDB::getMyDecryptionShares(
 
 
 bool TEDecryptionDB::isEnoughDecryptions( block_id _blockID ) {
+    if ( requireSigners == 0 )
+        return true;
+
     READ_LOCK(decryptionSetsMutex);
     const auto it = decryptionsStore.find(_blockID);
     if ( it == decryptionsStore.end() )
@@ -237,6 +240,9 @@ bool TEDecryptionDB::isEnoughDecryptions( block_id _blockID ) {
 };
 
 bool TEDecryptionDB::isEnoughForeignShares(block_id _blockID) {
+    if ( requireSigners == 0 )
+        return true;
+
     READ_LOCK(decryptionSetsMutex);
 
     const auto it = decryptionsStore.find(_blockID);


### PR DESCRIPTION
fixes https://github.com/skalenetwork/internal-support/issues/1277 (the original issue that caused crashes). another fix is coming in the next Stan's pr

1. lock mutex to protect `blockHash` from being read and written to from different threads.
tests:
without this changes a node crashes after ~50 blocks. with this patch applied blocks no crashes detected after running for 1000+ 

2. fix accessing map element using `operator[]` under the `READ_LOCK`. 