### PR TITLE
Bug/is 1278 bite data validation

### DIFF
--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -244,7 +244,8 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
             processEncryptedAESKey(i, false);
         }
     } else {
-        std::vector<folly::Future<folly::Unit>> futures(NUM_BITE_VALIDATION_THREADS);
+        std::vector<folly::Future<folly::Unit>> futures;
+        futures.reserve(NUM_BITE_VALIDATION_THREADS);
 
         const size_t chunkSize = (encryptedAESKeys->size() + NUM_BITE_VALIDATION_THREADS - 1) /
                 NUM_BITE_VALIDATION_THREADS;

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -200,17 +200,18 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
 
     CHECK_STATE(encryptedAESKeys);
 
+    auto failedTransactionRef = _proposal->getFailedTransactionsRef();
 
     auto publicDecryptionValues = make_shared<vector<ptr<string>>>();
 
-    publicDecryptionValuesBatch.resize(_encryptedAESKeys.size());
+    publicDecryptionValues->resize(encryptedAESKeys->size());
         
     std::mutex failedTransactionsMutex;
 
     // lambda for processing a single encrypted AES key
-    auto processEncryptedAESKey = [&_encryptedAESKeys, &publicDecryptionValuesBatch, &_failedTransactions, &failedTransactionsMutex](size_t i, bool useThreadSafety) -> folly::Unit {
+    auto processEncryptedAESKey = [encryptedAESKeys, publicDecryptionValues, &failedTransactionRef, &failedTransactionsMutex](uint64_t i, bool useThreadSafety) -> folly::Unit {
         try {
-            auto encryptedAESKey = _encryptedAESKeys.at(i);
+            auto encryptedAESKey = encryptedAESKeys->at(i);
             CHECK_STATE(encryptedAESKey)
             auto cipheredKey = libBLS::CipheredKey::fromBytes(*encryptedAESKey->getKey());
             libBLS::ThresholdEncryption::validateEncryption( cipheredKey );
@@ -222,35 +223,35 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
                 publicDecryptionValue->append(str);
             }
 
-            publicDecryptionValuesBatch[i] = publicDecryptionValue;
+            publicDecryptionValues->at(i) = publicDecryptionValue;
         } catch (exception &_e) {
             LOG(err, fmt::format( "Could not validate transaction: {} : {}" , i, _e.what()));
             if (useThreadSafety) {
                 lock_guard<mutex> lock(failedTransactionsMutex);
-                _failedTransactions.emplace(i,
+                failedTransactionRef.emplace(i,
                                             ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
             } else {
-                _failedTransactions.emplace(i,
+                failedTransactionRef.emplace(i,
                                             ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
             }
         }
         return folly::unit;
     };
     
-    if (_encryptedAESKeys.size() < NUM_BITE_VALIDATION_THREADS) {
+    if (encryptedAESKeys->size() < NUM_BITE_VALIDATION_THREADS) {
         // do sequential processing for small batches
-        for (uint64_t i = 0; i < _encryptedAESKeys.size(); i++) {
+        for (uint64_t i = 0; i < encryptedAESKeys->size(); i++) {
             processEncryptedAESKey(i, false);
         }
     } else {
         std::vector<folly::Future<folly::Unit>> futures(NUM_BITE_VALIDATION_THREADS);
 
-        const size_t chunkSize = (_encryptedAESKeys.size() + NUM_BITE_VALIDATION_THREADS - 1) /
+        const size_t chunkSize = (encryptedAESKeys->size() + NUM_BITE_VALIDATION_THREADS - 1) /
                 NUM_BITE_VALIDATION_THREADS;
         
         for (size_t threadId = 0; threadId < NUM_BITE_VALIDATION_THREADS; ++threadId) {
             size_t startIdx = threadId * chunkSize;
-            size_t endIdx = std::min(startIdx + chunkSize, _encryptedAESKeys.size());
+            size_t endIdx = std::min(startIdx + chunkSize, encryptedAESKeys->size());
             
             if (startIdx >= endIdx)
                 break;

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -203,18 +203,18 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
 
     auto publicDecryptionValues = make_shared<vector<ptr<string>>>();
 
-    uint64_t i = 0;
+    publicDecryptionValuesBatch.resize(_encryptedAESKeys.size());
+        
+    std::mutex failedTransactionsMutex;
 
-    for (auto&& it : *encryptedAESKeys) {
+    // lambda for processing a single encrypted AES key
+    auto processEncryptedAESKey = [&_encryptedAESKeys, &publicDecryptionValuesBatch, &_failedTransactions, &failedTransactionsMutex](size_t i, bool useThreadSafety) -> folly::Unit {
         try {
-            auto encryptedAESKey = it.second;
+            auto encryptedAESKey = _encryptedAESKeys.at(i);
             CHECK_STATE(encryptedAESKey)
             auto cipheredKey = libBLS::CipheredKey::fromBytes(*encryptedAESKey->getKey());
-            auto U = cipheredKey.U;
-            U.to_affine_coordinates();
-            libBLS::ThresholdUtils::validateG2(U);
-
-            auto g2AsStringVector = libBLS::ThresholdUtils::G2ToString(U, libBLS::BASE_HEXA);
+            libBLS::ThresholdEncryption::validateEncryption( cipheredKey );
+            auto g2AsStringVector = libBLS::ThresholdUtils::G2ToString(cipheredKey.U, libBLS::BASE_HEXA);
 
             // convert to string
             auto publicDecryptionValue = make_shared<string>();
@@ -222,13 +222,50 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
                 publicDecryptionValue->append(str);
             }
 
-            publicDecryptionValues->push_back(publicDecryptionValue);
+            publicDecryptionValuesBatch[i] = publicDecryptionValue;
         } catch (exception &_e) {
-            LOG(err, fmt::format("Could not validate transaction: {} : {}", i, _e.what()));
-            _proposal->getFailedTransactionsRef().emplace(i,
-                                        CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
-            return;
+            LOG(err, fmt::format( "Could not validate transaction: {} : {}" , i, _e.what()));
+            if (useThreadSafety) {
+                lock_guard<mutex> lock(failedTransactionsMutex);
+                _failedTransactions.emplace(i,
+                                            ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
+            } else {
+                _failedTransactions.emplace(i,
+                                            ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
+            }
         }
+        return folly::unit;
+    };
+    
+    if (_encryptedAESKeys.size() < NUM_BITE_VALIDATION_THREADS) {
+        // do sequential processing for small batches
+        for (uint64_t i = 0; i < _encryptedAESKeys.size(); i++) {
+            processEncryptedAESKey(i, false);
+        }
+    } else {
+        std::vector<folly::Future<folly::Unit>> futures(NUM_BITE_VALIDATION_THREADS);
+
+        const size_t chunkSize = (_encryptedAESKeys.size() + NUM_BITE_VALIDATION_THREADS - 1) /
+                NUM_BITE_VALIDATION_THREADS;
+        
+        for (size_t threadId = 0; threadId < NUM_BITE_VALIDATION_THREADS; ++threadId) {
+            size_t startIdx = threadId * chunkSize;
+            size_t endIdx = std::min(startIdx + chunkSize, _encryptedAESKeys.size());
+            
+            if (startIdx >= endIdx)
+                break;
+
+            auto future = folly::via(threadPoolExecutor.get(), [startIdx, endIdx, &processEncryptedAESKey]() {
+                for (size_t i = startIdx; i < endIdx; ++i) {
+                    processEncryptedAESKey(i, true);
+                }
+            });
+
+            futures.push_back(std::move(future));
+        }
+        
+        // Wait for all threads to complete
+        auto allResults = folly::collectAll(futures).get();
     }
     _proposal->setSGXAESKeyBatch(publicDecryptionValues);
 }

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -208,12 +208,11 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
             CHECK_STATE(encryptedAESKey)
             auto cipheredKey = libBLS::CipheredKey::fromBytes(*encryptedAESKey->getKey());
             libBLS::ThresholdEncryption::validateEncryption( cipheredKey );
-            auto g2AsStringVector = libBLS::ThresholdUtils::G2ToString(cipheredKey.U, libBLS::BASE_HEXA);
 
             // convert to string
             auto decryptionShareInput = cipheredKey.getDecryptionShareInput();
 
-            publicDecryptionValues->at(i) = decryptionShareInput;
+            publicDecryptionValues->at(i) = make_shared<string>(decryptionShareInput);
         } catch (exception &_e) {
             LOG(err, fmt::format( "Could not validate transaction: {} : {}" , i, _e.what()));
             if (useThreadSafety) {

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1419,6 +1419,8 @@ bool Schain::haveAllElementsToFinalizeBlock(block_id _blockId, schain_index _pro
             ;
 }
 
+#include <libBLS/bls/BLSPublicKeyShare.h>
+
 void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_index _proposerIndex,
                                                    const ptr<ThresholdSignature> &_thresholdSig) {
 
@@ -1501,8 +1503,13 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
 
         CHECK_STATE(encryptedAESKeys);
 
+        ptr<vector<ptr<BLSPublicKeyShare>>> blsKeys = nullptr;
+        if (!getCryptoManager()->getSgxUrl().empty()) {
+            blsKeys = make_shared<vector<ptr<BLSPublicKeyShare>>>(getCryptoManager()->getAllBlsPublicKeyShares());
+        }
+
         auto keys = getNode()->getTEDecryptionDB()->mergeAESKeys(proposal->getBlockID(),
-                                                                 encryptedAESKeys);
+                                                                 encryptedAESKeys, blsKeys);
 
         CHECK_STATE(keys);
 

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1503,13 +1503,7 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
 
         CHECK_STATE(encryptedAESKeys);
 
-        ptr<vector<ptr<BLSPublicKeyShare>>> blsKeys = nullptr;
-        if (getNode()->isSgxEnabled()) {
-            blsKeys = make_shared<vector<ptr<BLSPublicKeyShare>>>(getCryptoManager()->getAllBlsPublicKeyShares());
-        }
-
-        auto keys = getNode()->getTEDecryptionDB()->mergeAESKeys(proposal->getBlockID(),
-                                                                 encryptedAESKeys, blsKeys);
+        auto keys = getNode()->getTEDecryptionDB()->mergeAESKeys(proposal->getBlockID(), encryptedAESKeys);
 
         CHECK_STATE(keys);
 

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1504,7 +1504,7 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
         CHECK_STATE(encryptedAESKeys);
 
         ptr<vector<ptr<BLSPublicKeyShare>>> blsKeys = nullptr;
-        if (!getCryptoManager()->getSgxUrl().empty()) {
+        if (getNode()->isSgxEnabled()) {
             blsKeys = make_shared<vector<ptr<BLSPublicKeyShare>>>(getCryptoManager()->getAllBlsPublicKeyShares());
         }
 

--- a/crypto/CryptoManager.cpp
+++ b/crypto/CryptoManager.cpp
@@ -1034,6 +1034,22 @@ void CryptoManager::verifyThresholdSigShare(
     }
 }
 
+ptr<BLSPublicKeyShare> CryptoManager::getBlsPublicKeyShare(uint64_t _nodeId) const {
+    CHECK_STATE(blsPublicKeySharesMapByIndex.count( _nodeId ) > 0 );
+
+    return make_shared<BLSPublicKeyShare>(blsPublicKeySharesMapByIndex.at(_nodeId),
+                                          requiredSigners, totalSigners);
+}
+
+vector<ptr<BLSPublicKeyShare>> CryptoManager::getAllBlsPublicKeyShares() const {
+    vector<ptr<BLSPublicKeyShare>> ret;
+    ret.reserve((uint64_t)getSchain()->getNodeCount());
+    for (uint64_t i = 0; i < getSchain()->getNodeCount(); ++i) {
+        ret[i] = getBlsPublicKeyShare(i);
+    }
+
+    return ret;
+}
 
 // Verify BLS sig share using the current set of BLS keys.
 // Since threshold sig shares are glued for the current block

--- a/crypto/CryptoManager.cpp
+++ b/crypto/CryptoManager.cpp
@@ -1018,15 +1018,15 @@ void CryptoManager::verifyThresholdSigShare(
     }
 }
 
-ptr<BLSPublicKeyShare> CryptoManager::getBlsPublicKeyShare(uint64_t _nodeId) const {
+ptr<libBLS::BLSPublicKeyShare> CryptoManager::getBlsPublicKeyShare(uint64_t _nodeId) const {
     CHECK_STATE(blsPublicKeySharesMapByIndex.count( _nodeId ) > 0 );
 
-    return make_shared<BLSPublicKeyShare>(blsPublicKeySharesMapByIndex.at(_nodeId),
+    return make_shared<libBLS::BLSPublicKeyShare>(*blsPublicKeySharesMapByIndex.at(_nodeId),
                                           requiredSigners, totalSigners);
 }
 
-vector<ptr<BLSPublicKeyShare>> CryptoManager::getAllBlsPublicKeyShares() const {
-    vector<ptr<BLSPublicKeyShare>> ret;
+vector<ptr<libBLS::BLSPublicKeyShare>> CryptoManager::getAllBlsPublicKeyShares() const {
+    vector<ptr<libBLS::BLSPublicKeyShare>> ret;
     ret.resize((uint64_t)getSchain()->getNodeCount());
     for (uint64_t i = 0; i < getSchain()->getNodeCount(); ++i) {
         ret[i] = getBlsPublicKeyShare(i + 1);

--- a/crypto/CryptoManager.cpp
+++ b/crypto/CryptoManager.cpp
@@ -1043,9 +1043,9 @@ ptr<BLSPublicKeyShare> CryptoManager::getBlsPublicKeyShare(uint64_t _nodeId) con
 
 vector<ptr<BLSPublicKeyShare>> CryptoManager::getAllBlsPublicKeyShares() const {
     vector<ptr<BLSPublicKeyShare>> ret;
-    ret.reserve((uint64_t)getSchain()->getNodeCount());
+    ret.resize((uint64_t)getSchain()->getNodeCount());
     for (uint64_t i = 0; i < getSchain()->getNodeCount(); ++i) {
-        ret[i] = getBlsPublicKeyShare(i);
+        ret[i] = getBlsPublicKeyShare(i + 1);
     }
 
     return ret;

--- a/crypto/CryptoManager.h
+++ b/crypto/CryptoManager.h
@@ -58,6 +58,8 @@ class BLSPublicKey;
 
 class BLSSigShare;
 
+class BLSPublicKeyShare;
+
 namespace CryptoPP {
     class ECP;
 
@@ -243,6 +245,9 @@ public:
 
     void verifyBlsSigShare(ptr<BLSSigShare> _sigShare, BLAKE3Hash &_hash);
 
+    ptr<BLSPublicKeyShare> getBlsPublicKeyShare(uint64_t nodeId) const;
+
+    vector<ptr<BLSPublicKeyShare>> getAllBlsPublicKeyShares() const;
 
     ptr<ThresholdSigShareSet> createSigShareSet(block_id _blockId);
 

--- a/crypto/CryptoManager.h
+++ b/crypto/CryptoManager.h
@@ -57,9 +57,8 @@ class ECP;
 namespace libBLS {
     class BLSPublicKey;
     class BLSSigShare;
+    class BLSPublicKeyShare;
 }
-
-class BLSPublicKeyShare;
 
 namespace CryptoPP {
     class ECP;
@@ -235,9 +234,9 @@ public:
 
     void verifyBlsSigShare(libBLS::BLSSigShare& _sigShare, BLAKE3Hash &_hash);
 
-    ptr<BLSPublicKeyShare> getBlsPublicKeyShare(uint64_t nodeId) const;
+    ptr<libBLS::BLSPublicKeyShare> getBlsPublicKeyShare(uint64_t nodeId) const;
 
-    vector<ptr<BLSPublicKeyShare>> getAllBlsPublicKeyShares() const;
+    vector<ptr<libBLS::BLSPublicKeyShare>> getAllBlsPublicKeyShares() const;
 
     ptr<ThresholdSigShareSet> createSigShareSet(block_id _blockId);
 

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -189,11 +189,10 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
 
     // prepare TE public key shares if real signatures are enabled
     vector<libBLS::TEPublicKeyShare> tePublicKeys;
-    tePublicKeys.reserve(totalSigners);
     if ( _keyShares != nullptr ) {
-        for (size_t i = 0; i < tePublicKeys.size(); ++i) {
-            tePublicKeys[i] = libBLS::TEPublicKeyShare(*_keyShares->at(i)->getPublicKey(),
-                                                       i + 1, requiredSigners, totalSigners);
+        for (size_t i = 0; i < totalSigners; ++i) {
+            tePublicKeys.push_back(libBLS::TEPublicKeyShare(*_keyShares->at(i)->getPublicKey(),
+                                                       i + 1, requiredSigners, totalSigners) );
         }
     }
 
@@ -221,7 +220,7 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
                             auto cipheredKey = encryptions.at(transactionIndex);
                             libBLS::ThresholdEncryption::validateDecryptionShare(cipheredKey,
                                 *dynamic_cast<ConsensusAESKeyDecryptionShare*>(share.get())->getTEDecryptionShare(),
-                                                                                 tePublicKeys.at(decryptorIndex));
+                                                                                 tePublicKeys.at(decryptorIndex - 1));
                         }
                         // decryption shares set has its own lock
                         decryptionSharesSet->addDecryptionShare(share);

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -225,7 +225,8 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
                         CHECK_STATE(share);
                         size_t decryptorIndex = (size_t)share->getDecryptorIndex();
                         // verify share first if real signatures are enabled
-                        if (keyShares != nullptr && sChain->getSchainIndex() != decryptorIndex) {
+                        if (sChain->getNode()->isSgxEnabled() &&
+                                sChain->getSchainIndex() != decryptorIndex) {
                             auto cipheredKey = encryptions.at(transactionIndex);
                             libBLS::ThresholdEncryption::validateDecryptionShare(cipheredKey,
                                 *dynamic_cast<ConsensusAESKeyDecryptionShare*>(share.get())->getTEDecryptionShare(),

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -232,7 +232,7 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
                         // decryption shares set has its own lock
                         decryptionSharesSet->addDecryptionShare(share);
                     }  catch ( const std::exception& ex ) {
-                        LOG(trace, std::string("Error during adding shares: ") + ex.what());
+                        LOG(err, std::string("Error during adding shares: ") + ex.what());
                     }
                 }
             }

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -183,8 +183,10 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
         decryptionShareSets[decryptionShareIterator.first] =
             sChain->getBiteManager()->createAESDecryptionShareSet(
                 _blockId, decryptionShareIterator.first );
-        encryptions[decryptionShareIterator.first] =
-                libBLS::CipheredKey::fromBytes(*_encryptedAESKeyList->at(decryptionShareIterator.first)->getKey());
+        if (sChain->getNode()->isSgxEnabled()) {
+            encryptions[decryptionShareIterator.first] =
+                    libBLS::CipheredKey::fromBytes(*_encryptedAESKeyList->at(decryptionShareIterator.first)->getKey());
+        }
     }
 
     ptr<vector<ptr<BLSPublicKeyShare>>> keyShares = nullptr;

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -189,17 +189,17 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
         }
     }
 
-    ptr<vector<ptr<BLSPublicKeyShare>>> keyShares = nullptr;
+    ptr<vector<ptr<libBLS::BLSPublicKeyShare>>> keyShares = nullptr;
     if (sChain->getNode()->isSgxEnabled()) {
         keyShares =
-                std::make_shared<vector<ptr<BLSPublicKeyShare>>>(sChain->getCryptoManager()->getAllBlsPublicKeyShares());
+                std::make_shared<vector<ptr<libBLS::BLSPublicKeyShare>>>(sChain->getCryptoManager()->getAllBlsPublicKeyShares());
     }
 
     // prepare TE public key shares if real signatures are enabled
     vector<libBLS::TEPublicKeyShare> tePublicKeys;
     if ( keyShares != nullptr ) {
         for (size_t i = 0; i < totalSigners; ++i) {
-            tePublicKeys.push_back(libBLS::TEPublicKeyShare(*keyShares->at(i)->getPublicKey(),
+            tePublicKeys.push_back(libBLS::TEPublicKeyShare(keyShares->at(i)->getPublicKey(),
                                                        i + 1, requiredSigners, totalSigners) );
         }
     }

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -185,8 +185,11 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
                 _blockId, decryptionShareIterator.first );
         if (sChain->getNode()->isSgxEnabled()) {
             // fill the map to use in multiple threads later if real signatures are enabled
+            // dont validate inputs - were already validated before
+            bool toValidate = false;
             encryptions[decryptionShareIterator.first] =
-                    libBLS::CipheredKey::fromBytes(*_encryptedAESKeyList->at(decryptionShareIterator.first)->getKey());
+                    libBLS::CipheredKey::fromBytes(*_encryptedAESKeyList->at(decryptionShareIterator.first)->getKey(),
+                                                   toValidate);
         }
     }
 

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -184,20 +184,17 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
             sChain->getBiteManager()->createAESDecryptionShareSet(
                 _blockId, decryptionShareIterator.first );
         if (sChain->getNode()->isSgxEnabled()) {
+            // fill the map to use in multiple threads later if real signatures are enabled
             encryptions[decryptionShareIterator.first] =
                     libBLS::CipheredKey::fromBytes(*_encryptedAESKeyList->at(decryptionShareIterator.first)->getKey());
         }
     }
 
-    ptr<vector<ptr<libBLS::BLSPublicKeyShare>>> keyShares = nullptr;
-    if (sChain->getNode()->isSgxEnabled()) {
-        keyShares =
-                std::make_shared<vector<ptr<libBLS::BLSPublicKeyShare>>>(sChain->getCryptoManager()->getAllBlsPublicKeyShares());
-    }
-
     // prepare TE public key shares if real signatures are enabled
     vector<libBLS::TEPublicKeyShare> tePublicKeys;
-    if ( keyShares != nullptr ) {
+    if (sChain->getNode()->isSgxEnabled()) {
+        ptr<vector<ptr<libBLS::BLSPublicKeyShare>>> keyShares =
+                std::make_shared<vector<ptr<libBLS::BLSPublicKeyShare>>>(sChain->getCryptoManager()->getAllBlsPublicKeyShares());
         for (size_t i = 0; i < totalSigners; ++i) {
             tePublicKeys.push_back(libBLS::TEPublicKeyShare(keyShares->at(i)->getPublicKey(),
                                                        i + 1, requiredSigners, totalSigners) );
@@ -212,7 +209,7 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
 
     for ( auto&& decryptionSharesSetIterator: decryptionShareSets ) {
         auto transactionIndex = decryptionSharesSetIterator.first;
-        auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareLists, keyShares,
+        auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareLists,
                                  &decryptionShareSets, &aesKeys, &aesKeysMutex, &tePublicKeys,
                                  &_encryptedAESKeyList, transactionIndex, &encryptions,
                                  sChain = this->sChain]() -> folly::Unit {

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -46,15 +46,17 @@
 
 
 #include "leveldb/db.h"
+#include <crypto/EncryptedAESKey.h>
 #include "crypto/ThresholdSigShare.h"
-#include "crypto/AESKeyDecryptionShareList.h"
 #include "LevelDBOptions.h"
 
 
 #include <bite/BiteManager.h>
 #include <bite/BiteAESDecryptionShareSerializer.h>
 #include <crypto/AESKeyDecryptionShareSet.h>
-#include "TEDecryptionDB.h"
+#include <crypto/ConsensusAESKeyDecryptionShare.h>
+
+#include <bls/BLSPublicKeyShare.h>
 
 
 using namespace std;
@@ -153,8 +155,8 @@ bool TEDecryptionDB::haveDecryptionShares(block_id _blockID, schain_index _decry
 
 };
 
-ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<EncryptedAESKeyList> _encryptedAESKeyList) {
-
+ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<EncryptedAESKeyList> _encryptedAESKeyList,
+                                                        ptr<vector<ptr<BLSPublicKeyShare>>> _keyShares) {
     CHECK_STATE(_encryptedAESKeyList);
 
     WRITE_LOCK(decryptionSetsMutex);
@@ -162,29 +164,37 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
     map< schain_index, ptr< AESKeyDecryptionShareList > >& decryptionShareLists =
         decryptionsStore[_blockId];
 
-
     CHECK_STATE( decryptionShareLists.size() >= requiredSigners )
-
 
     auto firstDecryptionShareList = decryptionShareLists.begin()->second;
     // TODO - count of decryption shares need to be in DA header
     CHECK_STATE( firstDecryptionShareList );
     auto size = firstDecryptionShareList->getSize();
 
-
     for (auto&& it : decryptionShareLists) {
         auto list = it.second;
         CHECK_STATE(list->getSize() == size);
     }
 
-
-    map< transaction_index, ptr< AESKeyDecryptionShareSet > > decryptionShareSets;
-
+    map<transaction_index, ptr<AESKeyDecryptionShareSet>> decryptionShareSets;
+    map<transaction_index, libBLS::CipheredKey> encryptions;
 
     for ( auto&& decryptionShareIterator : firstDecryptionShareList->getDecryptionShares() ) {
         decryptionShareSets[decryptionShareIterator.first] =
             sChain->getBiteManager()->createAESDecryptionShareSet(
                 _blockId, decryptionShareIterator.first );
+        encryptions[decryptionShareIterator.first] =
+                libBLS::CipheredKey::fromBytes(*_encryptedAESKeyList->at(decryptionShareIterator.first)->getKey());
+    }
+
+    // prepare TE public key shares if real signatures are enabled
+    vector<libBLS::TEPublicKeyShare> tePublicKeys;
+    tePublicKeys.reserve(totalSigners);
+    if ( _keyShares != nullptr ) {
+        for (size_t i = 0; i < tePublicKeys.size(); ++i) {
+            tePublicKeys[i] = libBLS::TEPublicKeyShare(*_keyShares->at(i)->getPublicKey(),
+                                                       i + 1, requiredSigners, totalSigners);
+        }
     }
 
     std::vector<folly::Future<folly::Unit>> futures;
@@ -195,17 +205,29 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
 
     for ( auto&& decryptionSharesSetIterator: decryptionShareSets ) {
         auto transactionIndex = decryptionSharesSetIterator.first;
-        auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareLists,
-                                 &decryptionShareSets, &aesKeys, &aesKeysMutex,
-                                 &_encryptedAESKeyList, transactionIndex]() -> folly::Unit {
+        auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareLists, _keyShares,
+                                 &decryptionShareSets, &aesKeys, &aesKeysMutex, &tePublicKeys,
+                                 &_encryptedAESKeyList, transactionIndex, &encryptions]() -> folly::Unit {
             auto decryptionSharesSet = decryptionShareSets[transactionIndex];
             if ( !decryptionSharesSet->isEnough() ) {
                 for ( auto&& it: decryptionShareLists) {
-                    auto decryptionSharesList = it.second;
-                    auto share = decryptionSharesList->getDecryptionShare( transactionIndex );
-                    CHECK_STATE( share  );
-                    // decryption shares set has its own lock
-                    decryptionSharesSet->addDecryptionShare( share );
+                    try {
+                        auto decryptionSharesList = it.second;
+                        auto share = decryptionSharesList->getDecryptionShare(transactionIndex);
+                        CHECK_STATE(share);
+                        // verify share first if real signatures are enabled
+                        if (_keyShares != nullptr) {
+                            size_t decryptorIndex = (size_t)share->getDecryptorIndex();
+                            auto cipheredKey = encryptions.at(transactionIndex);
+                            libBLS::ThresholdEncryption::validateDecryptionShare(cipheredKey,
+                                *dynamic_cast<ConsensusAESKeyDecryptionShare*>(share.get())->getTEDecryptionShare(),
+                                                                                 tePublicKeys.at(decryptorIndex));
+                        }
+                        // decryption shares set has its own lock
+                        decryptionSharesSet->addDecryptionShare(share);
+                    }  catch ( const std::exception& ex ) {
+                        LOG(trace, std::string("Error during adding shares: ") + ex.what());
+                    }
                 }
             }
             if ( decryptionSharesSet->isEnough() ) {
@@ -231,7 +253,7 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
     }
 
     CHECK_STATE(decryptionsStore.size() <= 2 * totalSigners);
-
+    CHECK_STATE2(aesKeys->getSize() == _encryptedAESKeyList->size(), "Not all aes keys could be decrypted");
 
     return aesKeys;
 }

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -206,7 +206,8 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
         auto transactionIndex = decryptionSharesSetIterator.first;
         auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareLists, _keyShares,
                                  &decryptionShareSets, &aesKeys, &aesKeysMutex, &tePublicKeys,
-                                 &_encryptedAESKeyList, transactionIndex, &encryptions]() -> folly::Unit {
+                                 &_encryptedAESKeyList, transactionIndex, &encryptions,
+                                 sChain = this->sChain]() -> folly::Unit {
             auto decryptionSharesSet = decryptionShareSets[transactionIndex];
             if ( !decryptionSharesSet->isEnough() ) {
                 for ( auto&& it: decryptionShareLists) {
@@ -214,9 +215,9 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
                         auto decryptionSharesList = it.second;
                         auto share = decryptionSharesList->getDecryptionShare(transactionIndex);
                         CHECK_STATE(share);
+                        size_t decryptorIndex = (size_t)share->getDecryptorIndex();
                         // verify share first if real signatures are enabled
-                        if (_keyShares != nullptr) {
-                            size_t decryptorIndex = (size_t)share->getDecryptorIndex();
+                        if (_keyShares != nullptr && sChain->getSchainIndex() != decryptorIndex) {
                             auto cipheredKey = encryptions.at(transactionIndex);
                             libBLS::ThresholdEncryption::validateDecryptionShare(cipheredKey,
                                 *dynamic_cast<ConsensusAESKeyDecryptionShare*>(share.get())->getTEDecryptionShare(),

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -41,6 +41,7 @@
 #include "thirdparty/json.hpp"
 #include "chains/Schain.h"
 #include "datastructures/BlockProposal.h"
+#include "crypto/CryptoManager.h"
 #include "crypto/DecryptedAESKeyList.h"
 #include "crypto/AESKeyDecryptionShareList.h"
 
@@ -155,8 +156,7 @@ bool TEDecryptionDB::haveDecryptionShares(block_id _blockID, schain_index _decry
 
 };
 
-ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<EncryptedAESKeyList> _encryptedAESKeyList,
-                                                        ptr<vector<ptr<BLSPublicKeyShare>>> _keyShares) {
+ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<EncryptedAESKeyList> _encryptedAESKeyList) {
     CHECK_STATE(_encryptedAESKeyList);
 
     WRITE_LOCK(decryptionSetsMutex);
@@ -187,11 +187,17 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
                 libBLS::CipheredKey::fromBytes(*_encryptedAESKeyList->at(decryptionShareIterator.first)->getKey());
     }
 
+    ptr<vector<ptr<BLSPublicKeyShare>>> keyShares = nullptr;
+    if (sChain->getNode()->isSgxEnabled()) {
+        keyShares =
+                std::make_shared<vector<ptr<BLSPublicKeyShare>>>(sChain->getCryptoManager()->getAllBlsPublicKeyShares());
+    }
+
     // prepare TE public key shares if real signatures are enabled
     vector<libBLS::TEPublicKeyShare> tePublicKeys;
-    if ( _keyShares != nullptr ) {
+    if ( keyShares != nullptr ) {
         for (size_t i = 0; i < totalSigners; ++i) {
-            tePublicKeys.push_back(libBLS::TEPublicKeyShare(*_keyShares->at(i)->getPublicKey(),
+            tePublicKeys.push_back(libBLS::TEPublicKeyShare(*keyShares->at(i)->getPublicKey(),
                                                        i + 1, requiredSigners, totalSigners) );
         }
     }
@@ -204,7 +210,7 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
 
     for ( auto&& decryptionSharesSetIterator: decryptionShareSets ) {
         auto transactionIndex = decryptionSharesSetIterator.first;
-        auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareLists, _keyShares,
+        auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareLists, keyShares,
                                  &decryptionShareSets, &aesKeys, &aesKeysMutex, &tePublicKeys,
                                  &_encryptedAESKeyList, transactionIndex, &encryptions,
                                  sChain = this->sChain]() -> folly::Unit {
@@ -217,7 +223,7 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
                         CHECK_STATE(share);
                         size_t decryptorIndex = (size_t)share->getDecryptorIndex();
                         // verify share first if real signatures are enabled
-                        if (_keyShares != nullptr && sChain->getSchainIndex() != decryptorIndex) {
+                        if (keyShares != nullptr && sChain->getSchainIndex() != decryptorIndex) {
                             auto cipheredKey = encryptions.at(transactionIndex);
                             libBLS::ThresholdEncryption::validateDecryptionShare(cipheredKey,
                                 *dynamic_cast<ConsensusAESKeyDecryptionShare*>(share.get())->getTEDecryptionShare(),

--- a/db/TEDecryptionDB.h
+++ b/db/TEDecryptionDB.h
@@ -16,8 +16,6 @@ namespace folly {
 class CPUThreadPoolExecutor;
 }
 
-class BLSPublicKeyShare;
-
 using EncryptedAESKeyList = boost::container::flat_map<transaction_index, ptr<EncryptedAESKey> >;
 
 

--- a/db/TEDecryptionDB.h
+++ b/db/TEDecryptionDB.h
@@ -16,6 +16,8 @@ namespace folly {
 class CPUThreadPoolExecutor;
 }
 
+class BLSPublicKeyShare;
+
 using EncryptedAESKeyList = boost::container::flat_map<transaction_index, ptr<EncryptedAESKey> >;
 
 
@@ -39,8 +41,7 @@ public:
 
     bool haveDecryptionShares(block_id _blockID, schain_index _decryptorIndex);
 
-    ptr<DecryptedAESKeyList> mergeAESKeys(block_id _blockId, ptr<EncryptedAESKeyList> _encryptedAESKeyList);
-
+    ptr<DecryptedAESKeyList> mergeAESKeys(block_id _blockId, ptr<EncryptedAESKeyList> _encryptedAESKeyList, ptr<vector<ptr<BLSPublicKeyShare>>> _keyShares);
 
     void addMyDecryptionShares(const ptr<AESKeyDecryptionShareList> &_decryptionShareList);
 

--- a/db/TEDecryptionDB.h
+++ b/db/TEDecryptionDB.h
@@ -41,7 +41,7 @@ public:
 
     bool haveDecryptionShares(block_id _blockID, schain_index _decryptorIndex);
 
-    ptr<DecryptedAESKeyList> mergeAESKeys(block_id _blockId, ptr<EncryptedAESKeyList> _encryptedAESKeyList, ptr<vector<ptr<BLSPublicKeyShare>>> _keyShares);
+    ptr<DecryptedAESKeyList> mergeAESKeys(block_id _blockId, ptr<EncryptedAESKeyList> _encryptedAESKeyList);
 
     void addMyDecryptionShares(const ptr<AESKeyDecryptionShareList> &_decryptionShareList);
 


### PR DESCRIPTION
fixes https://github.com/skalenetwork/internal-support/issues/1278

- improved BITE txns validation - validate that parts of the ciphertext correspond to each other (`BiteManager.cpp`) as well as the validity of each part; verify that decryption shares correspond to the encrypted AES key (`TEDecryptionDB.cpp`)
- split validation in multiple (NUM_BITE_VALIDATION_THREADS) threads (`BiteManager.cpp`)