### PR TITLE
Is 1278 improve bite data validation

### DIFF
--- a/SkaleCommon.h
+++ b/SkaleCommon.h
@@ -201,6 +201,8 @@ static constexpr size_t PARTIAL_HASH_LEN = 8;
 
 #ifdef BITE
 static constexpr size_t EXTRA_DATA_LEN = 32;
+
+static constexpr size_t NUM_BITE_VALIDATION_THREADS = 8;
 #endif
 
 

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -27,6 +27,7 @@
 #include <future>
 #include <thread>
 #include <mutex>
+#include <chrono>
 
 BiteManager::BiteManager(Schain &_schain) : schain(_schain) {
     doRealCrypto = _schain.getNode()->verifyRealSignatures();
@@ -60,7 +61,6 @@ void BiteManager::parseBITETransactions(
                                                           ConnectionSubStatus::CONNECTION_ERROR_CANT_PARSE_PROPOSAL_TRANSACTION);
         }
     }
-
 
     if (!_proposal->getFailedTransactionsRef().empty()) {
         return;
@@ -179,9 +179,11 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
         publicDecryptionValuesBatch.resize(_encryptedAESKeys.size());
         
         std::mutex failedTransactionsMutex;
+
+        auto validationStartTime = std::chrono::high_resolution_clock::now();
         
         // lambda for processing a single encrypted AES key
-        auto processEncryptedAESKey = [&](size_t i, bool useThreadSafety) {
+        auto processEncryptedAESKey = [&_encryptedAESKeys, &publicDecryptionValuesBatch, &_failedTransactions, &failedTransactionsMutex](size_t i, bool useThreadSafety) {
             try {
                 auto encryptedAESKey = _encryptedAESKeys.at(i);
                 CHECK_STATE(encryptedAESKey)
@@ -228,7 +230,7 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
                 if (startIdx >= endIdx)
                     break;
                 
-                futures.push_back(std::thread( [&]() {
+                futures.push_back(std::thread( [startIdx, endIdx, &processEncryptedAESKey]() {
                     for (size_t i = startIdx; i < endIdx; ++i) {
                         processEncryptedAESKey(i, true);
                     }
@@ -241,12 +243,17 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
             }
         }
 
+        auto validationEndTime = std::chrono::high_resolution_clock::now();
+        auto validationDuration = std::chrono::duration_cast<std::chrono::milliseconds>(validationEndTime - validationStartTime);
+        LOG(info, fmt::format("BITE validation took {} ms for {} encrypted AES keys (avg: {:.2f} ms per key)", 
+                              validationDuration.count(), 
+                              _encryptedAESKeys.size(),
+                              static_cast<double>(validationDuration.count()) / _encryptedAESKeys.size()));
+
         if (!_failedTransactions.empty()) {
             // found failed transactions, just return
             return nullptr;
         }
-
-        CHECK_STATE(publicDecryptionValuesBatch.size() == _encryptedAESKeys.size())
 
         return schain.getCryptoManager()->sgxDecryptAESKeyShareBatch(publicDecryptionValuesBatch);
     } else {

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -1,3 +1,12 @@
+// avoid macro definition conflicts
+#pragma push_macro("CHECK")
+#pragma push_macro("LOG")
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/Future.h>
+#include <folly/Unit.h>
+#pragma pop_macro("LOG")
+#pragma pop_macro("CHECK")
+
 #include "Log.h"
 #include <chains/Schain.h>
 #include <crypto/AESKeyDecryptionShare.h>
@@ -31,6 +40,7 @@
 
 BiteManager::BiteManager(Schain &_schain) : schain(_schain) {
     doRealCrypto = _schain.getNode()->verifyRealSignatures();
+    threadPoolExecutor = std::make_shared<folly::CPUThreadPoolExecutor>(NUM_BITE_VALIDATION_THREADS);
 }
 
 
@@ -181,7 +191,7 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
         std::mutex failedTransactionsMutex;
 
         // lambda for processing a single encrypted AES key
-        auto processEncryptedAESKey = [&_encryptedAESKeys, &publicDecryptionValuesBatch, &_failedTransactions, &failedTransactionsMutex](size_t i, bool useThreadSafety) {
+        auto processEncryptedAESKey = [&_encryptedAESKeys, &publicDecryptionValuesBatch, &_failedTransactions, &failedTransactionsMutex](size_t i, bool useThreadSafety) -> folly::Unit {
             try {
                 auto encryptedAESKey = _encryptedAESKeys.at(i);
                 CHECK_STATE(encryptedAESKey)
@@ -207,6 +217,7 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
                                                 ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
                 }
             }
+            return folly::unit;
         };
         
         if (_encryptedAESKeys.size() < NUM_BITE_VALIDATION_THREADS) {
@@ -215,8 +226,7 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
                 processEncryptedAESKey(i, false);
             }
         } else {
-            std::vector<std::thread> futures;
-            futures.reserve( NUM_BITE_VALIDATION_THREADS );
+            std::vector<folly::Future<folly::Unit>> futures(NUM_BITE_VALIDATION_THREADS);
 
             const size_t chunkSize = (_encryptedAESKeys.size() + NUM_BITE_VALIDATION_THREADS - 1) /
                     NUM_BITE_VALIDATION_THREADS;
@@ -227,18 +237,18 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
                 
                 if (startIdx >= endIdx)
                     break;
-                
-                futures.push_back(std::thread( [startIdx, endIdx, &processEncryptedAESKey]() {
+
+                auto future = folly::via(threadPoolExecutor.get(), [startIdx, endIdx, &processEncryptedAESKey]() {
                     for (size_t i = startIdx; i < endIdx; ++i) {
                         processEncryptedAESKey(i, true);
                     }
-                }));
+                });
+
+                futures.push_back(std::move(future));
             }
             
             // Wait for all threads to complete
-            for (auto& future : futures) {
-                future.join();
-            }
+            auto allResults = folly::collectAll(futures).get();
         }
 
         if (!_failedTransactions.empty()) {

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -24,6 +24,9 @@
 #include "BLSPublicKey.h"
 #include "db/TEDecryptionDB.h"
 #include "rlp/RLPStream.h"
+#include <future>
+#include <thread>
+#include <mutex>
 
 BiteManager::BiteManager(Schain &_schain) : schain(_schain) {
     doRealCrypto = _schain.getNode()->verifyRealSignatures();
@@ -172,19 +175,19 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
     MONITOR2(__CLASS_NAME__, __FUNCTION__, schain.getMaxExternalBlockProcessingTime())
 
     if (doRealCrypto) {
-        vector<ptr<string> > publicDecryptionValuesBatch;
-
-        for (uint64_t i = 0; i < _encryptedAESKeys.size(); i++) {
+        vector<ptr<string>> publicDecryptionValuesBatch;
+        publicDecryptionValuesBatch.resize(_encryptedAESKeys.size());
+        
+        std::mutex failedTransactionsMutex;
+        
+        // lambda for processing a single encrypted AES key
+        auto processEncryptedAESKey = [&](size_t i, bool useThreadSafety) {
             try {
                 auto encryptedAESKey = _encryptedAESKeys.at(i);
                 CHECK_STATE(encryptedAESKey)
                 auto cipheredKey = libBLS::CipheredKey::fromBytes(*encryptedAESKey->getKey());
-                auto U = cipheredKey.U;
-                U.to_affine_coordinates();
-                // validate U
-                libBLS::ThresholdUtils::validateG2(U);
-
-                auto g2AsStringVector = libBLS::ThresholdUtils::G2ToString(U, libBLS::BASE_HEXA);
+                libBLS::ThresholdEncryption::validateEncryption( cipheredKey );
+                auto g2AsStringVector = libBLS::ThresholdUtils::G2ToString(cipheredKey.U, libBLS::BASE_HEXA);
 
                 // convert to string
                 auto publicDecryptionValue = make_shared<string>();
@@ -192,11 +195,49 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
                     publicDecryptionValue->append(str);
                 }
 
-                publicDecryptionValuesBatch.push_back(publicDecryptionValue);
+                publicDecryptionValuesBatch[i] = publicDecryptionValue;
             } catch (exception &_e) {
                 LOG(err, fmt::format( "Could not validate transaction: {} : {}" , i, _e.what()));
-                _failedTransactions.emplace(i,
-                                            ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
+                if (useThreadSafety) {
+                    lock_guard<mutex> lock(failedTransactionsMutex);
+                    _failedTransactions.emplace(i,
+                                                ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
+                } else {
+                    _failedTransactions.emplace(i,
+                                                ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
+                }
+            }
+        };
+        
+        if (_encryptedAESKeys.size() < NUM_BITE_VALIDATION_THREADS) {
+            // do sequential processing for small batches
+            for (uint64_t i = 0; i < _encryptedAESKeys.size(); i++) {
+                processEncryptedAESKey(i, false);
+            }
+        } else {
+            std::vector<std::thread> futures;
+            futures.reserve( NUM_BITE_VALIDATION_THREADS );
+
+            const size_t chunkSize = (_encryptedAESKeys.size() + NUM_BITE_VALIDATION_THREADS - 1) /
+                    NUM_BITE_VALIDATION_THREADS;
+            
+            for (size_t threadId = 0; threadId < NUM_BITE_VALIDATION_THREADS; ++threadId) {
+                size_t startIdx = threadId * chunkSize;
+                size_t endIdx = std::min(startIdx + chunkSize, _encryptedAESKeys.size());
+                
+                if (startIdx >= endIdx)
+                    break;
+                
+                futures.push_back(std::thread( [&]() {
+                    for (size_t i = startIdx; i < endIdx; ++i) {
+                        processEncryptedAESKey(i, true);
+                    }
+                }));
+            }
+            
+            // Wait for all threads to complete
+            for (auto& future : futures) {
+                future.join();
             }
         }
 
@@ -214,6 +255,7 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
             CHECK_STATE(encryptedAESKey);
             result->push_back(MockupAESKeyDecryptionShare::mockupDecrypt(encryptedAESKey, _decryptorIndex));
         }
+        
         return result;
     }
 }

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -180,8 +180,6 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
         
         std::mutex failedTransactionsMutex;
 
-        auto validationStartTime = std::chrono::high_resolution_clock::now();
-        
         // lambda for processing a single encrypted AES key
         auto processEncryptedAESKey = [&_encryptedAESKeys, &publicDecryptionValuesBatch, &_failedTransactions, &failedTransactionsMutex](size_t i, bool useThreadSafety) {
             try {
@@ -242,13 +240,6 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
                 future.join();
             }
         }
-
-        auto validationEndTime = std::chrono::high_resolution_clock::now();
-        auto validationDuration = std::chrono::duration_cast<std::chrono::milliseconds>(validationEndTime - validationStartTime);
-        LOG(info, fmt::format("BITE validation took {} ms for {} encrypted AES keys (avg: {:.2f} ms per key)", 
-                              validationDuration.count(), 
-                              _encryptedAESKeys.size(),
-                              static_cast<double>(validationDuration.count()) / _encryptedAESKeys.size()));
 
         if (!_failedTransactions.empty()) {
             // found failed transactions, just return

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -7,6 +7,7 @@
 #include <crypto/AESKeyDecryptionShareSet.h>
 #include "node/ConsensusInterface.h"
 #include "abstracttcpserver/ConnectionStatus.h"
+
 class Schain;
 class BlockProposal;
 class CommittedBlock;
@@ -15,10 +16,14 @@ class AESKeyDecryptionShareList;
 class BiteDataField;
 class TransactionList;
 class EncryptedAESKey;
+namespace folly {
+class CPUThreadPoolExecutor;
+}
 
 class BiteManager {
     Schain &schain;
     bool doRealCrypto = false;
+    std::shared_ptr<folly::CPUThreadPoolExecutor> threadPoolExecutor;
 
 public:
     explicit BiteManager(Schain &_schain);

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -464,7 +464,8 @@ void BlockFinalizeDownloader::workerThreadFragmentDownloadLoop(
 }
 
 bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
-    MONITOR(__CLASS_NAME__, __FUNCTION__) {
+    MONITOR(__CLASS_NAME__, __FUNCTION__);
+    {
         threadPool = make_shared<BlockFinalizeDownloaderThreadPool>(
             (uint64_t) getSchain()->getNodeCount(), this);
         threadPool->startService();
@@ -491,8 +492,9 @@ bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
             proposal = BlockProposal::makeFromNetworkSerialized(
                 fragmentList.serialize(), getSchain()->getCryptoManager());
             CHECK_STATE(proposal)
-            CHECK_STATE(proposal->getProposerIndex() == ( uint64_t ) proposerIndex); {
-                LOCK(m)
+            CHECK_STATE(proposal->getProposerIndex() == ( uint64_t ) proposerIndex);
+            {
+                LOCK(m);
                 if (!this->blockHash.empty()) {
                     auto h = BLAKE3Hash::fromHex(blockHash);
                     CHECK_STATE2(proposal->getHash().compare( h ) == 0, "Incorrect block hash");

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1415,7 +1415,8 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
             // Dowload missing objects - proposal, daProof, and decryption shares
             // Note that due to the BLS signature proof, 2t hosts out of 3t + 1 total are
             // guaranteed to posSess the proposal
-            auto agent = make_unique<BlockFinalizeDownloader>(this, _blockId, _proposerIndex); {
+            auto agent = make_unique<BlockFinalizeDownloader>(this, _blockId, _proposerIndex);
+            {
                 const string msg = "Finalization download:" + to_string(_blockId) + ":" +
                                    to_string(_proposerIndex);
 

--- a/db/TEDecryptionDB.h
+++ b/db/TEDecryptionDB.h
@@ -27,7 +27,7 @@ public:
     explicit TEDecryptionDB(
         Schain* _sChain, string& _dirName, string& _prefix, node_id _nodeId, uint64_t _maxDBSize );
 
-     void addDecryptionShares(const ptr<AESKeyDecryptionShareList> &_decryptionShareList);
+    void addDecryptionShares(const ptr<AESKeyDecryptionShareList> &_decryptionShareList);
 
     bool haveDecryptionShares(block_id _blockID, schain_index _decryptorIndex);
 

--- a/rlp/EthTransactionEncoder.cpp
+++ b/rlp/EthTransactionEncoder.cpp
@@ -45,10 +45,10 @@ ptr< vector< uint8_t > > EthTransactionEncoder::signAndEncodeTx( const EthTransa
 
 /// @brief Generates a sample transaction of one of the three types (Legacy, Type1, Type2).
 /// The transaction is signed and encoded. Each time it is called, it rotates through the three types.
-/// @param _isByte Specifies if the transaction data should be BITE encrypted.
+/// @param _isBite Specifies if the transaction data should be BITE encrypted.
 /// @param _biteManager 
 /// @return pointer to RLP-encoded transaction
-ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, ptr<BiteManager> _biteManager ) {
+ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isBite, ptr<BiteManager> _biteManager ) {
     CHECK_STATE(_biteManager)
     static atomic< uint64_t > counter = 0;
     static atomic< uint64_t > nonce = 0;
@@ -117,7 +117,7 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
     EthTransaction& txRef = *tx;
     txRef.nonce = RLPStream::u256toBytes( static_cast<u256>( currentNonce ) );
 
-    if ( _isByte ) {
+    if ( _isBite ) {
         auto encryptedKeyPlusData = _biteManager->teEncryptDataAndToAddress(txRef.data, txRef.to);
         BiteDataField biteDataField(encryptedKeyPlusData , 0);
         // set data

--- a/rlp/EthTransactionEncoder.h
+++ b/rlp/EthTransactionEncoder.h
@@ -11,7 +11,7 @@ class BiteManager;
 class EthTransactionEncoder {
 
 public:
-    static std::shared_ptr<std::vector<uint8_t>> generateSampleTx(bool _isByte, ptr<BiteManager> _biteManager);
+    static std::shared_ptr<std::vector<uint8_t>> generateSampleTx(bool _isBite, ptr<BiteManager> _biteManager);
 
     static std::shared_ptr< std::vector< uint8_t > >  rlpEncodeWithoutSig(ParsedEthTransaction& _transaction);
 


### PR DESCRIPTION
fixes https://github.com/skalenetwork/internal-support/issues/1278

1. improved BITE txns validation - validate that parts of the ciphertext correspond to each other as well as the validity of each part
2. split validation in multiple (`NUM_BITE_VALIDATION_THREADS`) threads. using 8 threads speed up validation 3 times comparing to sequential processing (for sequential processing it takes ~7.5s to validate BITE 1000 txns, for parallel - 1.8s)