### PR TITLE
#933 improve db rotation for archive mode

### DIFF
--- a/db/CacheLevelDB.cpp
+++ b/db/CacheLevelDB.cpp
@@ -125,7 +125,7 @@ string CacheLevelDB::readStringUnsafe( string& _key ) {
     if ( measureTime )
         time = Time::getCurrentTimeMs();
 
-    for ( int i = LEVELDB_SHARDS - 1; i >= 0; i-- ) {
+    for ( int i = db.size() - 1; i >= 0; i-- ) {
         string result;
         CHECK_STATE( db.at( i ) )
         auto status = db.at( i )->Get( readOptions, _key, &result );
@@ -142,7 +142,7 @@ string CacheLevelDB::readStringUnsafe( string& _key ) {
 }
 
 bool CacheLevelDB::keyExistsUnsafe( const string& _key ) {
-    for ( int i = LEVELDB_SHARDS - 1; i >= 0; i-- ) {
+    for ( int i = db.size() - 1; i >= 0; i-- ) {
         auto result = make_shared< string >();
         CHECK_STATE( db[i] )
         auto status = db.at( i )->Get( readOptions, _key, result.get() );
@@ -280,7 +280,7 @@ ptr< map< string, string > > CacheLevelDB::readPrefixRange( string& _prefix ) {
     checkForDeadLockRead( __FUNCTION__ );
     shared_lock< shared_timed_mutex > lock( m );
 
-    for ( int i = LEVELDB_SHARDS - 1; i >= 0; i-- ) {
+    for ( int i = db.size() - 1; i >= 0; i-- ) {
         CHECK_STATE( db.at( i ) )
         auto partialResult = readPrefixRangeFromDBUnsafe( _prefix, db[i] );
         if ( partialResult ) {
@@ -466,6 +466,7 @@ pair< uint64_t, uint64_t > CacheLevelDB::findMaxMinDBIndex() {
 }
 
 void CacheLevelDB::rotateDBsIfNeeded() {
+    bool isArchiveNode = sChain->getNode()->isArchiveNode();
     try {
         if ( getActiveDBSize() <= maxDBSize )
             return;
@@ -473,35 +474,41 @@ void CacheLevelDB::rotateDBsIfNeeded() {
             checkForDeadLock( __FUNCTION__ );
             lock_guard< shared_timed_mutex > lock( m );
 
-            if ( getActiveDBSize() <= maxDBSize )
-                return;
-
             LOG(
                 info, "ROTATED_DATABASE: " << prefix << ":MAX_DB_SIZE:" << to_string( maxDBSize ) );
 
             auto newDB = openDB( highestDBIndex + 1 );
 
-            for ( uint64_t i = 1; i < LEVELDB_SHARDS; i++ ) {
-                db.at( i - 1 ) = nullptr;
-                db.at( i - 1 ) = db.at( i );
+            if ( isArchiveNode ) {
+                // For archive nodes: add new database
+                db.push_back( newDB );
+                LOG( info, "ARCHIVE_NODE: Added new database, total databases: " << db.size() );
+            } else {
+                // For regular nodes: keep exactly LEVELDB_SHARDS databases
+                for ( uint64_t i = 1; i < LEVELDB_SHARDS; i++ ) {
+                    db.at( i - 1 ) = nullptr;
+                    db.at( i - 1 ) = db.at( i );
+                }
+                db[LEVELDB_SHARDS - 1] = newDB;
             }
-
-            db[LEVELDB_SHARDS - 1] = newDB;
 
             highestDBIndex++;
 
-            uint64_t minIndex;
+            // For archive nodes, don't delete old databases - keep them for historical data
+            if ( !isArchiveNode ) {
+                uint64_t minIndex;
 
-            while ( ( minIndex = findMaxMinDBIndex().second ) + LEVELDB_SHARDS <= highestDBIndex ) {
-                if ( minIndex == 0 ) {
-                    return;
-                }
+                while ( ( minIndex = findMaxMinDBIndex().second ) + LEVELDB_SHARDS <= highestDBIndex ) {
+                    if ( minIndex == 0 ) {
+                        return;
+                    }
 
-                auto dbName = index2Path( minIndex );
-                try {
-                    boost::filesystem::remove_all( path( dbName ) );
-                } catch ( SkaleException& e ) {
-                    LOG( err, "Could not remove db:" << dbName );
+                    auto dbName = index2Path( minIndex );
+                    try {
+                        boost::filesystem::remove_all( path( dbName ) );
+                    } catch ( SkaleException& e ) {
+                        LOG( err, "Could not remove db:" << dbName );
+                    }
                 }
             }
 
@@ -672,7 +679,10 @@ ptr< map< schain_index, string > > CacheLevelDB::writeByteArrayToSetUnsafe(
 }
 
 void CacheLevelDB::verify() {
-    CHECK_STATE( db.size() == LEVELDB_SHARDS );
+    if ( !sChain->getNode()->isArchiveNode() ) {
+        CHECK_STATE( db.size() == LEVELDB_SHARDS );
+    }
+    
     for ( auto&& x : db ) {
         CHECK_STATE( x );
     }
@@ -720,8 +730,10 @@ void CacheLevelDB::destroy() {
     checkForDeadLock( __FUNCTION__ );
     lock_guard< shared_timed_mutex > lock( m );
 
-    for ( int i = LEVELDB_SHARDS - 1; i >= 0; i-- ) {
-        CHECK_STATE( db.at( i ) )
+    auto [maxIndex, minIndex] = findMaxMinDBIndex();
+    
+    for ( uint64_t i = minIndex; i <= maxIndex; i++ ) {
+        CHECK_STATE( db.at( i ) );
         db.at( i ) = nullptr;
         DestroyDB( index2Path( i ), leveldb::Options() );
     }
@@ -730,7 +742,7 @@ uint64_t CacheLevelDB::getMemoryUsed() {
     uint totalMemory = 0;
     checkForDeadLockRead( __FUNCTION__ );
     shared_lock< shared_timed_mutex > lock( m );
-    for ( int i = LEVELDB_SHARDS - 1; i >= 0; i-- ) {
+    for ( int i = db.size() - 1; i >= 0; i-- ) {
         CHECK_STATE( db.at( i ) )
         string usage;
         db.at( i )->GetProperty( "leveldb.approximate-memory-usage", &usage );

--- a/db/CacheLevelDB.cpp
+++ b/db/CacheLevelDB.cpp
@@ -466,7 +466,7 @@ pair< uint64_t, uint64_t > CacheLevelDB::findMaxMinDBIndex() {
 }
 
 void CacheLevelDB::rotateDBsIfNeeded() {
-    bool isArchiveNode = sChain->getNode()->isArchiveNode();
+    bool isArchiveMode = sChain->getNode()->isArchiveMode();
     try {
         if ( getActiveDBSize() <= maxDBSize )
             return;
@@ -479,7 +479,7 @@ void CacheLevelDB::rotateDBsIfNeeded() {
 
             auto newDB = openDB( highestDBIndex + 1 );
 
-            if ( isArchiveNode ) {
+            if ( isArchiveMode ) {
                 // For archive nodes: add new database
                 db.push_back( newDB );
                 LOG( info, "ARCHIVE_NODE: Added new database, total databases: " << db.size() );
@@ -495,7 +495,7 @@ void CacheLevelDB::rotateDBsIfNeeded() {
             highestDBIndex++;
 
             // For archive nodes, don't delete old databases - keep them for historical data
-            if ( !isArchiveNode ) {
+            if ( !isArchiveMode ) {
                 uint64_t minIndex;
 
                 while ( ( minIndex = findMaxMinDBIndex().second ) + LEVELDB_SHARDS <= highestDBIndex ) {
@@ -679,7 +679,7 @@ ptr< map< schain_index, string > > CacheLevelDB::writeByteArrayToSetUnsafe(
 }
 
 void CacheLevelDB::verify() {
-    if ( !sChain->getNode()->isArchiveNode() ) {
+    if ( !sChain->getNode()->isArchiveMode() ) {
         CHECK_STATE( db.size() == LEVELDB_SHARDS );
     }
     

--- a/db/CacheLevelDB.h
+++ b/db/CacheLevelDB.h
@@ -64,7 +64,6 @@ protected:
 
     void verify();
 
-
     ptr< map< schain_index, string > > writeByteArrayToSetUnsafe(
         const char* _value, uint64_t _valueLen, block_id _blockId, schain_index _index );
     string index2Path( uint64_t index );

--- a/json/JSONFactory.cpp
+++ b/json/JSONFactory.cpp
@@ -106,14 +106,14 @@ ptr< Node > JSONFactory::createNodeFromJsonObject( const nlohmann::json& _j,
     const ptr< map< uint64_t, string > >& _historicECDSAPublicKeys,
     const ptr< map< uint64_t, vector< uint64_t > > >& _historicNodeGroups ) {
     bool isSyncNode = false;
-    bool isArchiveNode = false;
+    bool isArchiveMode = false;
 
     if ( _j.find( "syncNode" ) != _j.end() ) {
         isSyncNode = _j.at( "syncNode" ).get< bool >();
     }
 
     if ( _j.find( "archiveMode" ) != _j.end() ) {
-        isArchiveNode = _j.at( "archiveMode" ).get< bool >();
+        isArchiveMode = _j.at( "archiveMode" ).get< bool >();
     }
 
     if ( isSyncNode && _useSGX ) {
@@ -160,7 +160,7 @@ ptr< Node > JSONFactory::createNodeFromJsonObject( const nlohmann::json& _j,
             node = make_shared< Node >( _j, _engine, _useSGX, _sgxURL, sgxSSLKeyFileFullPathCopy,
                 sgxSSLCertFileFullPathCopy, _ecdsaKeyName, _ecdsaPublicKeys, _blsKeyName,
                 _blsPublicKeys, _blsPublicKey, _gethURL, _previousBlsPublicKeys,
-                _historicECDSAPublicKeys, _historicNodeGroups, isSyncNode, isArchiveNode );
+                _historicECDSAPublicKeys, _historicNodeGroups, isSyncNode, isArchiveMode );
         } catch ( ... ) {
             throw_with_nested( FatalError( "Could not init node", __CLASS_NAME__ ) );
         }

--- a/json/JSONFactory.cpp
+++ b/json/JSONFactory.cpp
@@ -106,12 +106,15 @@ ptr< Node > JSONFactory::createNodeFromJsonObject( const nlohmann::json& _j,
     const ptr< map< uint64_t, string > >& _historicECDSAPublicKeys,
     const ptr< map< uint64_t, vector< uint64_t > > >& _historicNodeGroups ) {
     bool isSyncNode = false;
-
+    bool isArchiveNode = false;
 
     if ( _j.find( "syncNode" ) != _j.end() ) {
         isSyncNode = _j.at( "syncNode" ).get< bool >();
     }
 
+    if ( _j.find( "archiveMode" ) != _j.end() ) {
+        isArchiveNode = _j.at( "archiveMode" ).get< bool >();
+    }
 
     if ( isSyncNode && _useSGX ) {
         LOG( err, "SGX mode is not available for a sync node" );
@@ -157,7 +160,7 @@ ptr< Node > JSONFactory::createNodeFromJsonObject( const nlohmann::json& _j,
             node = make_shared< Node >( _j, _engine, _useSGX, _sgxURL, sgxSSLKeyFileFullPathCopy,
                 sgxSSLCertFileFullPathCopy, _ecdsaKeyName, _ecdsaPublicKeys, _blsKeyName,
                 _blsPublicKeys, _blsPublicKey, _gethURL, _previousBlsPublicKeys,
-                _historicECDSAPublicKeys, _historicNodeGroups, isSyncNode );
+                _historicECDSAPublicKeys, _historicNodeGroups, isSyncNode, isArchiveNode );
         } catch ( ... ) {
             throw_with_nested( FatalError( "Could not init node", __CLASS_NAME__ ) );
         }

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -89,8 +89,9 @@ Node::Node( const nlohmann::json& _cfg, ConsensusEngine* _consensusEngine, bool 
     ptr< vector< ptr< vector< string > > > > _blsPublicKeys, ptr< BLSPublicKey > _blsPublicKey,
     string& _gethURL, ptr< map< uint64_t, ptr< BLSPublicKey > > > _previousBlsPublicKeys,
     ptr< map< uint64_t, string > > _historicECDSAPublicKeys,
-    ptr< map< uint64_t, vector< uint64_t > > > _historicNodeGroups, bool _isSyncNode )
-    : gethURL( _gethURL ), isSyncNode( _isSyncNode ) {
+    ptr< map< uint64_t, vector< uint64_t > > > _historicNodeGroups, bool _isSyncNode,
+    bool _isArchiveModeEnabled )
+    : gethURL( _gethURL ), isSyncNode( _isSyncNode ), isArchiveModeEnabled( _isArchiveModeEnabled ) {
     if ( _consensusEngine ) {
         patchTimestamps = _consensusEngine->getPatchTimestamps();
     }
@@ -728,6 +729,10 @@ bool Node::isInited() const {
 
 bool Node::isSyncOnlyNode() const {
     return isSyncNode;
+}
+
+bool Node::isArchiveNode() const {
+    return isArchiveModeEnabled;
 }
 
 bool Node::verifyRealSignatures() const {

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -731,7 +731,7 @@ bool Node::isSyncOnlyNode() const {
     return isSyncNode;
 }
 
-bool Node::isArchiveNode() const {
+bool Node::isArchiveMode() const {
     return isArchiveModeEnabled;
 }
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -230,6 +230,7 @@ class Node {
 
 
     bool isSyncNode = false;
+    bool isArchiveModeEnabled = false;
 
     bool inited = false;
 
@@ -334,7 +335,8 @@ public:
         ptr< vector< ptr< vector< string > > > > _blsPublicKeys, ptr< BLSPublicKey > _blsPublicKey,
         string& _gethURL, ptr< map< uint64_t, ptr< BLSPublicKey > > > _previousBlsPublicKeys,
         ptr< map< uint64_t, string > > _historicECDSAPublicKeys,
-        ptr< map< uint64_t, vector< uint64_t > > > _historicNodeGroups, bool _isSyncNode );
+        ptr< map< uint64_t, vector< uint64_t > > > _historicNodeGroups, bool _isSyncNode,
+        bool _isArchiveModeEnabled );
 
 
     ~Node();
@@ -447,6 +449,8 @@ public:
     const string& getGethUrl() const;
 
     bool isSyncOnlyNode() const;
+
+    bool isArchiveNode() const;
 
     bool verifyRealSignatures() const;
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -450,7 +450,7 @@ public:
 
     bool isSyncOnlyNode() const;
 
-    bool isArchiveNode() const;
+    bool isArchiveMode() const;
 
     bool verifyRealSignatures() const;
 


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skale-consensus/issues/933
don't delete old databases if a node has archiveMode enabled
this will improve performance for indexer and historic nodes

tested on local machine: databases are never deleted, number of databases is Infinitely growing