### PR TITLE
Add security checks

### DIFF
--- a/JsonStubClient.h
+++ b/JsonStubClient.h
@@ -51,11 +51,15 @@ public:
         const std::string& keyShareName, std::vector<std::shared_ptr<std::string>>& _publicDecryptionValues ) {
 
         Json::Value p;
-        Json::Value batch;
+        Json::Value batch(Json::arrayValue);
 
-        for (auto value : _publicDecryptionValues) {
-            batch.append( *value );
-        };
+        for (const auto& v : _publicDecryptionValues) {
+            if (v && !v->empty()) {
+                batch.append(*v);
+            } else {
+                batch.append(Json::Value(""));
+            }
+        }
 
         p["blsKeyName"] = keyShareName;
 

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -85,7 +85,6 @@ void BiteManager::callSGXToCreateMyDecryptionSharesForProposalTransactions(
     CHECK_STATE(_proposal);
     // check we are not verifying twice
 
-
     auto savedShares = getSchain()->getNode()->getTEDecryptionDB()->getMyDecryptionShares(_proposal->getBlockID(),
                                                                                           _proposal->getProposerIndex());
 
@@ -121,7 +120,6 @@ void BiteManager::callSGXToCreateMyDecryptionSharesForProposalTransactions(
     // database when proposal is committed
     _proposal->setMyDecryptionShares(decryptionShareList);
 
-
     getSchain()->getNode()->getTEDecryptionDB()->addMyDecryptionShares(decryptionShareList);
 
 }
@@ -136,10 +134,8 @@ ptr<AESKeyDecryptionShareList> BiteManager::getDecryptionSharesFromDataFieldsMap
             _proposal->getBlockID(),
             _proposal->getProposerIndex(), schain.getSchainIndex());
 
-
     ptr<vector<ptr<AESKeyDecryptionShare> > > decryptionSharesVector = getDecryptionSharesFromAESKeys(
             _proposal, schain.getSchainIndex());
-
 
     if (!decryptionSharesVector) {
         return nullptr;
@@ -155,7 +151,6 @@ ptr<AESKeyDecryptionShareList> BiteManager::getDecryptionSharesFromDataFieldsMap
         arrayIndex++;
     }
 
-
     return decryptionShareList;
 }
 
@@ -168,8 +163,6 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAE
 
     auto encryptedAESKeys = _proposal->getEncryptedAESKeys();
     CHECK_STATE(encryptedAESKeys);
-
-
 
     if (doRealCrypto) {
 

--- a/crypto/CryptoManager.cpp
+++ b/crypto/CryptoManager.cpp
@@ -910,7 +910,6 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > CryptoManager::sgxDecryptAESKeyShareBa
         auto finishTimeMs = Time::getCurrentTimeMs();
         sgxBlockProcessingTimeMs += finishTimeMs - startTimeMs;
         RETRY_END
-
         auto sharesArray = jsonShares["decryptionShares"];
         CHECK_STATE(sharesArray.isArray())
         CHECK_STATE(sharesArray.size() == _publicDecryptionValues.size() )


### PR DESCRIPTION
- on empty blocks, the `batch` variable is `null`, and gets rejected by SGX.
- Add safety checks to always guarantee `batch` is an array, even if empty.

Fixes #943 