### PR TITLE
Add BITE epoch to oracle constructors

### DIFF
--- a/JsonStubClient.h
+++ b/JsonStubClient.h
@@ -51,11 +51,15 @@ public:
         const std::string& keyShareName, std::vector<std::shared_ptr<std::string>>& _publicDecryptionValues ) {
 
         Json::Value p;
-        Json::Value batch;
+        Json::Value batch(Json::arrayValue);
 
-        for (auto value : _publicDecryptionValues) {
-            batch.append( *value );
-        };
+        for (const auto& v : _publicDecryptionValues) {
+            if (v && !v->empty()) {
+                batch.append(*v);
+            } else {
+                batch.append(Json::Value(""));
+            }
+        }
 
         p["blsKeyName"] = keyShareName;
 

--- a/messages/NetworkMessage.cpp
+++ b/messages/NetworkMessage.cpp
@@ -402,7 +402,11 @@ ptr< NetworkMessage > NetworkMessage::parseMessage(
             string spec = getStringRapid( d, "spec" );
             CHECK_STATE( !spec.empty() )
             nwkMsg = make_shared< OracleRequestBroadcastMessage >( spec, node_id( srcNodeID ),
-                block_id( blockID ), timeMs, schain_id( sChainID ), msg_id( msgID ), srcSchainIndex,
+                block_id( blockID ),
+#ifdef BITE
+                epoch_id(epochID),
+#endif
+                timeMs, schain_id( sChainID ), msg_id( msgID ), srcSchainIndex,
                 ecdsaSig, publicKey, pkSig, _sChain );
 
         } else if ( type == BasicHeader::ORACLE_RESPONSE ) {
@@ -414,7 +418,11 @@ ptr< NetworkMessage > NetworkMessage::parseMessage(
 
 
             nwkMsg = make_shared< OracleResponseMessage >( result, receipt, node_id( srcNodeID ),
-                block_id( blockID ), timeMs, schain_id( sChainID ), msg_id( msgID ), srcSchainIndex,
+                block_id( blockID ),
+#ifdef BITE
+                epoch_id( epochID ),
+#endif
+                timeMs, schain_id( sChainID ), msg_id( msgID ), srcSchainIndex,
                 ecdsaSig, publicKey, pkSig, _sChain );
 #endif
         } else {

--- a/oracle/OracleClient.cpp
+++ b/oracle/OracleClient.cpp
@@ -39,6 +39,7 @@
 #include "protocols/ProtocolInstance.h"
 #include "utils/Time.h"
 #include "exceptions/OracleException.h"
+#include "datastructures/CommittedBlock.h"
 
 
 OracleClient::OracleClient( Schain& _sChain )
@@ -126,8 +127,12 @@ pair< uint64_t, string > OracleClient::submitOracleRequest(
     ptr< OracleRequestBroadcastMessage > msg = nullptr;
 
     try {
+
         msg =
             make_shared< OracleRequestBroadcastMessage >( _spec, sChain->getLastCommittedBlockID(),
+#ifdef BITE
+            epoch_id( sChain->getNode()->getCurrentEpochId() ),
+#endif
                 Time::getCurrentTimeMs(), *sChain->getOracleClient() );
 
         auto spec = msg->getParsedSpec();

--- a/oracle/OracleRequestBroadcastMessage.cpp
+++ b/oracle/OracleRequestBroadcastMessage.cpp
@@ -41,9 +41,17 @@
 #include "OracleRequestBroadcastMessage.h"
 
 OracleRequestBroadcastMessage::OracleRequestBroadcastMessage( const string& _requestSpec,
-    block_id _blockID, uint64_t _timeMs, OracleClient& sourceProtocolInstance )
+    block_id _blockID, 
+#ifdef BITE
+    epoch_id epochId,
+#endif
+    uint64_t _timeMs, OracleClient& sourceProtocolInstance )
     : NetworkMessage(
-          MSG_ORACLE_REQ_BROADCAST, _blockID, 0, 0, 0, _timeMs, sourceProtocolInstance ),
+          MSG_ORACLE_REQ_BROADCAST, _blockID, 
+#ifdef BITE
+          epochId,
+#endif
+          0, 0, 0, _timeMs, sourceProtocolInstance ),
       requestSpec( _requestSpec ) {
     requestSpec.erase(
         std::remove_if( requestSpec.begin(), requestSpec.end(), ::isspace ), requestSpec.end() );
@@ -55,10 +63,18 @@ OracleRequestBroadcastMessage::OracleRequestBroadcastMessage( const string& _req
 
 
 OracleRequestBroadcastMessage::OracleRequestBroadcastMessage( const string& _requestSpec,
-    node_id _srcNodeID, block_id _blockID, uint64_t _timeMs, schain_id _schainId, msg_id _msgID,
+    node_id _srcNodeID, block_id _blockID, 
+#ifdef BITE
+    epoch_id epochId,
+#endif
+    uint64_t _timeMs, schain_id _schainId, msg_id _msgID,
     schain_index _srcSchainIndex, const string& _ecdsaSig, const string& _publicKey,
     const string& _pkSig, Schain* _sChain )
-    : NetworkMessage( MSG_ORACLE_REQ_BROADCAST, _srcNodeID, _blockID, 0, 0, 0, _timeMs, _schainId,
+    : NetworkMessage( MSG_ORACLE_REQ_BROADCAST, _srcNodeID, _blockID, 
+#ifdef BITE
+        epochId,
+#endif
+          0, 0, 0, _timeMs, _schainId,
           _msgID, "", _ecdsaSig, _publicKey, _pkSig, _srcSchainIndex, _sChain->getCryptoManager() ),
       requestSpec( _requestSpec ) {
     CHECK_STATE( _requestSpec.front() == '{' && _requestSpec.back() == '}' )

--- a/oracle/OracleRequestBroadcastMessage.h
+++ b/oracle/OracleRequestBroadcastMessage.h
@@ -46,13 +46,21 @@ protected:
 
 
 public:
-    OracleRequestBroadcastMessage( const string& _requestSpec, block_id _blockID, uint64_t _timeMs,
+    OracleRequestBroadcastMessage( const string& _requestSpec, block_id _blockID, 
+#ifdef BITE
+        epoch_id epochId,
+#endif
+        uint64_t _timeMs,
         OracleClient& sourceProtocolInstance );
 
     const ptr< OracleRequestSpec >& getParsedSpec() const;
 
     OracleRequestBroadcastMessage( const string& _requestSpec, node_id _srcNodeID,
-        block_id _blockID, uint64_t _timeMs, schain_id _schainId, msg_id _msgID,
+        block_id _blockID, 
+#ifdef BITE
+        epoch_id epochId,
+#endif
+        uint64_t _timeMs, schain_id _schainId, msg_id _msgID,
         schain_index _srcSchainIndex, const string& _ecdsaSig, const string& _publicKey,
         const string& _pkSig, Schain* _sChain );
 };

--- a/oracle/OracleResponseMessage.cpp
+++ b/oracle/OracleResponseMessage.cpp
@@ -42,8 +42,16 @@
 #include "OracleResponseMessage.h"
 
 OracleResponseMessage::OracleResponseMessage( string& _oracleResult, string& _receipt,
-    block_id _blockID, uint64_t _timeMs, OracleClient& sourceProtocolInstance )
-    : NetworkMessage( MSG_ORACLE_RSP, _blockID, 0, 0, 0, _timeMs, sourceProtocolInstance ),
+    block_id _blockID,
+#ifdef BITE
+    epoch_id epochId,
+#endif
+    uint64_t _timeMs, OracleClient& sourceProtocolInstance )
+    : NetworkMessage( MSG_ORACLE_RSP, _blockID,
+#ifdef BITE
+        epochId,
+#endif
+        0, 0, 0, _timeMs, sourceProtocolInstance ),
       oracleResultStr( _oracleResult ),
       receipt( _receipt ) {
     printPrefix = "r";
@@ -51,10 +59,19 @@ OracleResponseMessage::OracleResponseMessage( string& _oracleResult, string& _re
 
 
 OracleResponseMessage::OracleResponseMessage( string& _oracleResult, string& _receipt,
-    node_id _srcNodeID, block_id _blockID, uint64_t _timeMs, schain_id _schainId, msg_id _msgID,
+    node_id _srcNodeID, block_id _blockID, 
+#ifdef BITE
+    epoch_id epochId,
+#endif
+
+    uint64_t _timeMs, schain_id _schainId, msg_id _msgID,
     schain_index _srcSchainIndex, const string& _ecdsaSig, const string& _publicKey,
     const string& _pkSig, Schain* _sChain )
-    : NetworkMessage( MSG_ORACLE_RSP, _srcNodeID, _blockID, 0, 0, 0, _timeMs, _schainId, _msgID, "",
+    : NetworkMessage( MSG_ORACLE_RSP, _srcNodeID, _blockID, 
+#ifdef BITE
+        epochId,
+#endif
+        0, 0, 0, _timeMs, _schainId, _msgID, "",
           _ecdsaSig, _publicKey, _pkSig, _srcSchainIndex, _sChain->getCryptoManager() ),
       oracleResultStr( _oracleResult ),
       receipt( _receipt ) {

--- a/oracle/OracleResponseMessage.h
+++ b/oracle/OracleResponseMessage.h
@@ -49,10 +49,17 @@ public:
     ptr< OracleResult >& getOracleResult( ptr< OracleRequestSpec > _spec, schain_id _schaiId );
 
     OracleResponseMessage( string& _oracleResult, string& _receipt, block_id _blockID,
+#ifdef BITE
+        epoch_id epochId,
+#endif
         uint64_t _timeMs, OracleClient& sourceProtocolInstance );
 
     OracleResponseMessage( string& _oracleResult, string& _receipt, node_id _srcNodeID,
-        block_id _blockID, uint64_t _timeMs, schain_id _schainId, msg_id _msgID,
+        block_id _blockID, 
+#ifdef BITE
+        epoch_id epochId,
+#endif
+        uint64_t _timeMs, schain_id _schainId, msg_id _msgID,
         schain_index _srcSchainIndex, const string& _ecdsaSig, const string& _publicKey,
         const string& _pkSig, Schain* _sChain );
 

--- a/oracle/OracleServerAgent.cpp
+++ b/oracle/OracleServerAgent.cpp
@@ -238,7 +238,11 @@ ptr< OracleResponseMessage > OracleServerAgent::doEndpointRequestResponse(
     string receipt = _requestSpec->getReceipt();
 
     return make_shared< OracleResponseMessage >( resultStr, receipt,
-        getSchain()->getLastCommittedBlockID() + 1, Time::getCurrentTimeMs(),
+        getSchain()->getLastCommittedBlockID() + 1, 
+#ifdef BITE
+        epoch_id( getSchain()->getNode()->getCurrentEpochId() ),
+#endif
+        Time::getCurrentTimeMs(),
         *getSchain()->getOracleClient() );
 }
 


### PR DESCRIPTION
## Description

- Add BITE epoch to all oracle constructors that require it
- Fix sgx `getDecryptionShares` call for empty shares

## Tests
- All previous tests should pass
- Tested locally & on devnet skaled 1 node sending 1 encrypted BITE transaction

Fixes #950 