### PR TITLE
Fix getRandomForBlockId for currently executing block

### DIFF
--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1639,7 +1639,10 @@ void Schain::writeToVisualizationStream(string &_s) {
 
 
 u256 Schain::getRandomForBlockId(block_id _blockId) {
-    auto block = getBlock(_blockId);
+    // Ensure the block has already been committed to the database
+    CHECK_STATE(_blockId <= readLastCommittedBlockIDFromDb());
+    auto block = getNode()->getBlockDB()->getBlock( _blockId, getCryptoManager() );
+    
     CHECK_STATE(block);
     auto signature = block->getThresholdSig();
 

--- a/chains/SchainGettersSetters.cpp
+++ b/chains/SchainGettersSetters.cpp
@@ -94,7 +94,8 @@ ptr< CommittedBlock > Schain::getBlock( block_id _blockID ) {
     MONITOR( __CLASS_NAME__, __FUNCTION__ )
 
     try {
-        if (_blockID > getLastCommittedBlockID())
+        // Ensure the block is committed in DB (including the currently executing block)
+        if (_blockID > readLastCommittedBlockIDFromDb())
             return nullptr;
         return getNode()->getBlockDB()->getBlock( _blockID, getCryptoManager() );
     } catch ( ExitRequestedException& ) {

--- a/chains/SchainGettersSetters.cpp
+++ b/chains/SchainGettersSetters.cpp
@@ -94,8 +94,7 @@ ptr< CommittedBlock > Schain::getBlock( block_id _blockID ) {
     MONITOR( __CLASS_NAME__, __FUNCTION__ )
 
     try {
-        // Ensure the block is committed in DB (including the currently executing block)
-        if (_blockID > readLastCommittedBlockIDFromDb())
+        if (_blockID > getLastCommittedBlockID())
             return nullptr;
         return getNode()->getBlockDB()->getBlock( _blockID, getCryptoManager() );
     } catch ( ExitRequestedException& ) {


### PR DESCRIPTION
This PR fixes an issue where getRandomForBlockId fails when called for the currently executing block.

## What is the problem

During execution of a transaction using RNG, skaled calls getBlockRandom(), which calls getRandomForBlockId(pending) which uses getBlock(pending) to get block from the database. Since the pending block has not yet been processed, getBlock returns nullptr, causing the RNG request to fail:
```
if (_blockID > getLastCommittedBlockID())
    return nullptr;
```

## How it is fixed 

Instead of requesting the block via getBlock, we now check the block number directly in getRandomForBlockId and fetch it from BlockDB

## Testing 

- Tested on 1-node chain using the steps from: https://github.com/skalenetwork/internal-support/issues/1294#issuecomment-3271851017
- Tested on 2-node devnet