### PR TITLE
BITE2 Conditional Transactions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,20 @@ if (BITE)
     add_definitions(-DBITE)
 endif ()
 
+if (BITE2)
+    set(BITE2 "1")
+    add_definitions(-DBITE2)
+    set(BITE "1")
+    add_definitions(-DBITE)
+endif ()
+
 if (FAIR)
     set(FAIR "1")
     add_definitions(-DFAIR)
     set(BITE "1")
     add_definitions(-DBITE)
+    set(BITE "2")
+    add_definitions(-DBITE2)
 endif ()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if (FAIR)
     add_definitions(-DFAIR)
     set(BITE "1")
     add_definitions(-DBITE)
-    set(BITE "2")
+    set(BITE2 "1")
     add_definitions(-DBITE2)
 endif ()
 

--- a/JsonStubClient.h
+++ b/JsonStubClient.h
@@ -48,17 +48,14 @@ public:
 
 #ifdef BITE
     Json::Value getDecryptionShares(
-        const std::string& keyShareName, std::vector<std::shared_ptr<std::string>>& _publicDecryptionValues ) {
+        const std::string& keyShareName, std::vector<std::string>& _publicDecryptionValues ) {
 
         Json::Value p;
         Json::Value batch(Json::arrayValue);
+        batch.resize(_publicDecryptionValues.size());
 
         for (const auto& v : _publicDecryptionValues) {
-            if (v && !v->empty()) {
-                batch.append(*v);
-            } else {
-                batch.append(Json::Value(""));
-            }
+            batch.append(v);
         }
 
         p["blsKeyName"] = keyShareName;

--- a/JsonStubClient.h
+++ b/JsonStubClient.h
@@ -48,7 +48,7 @@ public:
 
 #ifdef BITE
     Json::Value getDecryptionShares(
-        const std::string& keyShareName, std::vector<std::string>& _publicDecryptionValues ) {
+        const std::string& keyShareName, const std::vector<std::string>& _publicDecryptionValues ) {
 
         Json::Value p;
         Json::Value batch(Json::arrayValue);

--- a/bite/BiteAESDecryptionShareSerializer.cpp
+++ b/bite/BiteAESDecryptionShareSerializer.cpp
@@ -30,13 +30,14 @@ ptr< std::vector< uint8_t > > BiteAESDecryptionShareSerializer::serialize(
     std::vector< flatbuffers::Offset< skale_fb::DecryptionShare > > decryptionShareVec;
     decryptionShareVec.reserve( decryptionShares.size() );
 
-    for ( const auto& decryptionShare : decryptionShares ) {
-        uint32_t transactionIndex = ( uint32_t ) decryptionShare.first;
+    // run over all shares of all txs from this decryptor
+    for ( const auto& [txId, shares] : decryptionShares ) {
+        uint32_t transactionIndex = ( uint32_t ) txId;
         // convert all shares for this ciphertext into a single string
         std::string data;
-        for ( size_t i = 0; i < decryptionShare.second->size(); i++ ) {
-            data += decryptionShare.second->at(i)->toString();
-            if ( i != decryptionShare.second->size() - 1 ) {
+        for ( size_t i = 0; i < shares->size(); i++ ) {
+            data += shares->at(i)->toString();
+            if ( i != shares->size() - 1 ) {
                 data += ",";
             }
         }

--- a/bite/BiteAESDecryptionShareSerializer.cpp
+++ b/bite/BiteAESDecryptionShareSerializer.cpp
@@ -157,7 +157,7 @@ shared_ptr< AESKeyDecryptionShareList > BiteAESDecryptionShareSerializer::getDec
     // Merge results from all threads
     shares->reserve( numShares );
     for (size_t threadId = 0; threadId < NUM_BITE_VALIDATION_THREADS; ++threadId) {
-        for (auto& [txId, decryptionShares] : threadLocalShares[threadId]) {
+        for (auto& [txId, decryptionShares] : threadLocalShares.at(threadId)) {
             shares->addShares(txId, decryptionShares);
         }
     }

--- a/bite/BiteAESDecryptionShareSerializer.cpp
+++ b/bite/BiteAESDecryptionShareSerializer.cpp
@@ -32,8 +32,15 @@ ptr< std::vector< uint8_t > > BiteAESDecryptionShareSerializer::serialize(
 
     for ( const auto& decryptionShare : decryptionShares ) {
         uint32_t transactionIndex = ( uint32_t ) decryptionShare.first;
-        const auto data =
-            decryptionShare.second->toString();  // Assumes std::string or std::vector<uint8_t>
+        // convert all shares for this ciphertext into a single string
+        std::string data;
+        for ( size_t i = 0; i < decryptionShare.second->size(); i++ ) {
+            data += decryptionShare.second->at(i)->toString();
+            if ( i != decryptionShare.second->size() - 1 ) {
+                data += ",";
+            }
+        }
+
         auto dataOffset =
             builder.CreateVector( reinterpret_cast< const uint8_t* >( data.data() ), data.size() );
 
@@ -59,7 +66,7 @@ ptr< std::vector< uint8_t > > BiteAESDecryptionShareSerializer::serialize(
 
 void BiteAESDecryptionShareSerializer::serializedSanityCheck(
     const ptr< vector< uint8_t > >& _serializedDecryptionShares ) {
-    // 🔍 Verify the resulting buffer before returning
+    // Verify the resulting buffer before returning
     CHECK_STATE( _serializedDecryptionShares );
     flatbuffers::Verifier verifier(
         _serializedDecryptionShares->data(), _serializedDecryptionShares->size() );
@@ -106,7 +113,7 @@ shared_ptr< AESKeyDecryptionShareList > BiteAESDecryptionShareSerializer::getDec
     const size_t chunkSize = (numShares + NUM_BITE_VALIDATION_THREADS - 1) / NUM_BITE_VALIDATION_THREADS;
 
     // Thread-local storage for results to minimize lock contention
-    std::vector<std::vector<std::pair<transaction_index, ptr<AESKeyDecryptionShare>>>>
+    std::vector<std::vector<std::pair<transaction_index, ptr<AESKeyDecryptionShares>>>>
             threadLocalShares(NUM_BITE_VALIDATION_THREADS);
 
     for (size_t threadId = 0; threadId < NUM_BITE_VALIDATION_THREADS; ++threadId) {
@@ -129,11 +136,11 @@ shared_ptr< AESKeyDecryptionShareList > BiteAESDecryptionShareSerializer::getDec
                 CHECK_STATE( rawData );
 
                 string decryptionShareStr( rawData, rawData + fbdecryptionShareHandle->data()->size() );
-                auto decryptionShare = _biteManager->createAESDecryptionShare(
+                auto decryptionShares = _biteManager->createAESDecryptionShares(
                     decryptionShareStr, _decryptorIndex, fbdecryptionShareHandle->decryption_failed() );
 
                 threadLocalShares[threadId].emplace_back(
-                    fbdecryptionShareHandle->transaction_index(), decryptionShare);
+                    fbdecryptionShareHandle->transaction_index(), decryptionShares);
             }
 
             return folly::unit;
@@ -148,8 +155,8 @@ shared_ptr< AESKeyDecryptionShareList > BiteAESDecryptionShareSerializer::getDec
     // Merge results from all threads
     shares->reserve( numShares );
     for (size_t threadId = 0; threadId < NUM_BITE_VALIDATION_THREADS; ++threadId) {
-        for (auto& shareEntry : threadLocalShares[threadId]) {
-            shares->addShare(shareEntry.first, shareEntry.second);
+        for (auto& [txId, decryptionShares] : threadLocalShares[threadId]) {
+            shares->addShares(txId, decryptionShares);
         }
     }
 

--- a/bite/BiteAESDecryptionShareSerializer.cpp
+++ b/bite/BiteAESDecryptionShareSerializer.cpp
@@ -36,6 +36,7 @@ ptr< std::vector< uint8_t > > BiteAESDecryptionShareSerializer::serialize(
         // convert all shares for this ciphertext into a single string
         std::string data;
         for ( size_t i = 0; i < shares->size(); i++ ) {
+            CHECK_STATE( shares->at(i) );
             data += shares->at(i)->toString();
             if ( i != shares->size() - 1 ) {
                 data += ",";

--- a/bite/BiteCiphertext.cpp
+++ b/bite/BiteCiphertext.cpp
@@ -15,7 +15,7 @@
 const auto BITE_MIN_DATA_LEN = BITE_EPOCH_ID_LEN + ADDRESS_SIZE;
 const auto KEY_COUNT_BYTE_OFFSET = 1;
 
-// TODO - change name to BiteCiphertext insteadno
+
 BiteCiphertext::BiteCiphertext(const shared_ptr<EncryptedData> &_encryptedKeyPlusData, uint64_t _epoch)
     : keyPlusEncryptedData(_encryptedKeyPlusData), epoch(_epoch) {
     CHECK_STATE(_encryptedKeyPlusData);
@@ -23,9 +23,9 @@ BiteCiphertext::BiteCiphertext(const shared_ptr<EncryptedData> &_encryptedKeyPlu
     
 
     // Do not validate the key nor the ciphertext, just copy the first BITE_ENCRYPTED_AES_KEY_LEN bytes
-    auto keyVec = std::make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> >();
-    std::copy_n(keyPlusEncryptedData->begin(), BITE_ENCRYPTED_AES_KEY_LEN, keyVec->begin());
-    encryptedAESKey = make_shared<EncryptedAESKey>(keyVec);
+    auto keyVec = std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>();
+    std::copy_n(keyPlusEncryptedData->begin(), BITE_ENCRYPTED_AES_KEY_LEN, keyVec.begin());
+    encryptedAESKey.emplace(EncryptedAESKey(keyVec));
 
 
     // build serialized RLP-encoded data field
@@ -68,11 +68,11 @@ BiteCiphertext::BiteCiphertext(const std::shared_ptr<std::vector<uint8_t> > &_da
         epoch = epochIdCandidate;
         // set encrypted data and AES key
         keyPlusEncryptedData = encryptedBITEDataBytes;
-        auto keyVec = std::make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> >();
+        auto keyVec = std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>();
         // first byte stands for the number of keys in payload - skip it when parsing manually
         std::copy_n(keyPlusEncryptedData->begin() + KEY_COUNT_BYTE_OFFSET,
-                    BITE_ENCRYPTED_AES_KEY_LEN, keyVec->begin());
-        encryptedAESKey = make_shared<EncryptedAESKey>(keyVec);
+                    BITE_ENCRYPTED_AES_KEY_LEN, keyVec.begin());
+        encryptedAESKey = EncryptedAESKey(keyVec);
     } else {
         // if encryptedBITEData contains AES key encrypted with 2 BLS keys
         // need to determine which one was used to encrypt the original message based on epochId
@@ -96,9 +96,7 @@ BiteCiphertext::BiteCiphertext(const std::shared_ptr<std::vector<uint8_t> > &_da
         // set encrypted data and AES key
         encryptedBITEData.keepKey( keyIndexToKeep );
         keyPlusEncryptedData = make_shared<vector<uint8_t>>( encryptedBITEData.toBytes() );
-        encryptedAESKey = make_shared<EncryptedAESKey>(
-                    make_shared<std::array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>>(
-                        encryptedBITEData.getTargetKey().toBytes()));
+        encryptedAESKey.emplace(EncryptedAESKey(encryptedBITEData.getTargetKey().toBytes()));
     }
     
     CHECK_STATE2((uint64_t) _currentEpochId == epoch, "Incorrectly formatted BITE transaction: wrong epochId");
@@ -111,8 +109,8 @@ BiteCiphertext::BiteCiphertext(const std::shared_ptr<std::vector<uint8_t> > &_da
     serializedData = _data;
 }
 
-ptr<EncryptedAESKey> &BiteCiphertext::getEncryptedAESKey() {
-    return encryptedAESKey;
+EncryptedAESKey &BiteCiphertext::getEncryptedAESKey() {
+    return encryptedAESKey.value();
 }
 const shared_ptr< EncryptedData >& BiteCiphertext::getKeyPlusEncryptedData() const {
     return keyPlusEncryptedData;

--- a/bite/BiteCiphertext.cpp
+++ b/bite/BiteCiphertext.cpp
@@ -6,7 +6,7 @@
 #include "Log.h"
 #include <crypto/EncryptedAESKey.h>
 
-#include "bite/BiteDataField.h"
+#include "bite/BiteCiphertext.h"
 #include "rlp/RLPStream.h"
 #include "rlp/RLP.h"
 
@@ -16,7 +16,7 @@ const auto BITE_MIN_DATA_LEN = BITE_EPOCH_ID_LEN + ADDRESS_SIZE;
 const auto KEY_COUNT_BYTE_OFFSET = 1;
 
 // TODO - change name to BiteCiphertext insteadno
-BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusData, uint64_t _epoch)
+BiteCiphertext::BiteCiphertext(const shared_ptr<EncryptedData> &_encryptedKeyPlusData, uint64_t _epoch)
     : keyPlusEncryptedData(_encryptedKeyPlusData), epoch(_epoch) {
     CHECK_STATE(_encryptedKeyPlusData);
     CHECK_STATE(_encryptedKeyPlusData->size() > BITE_ENCRYPTED_AES_KEY_LEN);
@@ -39,7 +39,7 @@ BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusD
     serializedData = make_shared<vector<uint8_t> >(list.encode());
 }
 
-BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data, epoch_id _currentEpochId) {
+BiteCiphertext::BiteCiphertext(const std::shared_ptr<std::vector<uint8_t> > &_data, epoch_id _currentEpochId) {
     CHECK_STATE(_data);
 
     // parse RLP-encoded tx data field
@@ -111,17 +111,17 @@ BiteDataField::BiteDataField(const std::shared_ptr<std::vector<uint8_t> > &_data
     serializedData = _data;
 }
 
-ptr<EncryptedAESKey> &BiteDataField::getEncryptedAESKey() {
+ptr<EncryptedAESKey> &BiteCiphertext::getEncryptedAESKey() {
     return encryptedAESKey;
 }
-const shared_ptr< EncryptedData >& BiteDataField::getKeyPlusEncryptedData() const {
+const shared_ptr< EncryptedData >& BiteCiphertext::getKeyPlusEncryptedData() const {
     return keyPlusEncryptedData;
 }
 
-uint64_t BiteDataField::getEpoch() {
+uint64_t BiteCiphertext::getEpoch() {
     return epoch;
 }
 
-ptr<vector<uint8_t> > &BiteDataField::getSerializedData() {
+ptr<vector<uint8_t> > &BiteCiphertext::getSerializedData() {
     return serializedData;
 }

--- a/bite/BiteCiphertext.h
+++ b/bite/BiteCiphertext.h
@@ -1,25 +1,28 @@
 #pragma once
 #include <vector>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <atomic>
+#include <crypto/EncryptedAESKey.h>
 
-
-using EncryptedData = vector< std::uint8_t >;
-
-class EncryptedAESKey;
+using EncryptedData = std::vector< uint8_t >;
 
 class BiteCiphertext {
+    // optional to allow for lazy initialization - is always set in constructors
+    std::optional<EncryptedAESKey> encryptedAESKey;
 
-    ptr<EncryptedAESKey> encryptedAESKey;
     std::shared_ptr<EncryptedData> keyPlusEncryptedData;
     std::atomic_uint64_t epoch = 0;
-    ptr<vector<uint8_t >> serializedData;
+    std::shared_ptr<std::vector<uint8_t>> serializedData;
 
 public:
-    explicit BiteCiphertext( const shared_ptr< vector< std::uint8_t > >& data, epoch_id _currentEpochId);
-    explicit BiteCiphertext( const shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch);
+    explicit BiteCiphertext( const std::shared_ptr< std::vector< std::uint8_t > >& data, epoch_id _currentEpochId);
+    explicit BiteCiphertext( const std::shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch);
 
-    [[nodiscard]] ptr<EncryptedAESKey> & getEncryptedAESKey();
-    [[nodiscard]] const ptr< EncryptedData >& getKeyPlusEncryptedData() const;
+    [[nodiscard]] EncryptedAESKey & getEncryptedAESKey();
+    [[nodiscard]] const std::shared_ptr< EncryptedData >& getKeyPlusEncryptedData() const;
     [[nodiscard]] uint64_t getEpoch();
-    [[nodiscard]] ptr< vector< uint8_t > >& getSerializedData();
+    [[nodiscard]] std::shared_ptr< std::vector< uint8_t > >& getSerializedData();
 
 };

--- a/bite/BiteCiphertext.h
+++ b/bite/BiteCiphertext.h
@@ -6,7 +6,7 @@ using EncryptedData = vector< std::uint8_t >;
 
 class EncryptedAESKey;
 
-class BiteDataField {
+class BiteCiphertext {
 
     ptr<EncryptedAESKey> encryptedAESKey;
     std::shared_ptr<EncryptedData> keyPlusEncryptedData;
@@ -14,8 +14,8 @@ class BiteDataField {
     ptr<vector<uint8_t >> serializedData;
 
 public:
-    explicit BiteDataField( const shared_ptr< vector< std::uint8_t > >& data, epoch_id _currentEpochId);
-    explicit BiteDataField( const shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch);
+    explicit BiteCiphertext( const shared_ptr< vector< std::uint8_t > >& data, epoch_id _currentEpochId);
+    explicit BiteCiphertext( const shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch);
 
     [[nodiscard]] ptr<EncryptedAESKey> & getEncryptedAESKey();
     [[nodiscard]] const ptr< EncryptedData >& getKeyPlusEncryptedData() const;

--- a/bite/BiteCommittedBlockSerializer.cpp
+++ b/bite/BiteCommittedBlockSerializer.cpp
@@ -60,17 +60,20 @@ ptr<std::vector<uint8_t> > BiteCommittedBlockSerializer::serializeTransactionsAn
     // ---- Serialize AES Keys ----
     std::vector<skale_fb::AesKey> aesKeysVec;
 
-    for (auto &&it: _decryptedAesKeyList.getKeys()) {
-        auto key = it.second;
-        CHECK_STATE(key)
+    for (auto &&[txIdx, keys]: _decryptedAesKeyList.getKeys()) {
+        CHECK_STATE(keys)
 
-        auto rawKey = key->getAesKey(); // std::array<uint8_t, BITE_AES_KEY_LEN>
-        aesKeysVec.push_back(skale_fb::AesKey{
-            static_cast<uint32_t>(it.first),
-            rawKey // rawKey is std::array<uint8_t, 32>
-        });
+        // run over all aesKeys / ciphertexts for this transaction
+        // TODO - we should define a V2 structure that holds multiple keys per transaction
+        // without repeating transaction_index
+        for (const auto &key: *keys) {
+            auto rawKey = key.getAesKey(); // std::array<uint8_t, BITE_AES_KEY_LEN>
+            aesKeysVec.push_back(skale_fb::AesKey{
+                static_cast<uint32_t>(txIdx),
+                rawKey // rawKey is std::array<uint8_t, 32>
+            });
+        }
     }
-
 
     auto aesKeysOffset = builder.CreateVectorOfStructs(aesKeysVec);
 
@@ -160,13 +163,23 @@ ptr<CommittedBlock> BiteCommittedBlockSerializer::deserialize(const ptr<vector<u
     CHECK_STATE(fbAesKeys)
 
     if (fbAesKeys) {
+
+        bool keyForSameTxIdx = false;
+        transaction_index lastTxIdx = std::numeric_limits<transaction_index>::max();
+        DecryptedAESKeys keysForCurrTx;
+        
         for (const auto *aesKey: *fbAesKeys) {
             CHECK_STATE(aesKey->data() && aesKey->data()->size() == BITE_AES_KEY_LEN);
             std::array<uint8_t, BITE_AES_KEY_LEN> rawKey;
             std::memcpy(rawKey.data(), aesKey->data()->data(), BITE_AES_KEY_LEN);
 
+            keyForSameTxIdx = (lastTxIdx == aesKey->transaction_index());
+            if (!keyForSameTxIdx) {
+                lastTxIdx = aesKey->transaction_index();
+            }
+
             DecryptedAESKey key(rawKey);
-            decryptedAesKeyList->addKey(aesKey->transaction_index(), key);
+            keysForCurrTx.push_back(key);
         }
     }
 

--- a/bite/BiteCommittedBlockSerializer.cpp
+++ b/bite/BiteCommittedBlockSerializer.cpp
@@ -161,25 +161,44 @@ ptr<CommittedBlock> BiteCommittedBlockSerializer::deserialize(const ptr<vector<u
     auto fbAesKeys = fbBlock->aes_keys();
 
     CHECK_STATE(fbAesKeys)
-
     if (fbAesKeys) {
-
-        bool keyForSameTxIdx = false;
+        DecryptedAESKeys  keysForCurrTx;
         transaction_index lastTxIdx = std::numeric_limits<transaction_index>::max();
-        DecryptedAESKeys keysForCurrTx;
-        
-        for (const auto *aesKey: *fbAesKeys) {
+        bool              haveTx    = false;
+
+        // Keys are stored contiguously:
+        // Tx0Key0, Tx0Key1, ..., Tx1Key0, Tx1Key1, ...
+        for (size_t i = 0; i < fbAesKeys->size(); ++i) {
+            const auto* aesKey = (*fbAesKeys)[i];
             CHECK_STATE(aesKey->data() && aesKey->data()->size() == BITE_AES_KEY_LEN);
+
             std::array<uint8_t, BITE_AES_KEY_LEN> rawKey;
             std::memcpy(rawKey.data(), aesKey->data()->data(), BITE_AES_KEY_LEN);
 
-            keyForSameTxIdx = (lastTxIdx == aesKey->transaction_index());
-            if (!keyForSameTxIdx) {
-                lastTxIdx = aesKey->transaction_index();
+            transaction_index txIdx = aesKey->transaction_index();
+
+            // First key we see: initialize current tx
+            if (!haveTx) {
+                lastTxIdx = txIdx;
+                haveTx    = true;
+            }
+            // Transaction index changed: flush previous group
+            else if (txIdx != lastTxIdx) {
+                CHECK_STATE(!keysForCurrTx.empty());
+                decryptedAesKeyList->addKeys(lastTxIdx, keysForCurrTx);
+                keysForCurrTx.clear();
+
+                lastTxIdx = txIdx;
             }
 
-            DecryptedAESKey key(rawKey);
-            keysForCurrTx.push_back(key);
+            // Add current key to the current transaction's group
+            keysForCurrTx.emplace_back(rawKey);
+        }
+
+        // After the loop, flush the last transaction's keys (if any)
+        if (haveTx) {
+            CHECK_STATE(!keysForCurrTx.empty());
+            decryptedAesKeyList->addKeys(lastTxIdx, keysForCurrTx);
         }
     }
 

--- a/bite/BiteCommittedBlockSerializer.cpp
+++ b/bite/BiteCommittedBlockSerializer.cpp
@@ -17,8 +17,8 @@
 
 
 ptr<std::vector<uint8_t> > BiteCommittedBlockSerializer::serializeTransactionsAndCompleteSerialization(
-    BasicHeader& _blockHeader, TransactionList& transactionList,
-    DecryptedAESKeyList& _decryptedAesKeyList) {
+    BasicHeader& _blockHeader, const TransactionList& transactionList,
+    const DecryptedAESKeyList& _decryptedAesKeyList) {
     static_assert(BITE_AES_KEY_LEN == 32, "FlatBuffer AesKey requires 32-byte AES keys");
 
 
@@ -161,46 +161,34 @@ ptr<CommittedBlock> BiteCommittedBlockSerializer::deserialize(const ptr<vector<u
     auto fbAesKeys = fbBlock->aes_keys();
 
     CHECK_STATE(fbAesKeys)
-    if (fbAesKeys) {
+
+    // Assumes all fbaesKeys for the same transaction are contiguous
+    if (fbAesKeys && !fbAesKeys->empty()) {
         DecryptedAESKeys  keysForCurrTx;
-        transaction_index lastTxIdx = std::numeric_limits<transaction_index>::max();
-        bool              haveTx    = false;
+        transaction_index lastTxIdx = (*fbAesKeys)[0]->transaction_index();
 
-        // Keys are stored contiguously:
-        // Tx0Key0, Tx0Key1, ..., Tx1Key0, Tx1Key1, ...
-        for (size_t i = 0; i < fbAesKeys->size(); ++i) {
-            const auto* aesKey = (*fbAesKeys)[i];
-            CHECK_STATE(aesKey->data() && aesKey->data()->size() == BITE_AES_KEY_LEN);
+        for (const auto* aesKey : *fbAesKeys) {
+            CHECK_STATE(aesKey && aesKey->data() && aesKey->data()->size() == BITE_AES_KEY_LEN);
 
-            std::array<uint8_t, BITE_AES_KEY_LEN> rawKey;
-            std::memcpy(rawKey.data(), aesKey->data()->data(), BITE_AES_KEY_LEN);
+            const transaction_index txIdx = aesKey->transaction_index();
 
-            transaction_index txIdx = aesKey->transaction_index();
-
-            // First key we see: initialize current tx
-            if (!haveTx) {
-                lastTxIdx = txIdx;
-                haveTx    = true;
-            }
-            // Transaction index changed: flush previous group
-            else if (txIdx != lastTxIdx) {
+            if (txIdx != lastTxIdx) {
                 CHECK_STATE(!keysForCurrTx.empty());
                 decryptedAesKeyList->addKeys(lastTxIdx, keysForCurrTx);
                 keysForCurrTx.clear();
-
                 lastTxIdx = txIdx;
             }
 
-            // Add current key to the current transaction's group
+            std::array<uint8_t, BITE_AES_KEY_LEN> rawKey;
+            std::memcpy(rawKey.data(), aesKey->data()->data(), BITE_AES_KEY_LEN);
             keysForCurrTx.emplace_back(rawKey);
         }
 
-        // After the loop, flush the last transaction's keys (if any)
-        if (haveTx) {
-            CHECK_STATE(!keysForCurrTx.empty());
+        if (!keysForCurrTx.empty()) {
             decryptedAesKeyList->addKeys(lastTxIdx, keysForCurrTx);
         }
     }
+
 
     auto decryptedTransactionDataFields = _biteManager->verifyAndDecryptTransactionList(*transactionList,
         *decryptedAesKeyList);

--- a/bite/BiteCommittedBlockSerializer.h
+++ b/bite/BiteCommittedBlockSerializer.h
@@ -9,7 +9,7 @@ class BiteCommittedBlockSerializer {
 public:
 
     static ptr< std::vector< uint8_t > > serializeTransactionsAndCompleteSerialization(
-        BasicHeader& _blockHeader, TransactionList& _transactionList, DecryptedAESKeyList& _aesKeyList);
+        BasicHeader& _blockHeader, const TransactionList& _transactionList, const DecryptedAESKeyList& _aesKeyList);
 
     static ptr< CommittedBlock > deserialize(const ptr< vector< uint8_t > >& _serializedBlock,
                                              const ptr< CryptoManager >& _cryptoManager, ptr<BiteManager> _biteManager, bool _verifySig);

--- a/bite/BiteDataField.cpp
+++ b/bite/BiteDataField.cpp
@@ -6,7 +6,7 @@
 #include "Log.h"
 #include <crypto/EncryptedAESKey.h>
 
-#include "bite/BiteDataFiled.h"
+#include "bite/BiteDataField.h"
 #include "rlp/RLPStream.h"
 #include "rlp/RLP.h"
 
@@ -15,6 +15,7 @@
 const auto BITE_MIN_DATA_LEN = BITE_EPOCH_ID_LEN + ADDRESS_SIZE;
 const auto KEY_COUNT_BYTE_OFFSET = 1;
 
+// TODO - change name to BiteCiphertext insteadno
 BiteDataField::BiteDataField(const shared_ptr<EncryptedData> &_encryptedKeyPlusData, uint64_t _epoch)
     : keyPlusEncryptedData(_encryptedKeyPlusData), epoch(_epoch) {
     CHECK_STATE(_encryptedKeyPlusData);
@@ -120,24 +121,6 @@ const shared_ptr< EncryptedData >& BiteDataField::getKeyPlusEncryptedData() cons
 uint64_t BiteDataField::getEpoch() {
     return epoch;
 }
-
-
-ptr<BiteDataField> BiteDataField::createIfMagicMatches(ptr<vector<uint8_t> > &_data,
-                                                       ptr<vector<uint8_t> > &_to,
-                                                       epoch_id _currentEpochId) {
-    CHECK_STATE(_data)
-    CHECK_STATE(_to)
-
-    // compare _to field to BITE magic number
-    if (!std::equal(BITE_ADDRESS_AS_BYTE_ARRAY, BITE_ADDRESS_AS_BYTE_ARRAY + ADDRESS_SIZE,
-                    _to->begin())) {
-        return nullptr;
-    }
-
-    return ptr<BiteDataField>(new BiteDataField(_data, _currentEpochId));
-}
-
-
 
 ptr<vector<uint8_t> > &BiteDataField::getSerializedData() {
     return serializedData;

--- a/bite/BiteDataField.h
+++ b/bite/BiteDataField.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <vector>
 
 
 using EncryptedData = vector< std::uint8_t >;
@@ -11,17 +12,14 @@ class BiteDataField {
     std::shared_ptr<EncryptedData> keyPlusEncryptedData;
     std::atomic_uint64_t epoch = 0;
     ptr<vector<uint8_t >> serializedData;
-    explicit BiteDataField( const shared_ptr< vector< std::uint8_t > >& data, epoch_id _currentEpochId);
 
 public:
-    BiteDataField( const shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch);
+    explicit BiteDataField( const shared_ptr< vector< std::uint8_t > >& data, epoch_id _currentEpochId);
+    explicit BiteDataField( const shared_ptr< EncryptedData >& _encryptedKeyPlusData, uint64_t _epoch);
 
     [[nodiscard]] ptr<EncryptedAESKey> & getEncryptedAESKey();
     [[nodiscard]] const ptr< EncryptedData >& getKeyPlusEncryptedData() const;
     [[nodiscard]] uint64_t getEpoch();
     [[nodiscard]] ptr< vector< uint8_t > >& getSerializedData();
 
-    [[nodiscard]] static ptr<BiteDataField> createIfMagicMatches(ptr<vector<uint8_t >>& _data,
-                                                                 ptr<vector<uint8_t>>& _to,
-                                                                 epoch_id _currentEpochId);
 };

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -378,7 +378,7 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
     bool allValid = std::all_of(validationResult.begin(), validationResult.end(),
                                   [](bool v) { return v; });
 
-    // some transactions failed validationgetDecryptionSharesFromAESKeys
+    // some transactions failed validation getDecryptionSharesFromAESKeys
     if (!allValid) {
         size_t ciphertextGlobalIdx = 0;
         for (auto& [idx, ciphertexts] : *txsCiphertexts) {
@@ -545,8 +545,6 @@ DecryptedRegularTxFields BiteManager::parseDecryptedDataAsRegularTx(
     CHECK_STATE2(decryptedDataRlp.isList(), "Encrypted data rlp size must be a list");
     CHECK_STATE2(decryptedDataRlp.size() == 2,
                  "Encrypted data rlp lsit must have exactly 2 elements");
-    // extract decrypted data and to fields
-    vector<uint8_t> dataField = decryptedDataRlp[0].asBytes();
     
     std::array<uint8_t, 20> toField;
     std::copy(decryptedDataRlp[1].asBytes().begin(), decryptedDataRlp[1].asBytes().end(), toField.begin());
@@ -624,7 +622,7 @@ ptr<vector<uint8_t> > BiteManager::encryptRegularTx(const vector<uint8_t> &_data
 ptr<vector<uint8_t> > BiteManager::generateEncryptedCATData() {
     static size_t numberOfCiphertexts = 2;
 
-    // Keep ciphertext count between 3 and 5 (inclusive)
+    // Keep ciphertext count between 2 and 5 (inclusive)
     numberOfCiphertexts++;
     if (numberOfCiphertexts % 6 == 0) {
         numberOfCiphertexts = 2;

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -9,12 +9,16 @@
 #include "crypto/MockupAESKeyDecryptionShare.h"
 #include <crypto/AESKeyDecryptionShareList.h>
 #include <crypto/MockupAESKeyDecryptionShareSet.h>
+#include <crypto/TransactionCiphertexts.h>
 #include <algorithm>
+#include <string_view>
+#include <vector>
 
 #include "BiteCiphertext.h"
 #include "datastructures/BlockProposal.h"
 #include "datastructures/Transaction.h"
 #include "datastructures/TransactionList.h"
+#include "datastructures/TransactionCiphertextsMap.h"
 
 #include "rlp/ParsedEthTransaction.h"
 
@@ -50,7 +54,7 @@ ptr<BiteCiphertext> BiteManager::tryGetEncryptedRegularTxFields(
 
     auto ethTx = _transaction->getAsEthereumTransaction();
     
-    ptr<BiteCiphertext> result;
+    ptr<BiteCiphertext> biteCiphertext;
     if (ethTx->hasToField()) {
         
         auto to = ethTx->getToField();
@@ -65,39 +69,108 @@ ptr<BiteCiphertext> BiteManager::tryGetEncryptedRegularTxFields(
         auto dataField = ethTx->getTransactionDataField();
         CHECK_STATE(dataField);
 
-        result = ptr<BiteCiphertext>(new BiteCiphertext(dataField, _currentEpochId));
-        _transaction->setRegularTxEncryptedData(result); // cache it
+        biteCiphertext = ptr<BiteCiphertext>(new BiteCiphertext(dataField, _currentEpochId));
+        _transaction->setRegularTxEncryptedData(biteCiphertext); // cache it
     }
 
-    return result;
+    return biteCiphertext;
 }
 
+#ifdef BITE2
+ptr<std::vector<ptr<BiteCiphertext>>> BiteManager::tryGetEncryptedCATArgs(
+            const ptr<Transaction>& _transaction, epoch_id _currentEpochId ) {
+    CHECK_STATE(_transaction);
 
-ptr<std::vector<BiteCiphertext>> BiteManager::tryGetEncryptedCATArgs(
-            const ptr<Transaction> &, epoch_id ) {
-    // TODO
+    auto encryptedCATArgs = _transaction->getCATEncryptedArgs();
+
+    // if not cached - try to parse it
+    if (!encryptedCATArgs) {
+
+        // if not set bite data already - try parse it
+        auto ethTx = _transaction->getAsEthereumTransaction();
+        
+        auto dataField = ethTx->getTransactionDataField();
+        CHECK_STATE(dataField);
+
+        // compare first 4 bytes to BITE2 expected function selector
+        if (dataField->size() < BITE_FUNCTION_SELECTOR_SIZE_BYTES || 
+            !std::equal(BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY, BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY + BITE_FUNCTION_SELECTOR_SIZE_BYTES,
+                        dataField->begin())) {
+            return nullptr;
+        }
+
+        // Parse args as RLP list
+        // Data comes as:
+        // [funcSelector, RLP( RLP(cipher1, cipher2, ...), RLP(plaintext1, plaintext2, ...) )]
+
+        // offset function selector
+        auto dataWithoutSelector = std::vector<uint8_t>(dataField->begin() + BITE_FUNCTION_SELECTOR_SIZE_BYTES, dataField->end());
+        RLPItem rlpItem(dataWithoutSelector);
+        CHECK_STATE(rlpItem.isList());
+        CHECK_STATE(rlpItem.size() == 2); // RLP(ciphertexts, plaintexts)
+        RLPItem encryptedArgsRLP = rlpItem[0];
+        CHECK_STATE(encryptedArgsRLP.isList());
+
+        encryptedCATArgs = ptr<std::vector<ptr<BiteCiphertext>>>(new std::vector<ptr<BiteCiphertext>>());
+        
+        encryptedCATArgs->reserve(encryptedArgsRLP.size());
+        for (size_t i = 0; i < encryptedArgsRLP.size(); i++) {
+            auto argData = make_shared<std::vector<uint8_t>>(encryptedArgsRLP[i].asBytes());
+            ptr<BiteCiphertext> biteCiphertext = make_shared<BiteCiphertext>(argData, _currentEpochId);
+            encryptedCATArgs->emplace_back( biteCiphertext );
+        }
+        _transaction->setCATEncryptedArgs(encryptedCATArgs); // cache it   
+    }
+    return encryptedCATArgs;
 }
+#endif
 
 
 void BiteManager::parseBITETransactions(
     ptr<BlockProposal> _proposal) {
     transaction_index index = 0;
 
-    auto encryptedAESKeyMap = make_shared<EncryptedAESKeyMap>();
+    auto encryptedAESKeyMap = make_shared<TransactionCiphertextsMap>();
     auto biteDataFields     = make_shared<std::map<transaction_index, ptr<BiteCiphertext> > >();
 
-    ptr<vector<ptr<Transaction> > > transactions = _proposal->getTransactionList()->getItems();
-    for (size_t i = 0; i < transactions->size(); i++) {
+    bool regularTxsStartIdx = 0;
+    ptr<vector<ptr<Transaction> > > transactions = _proposal->getTransactionList()->getItems(); 
+
+#ifdef BITE2
+    // Try parsing CAT transactions first
+    for (size_t i = 0 ; i < transactions->size(); i++) {
         try {
             auto tx = transactions->at(i);
-            auto biteDataField = tryGetEncryptedRegularTxFields(tx, _proposal->getEpochID());
-            if (biteDataField) {
-                encryptedAESKeyMap->emplace(index, biteDataField->getEncryptedAESKey());
+            auto catArgs = tryGetEncryptedCATArgs(tx, _proposal->getEpochID());
+
+            if (catArgs) {
+                auto txCiphertexts = make_shared<TransactionCiphertexts>(catArgs);
+                encryptedAESKeyMap->emplace(index, txCiphertexts);
+            } else {
+                // the first non-CAT transaction indicates the start of regular transactions
+                regularTxsStartIdx = i;
+                break;
             }
-            index = index + 1;
+        } catch (exception &e) {
+            CONS_LOG(err, string("Could not parse CAT transaction:") + e.what());
+            _proposal->getFailedTransactionsRef().emplace(i,
+                                                          ConnectionSubStatus::CONNECTION_ERROR_CANT_PARSE_PROPOSAL_TRANSACTION);
+        }
+    }
+#endif
+                
+    // Parse regular txs
+    for (size_t i = regularTxsStartIdx; i < transactions->size(); i++) {
+        try {
+            auto tx = transactions->at(i);
+            auto ciphertext = tryGetEncryptedRegularTxFields(tx, _proposal->getEpochID());
+            if (ciphertext) {
+                auto txCiphertexts = make_shared<TransactionCiphertexts>(ciphertext);
+                encryptedAESKeyMap->emplace(index, txCiphertexts);
+            }
         } catch (exception &e) {
             CONS_LOG(err, string("Could not parse transaction:") + e.what());
-            _proposal->getFailedTransactionsRef().emplace(index,
+            _proposal->getFailedTransactionsRef().emplace(i,
                                                           ConnectionSubStatus::CONNECTION_ERROR_CANT_PARSE_PROPOSAL_TRANSACTION);
         }
     }
@@ -108,7 +181,7 @@ void BiteManager::parseBITETransactions(
     }
 
 
-    _proposal->setAESKeyMap(encryptedAESKeyMap);
+    _proposal->setTransactionCiphertexts(encryptedAESKeyMap);
 }
 
 void BiteManager::callSGXToCreateMyDecryptionSharesForProposalTransactions(
@@ -131,12 +204,11 @@ void BiteManager::callSGXToCreateMyDecryptionSharesForProposalTransactions(
 
     CHECK_STATE(transactions);
 
-
     if (!_proposal->getFailedTransactionsRef().empty()) {
         return;
     }
 
-    CHECK_STATE(_proposal->getEncryptedAESKeys());
+    CHECK_STATE(_proposal->getTransactionCiphertexts());
 
 
     // this function will not throw exception
@@ -147,7 +219,7 @@ void BiteManager::callSGXToCreateMyDecryptionSharesForProposalTransactions(
         return;
     }
     CHECK_STATE(decryptionShareList);
-    CHECK_STATE(decryptionShareList->getSize() == _proposal->getEncryptedAESKeys()->size());
+    CHECK_STATE(decryptionShareList->totalCiphertextSharesCount() == _proposal->getTransactionCiphertexts()->totalCiphertextCount());
     // no we know that the decryption shares are valid, we can set them to the proposal
     // now we set the decryption shares list to the block proposal so it is committed to the
     // database when proposal is committed
@@ -167,20 +239,19 @@ ptr<AESKeyDecryptionShareList> BiteManager::getDecryptionSharesForProposal(ptr<B
             _proposal->getBlockID(),
             _proposal->getProposerIndex(), schain.getSchainIndex());
 
-    ptr<vector<ptr<AESKeyDecryptionShare> > > decryptionSharesVector = getDecryptionSharesFromAESKeys(
+    ptr<vector<ptr<AESKeyDecryptionShares> > > decryptionSharesVector = getDecryptionSharesFromAESKeys(
             _proposal, schain.getSchainIndex());
 
     if (!decryptionSharesVector) {
         return nullptr;
     }
 
-    CHECK_STATE(decryptionSharesVector->size() == _proposal->getEncryptedAESKeys()->size());
-
+    CHECK_STATE(decryptionSharesVector->size() == _proposal->getTransactionCiphertexts()->size());
 
     auto arrayIndex = 0;
-    for (auto &&iterator: *_proposal->getEncryptedAESKeys()) {
+    for (auto &&[txIdx, ciphertexts]: *_proposal->getTransactionCiphertexts()) {
         auto AESKeyDecryptionShare = (*decryptionSharesVector)[arrayIndex];
-        decryptionShareList->addShare(iterator.first, decryptionSharesVector->at(arrayIndex));
+        decryptionShareList->addShares(txIdx, decryptionSharesVector->at(arrayIndex));
         arrayIndex++;
     }
 
@@ -188,30 +259,73 @@ ptr<AESKeyDecryptionShareList> BiteManager::getDecryptionSharesForProposal(ptr<B
 }
 
 
-ptr<vector<ptr<AESKeyDecryptionShare> > > BiteManager::getDecryptionSharesFromAESKeys(
+ptr<vector<ptr<AESKeyDecryptionShares> > > BiteManager::getDecryptionSharesFromAESKeys(
         ptr<BlockProposal> _proposal, schain_index _decryptorIndex) {
     MONITOR2(__CLASS_NAME__, __FUNCTION__, schain.getMaxExternalBlockProcessingTime())
 
     CHECK_STATE(_proposal);
 
-    auto encryptedAESKeys = _proposal->getEncryptedAESKeys();
-    CHECK_STATE(encryptedAESKeys);
+    auto ciphertexts = _proposal->getTransactionCiphertexts();
+    CHECK_STATE(ciphertexts);
+
+    auto shares = make_shared<vector<ptr<AESKeyDecryptionShares> > >();
+    shares->reserve(ciphertexts->size()); // for number of txs
+
+    // define how to add share depending on real or mockup crypto
+    // EncryptedAESKey is the current ciphertext being processed (may be multiple per tx)
+    // size_t is the global ciphertext
+    std::function<void(ptr<AESKeyDecryptionShares>&, EncryptedAESKey&, size_t)> addShareForCurrentTx;
 
     if (doRealCrypto) {
-
+        // flatten out vec
         auto sgxAESKeyBatch = _proposal->getSGXAESKeyBatch();
 
         CHECK_STATE(sgxAESKeyBatch);
+        CHECK_STATE(sgxAESKeyBatch->size() == ciphertexts->totalCiphertextCount());
 
-        CHECK_STATE(sgxAESKeyBatch->size() == encryptedAESKeys->size());
-
-        return schain.getCryptoManager()->sgxDecryptAESKeyShareBatch(*sgxAESKeyBatch);
+        auto flatDecryptionShares = schain.getCryptoManager()->sgxDecryptAESKeyShareBatch(*sgxAESKeyBatch);
+        addShareForCurrentTx = [&](ptr<AESKeyDecryptionShares>& decryptSharesForTx, EncryptedAESKey&, size_t globalCiphertextIdxForCurrTx) {
+            decryptSharesForTx->push_back(flatDecryptionShares->at(globalCiphertextIdxForCurrTx));
+        };
     } else {
-        auto result = make_shared<vector<ptr<AESKeyDecryptionShare> > >();
-        for (auto && it: *encryptedAESKeys) {
-            result->push_back(MockupAESKeyDecryptionShare::mockupDecrypt(it.second, _decryptorIndex));
+        addShareForCurrentTx = [&](ptr<AESKeyDecryptionShares>& decryptSharesForTx, EncryptedAESKey& ciphertext, size_t) {
+            decryptSharesForTx->push_back(MockupAESKeyDecryptionShare::mockupDecrypt(ciphertext, _decryptorIndex));
+        }; 
+    }
+
+    // unflatten the shares into per-transaction vectors
+    size_t globalCiphertextIdx = 0;
+    for (auto && [idx, txCiphertexts]: *ciphertexts) { // for each tx
+        auto decryptSharesForTx = make_shared<AESKeyDecryptionShares>();
+        for (size_t i = 0; i < txCiphertexts->count(); ++i) { // for each ciphertext within the tx
+            auto currentCiphertextWithinTx = (*txCiphertexts)[i];
+            addShareForCurrentTx(decryptSharesForTx, currentCiphertextWithinTx, globalCiphertextIdx);
+            globalCiphertextIdx++;
         }
-        return result;
+        shares->push_back(decryptSharesForTx);
+    }
+
+    return shares;
+}
+
+/**
+ * @brief Helper function - appends ciphertexts from TransactionCiphertexts to vector of CipheredKey
+ */
+void appendCiphertextsToVector(ptr<TransactionCiphertexts> _ciphertexts, std::vector< libBLS::CipheredKey >& _vec, size_t& _ciphertextIdx) {
+    if (_ciphertexts->count() > 1) {
+        std::vector< libBLS::CipheredKey > cipheredKeysLocal;
+        cipheredKeysLocal.reserve(_ciphertexts->count());
+        for (const auto& encryptedKey : *_ciphertexts) {
+            auto cipheredKey = libBLS::CipheredKey::fromBytes(encryptedKey.data());
+            cipheredKeysLocal.push_back(cipheredKey);
+            _ciphertextIdx++;
+        }
+        // Only insert all after all have been successfully created (there could be exceptions thrown)
+        _vec.insert(_vec.end(), cipheredKeysLocal.begin(), cipheredKeysLocal.end());
+    }
+    else {
+        auto cipheredKey = libBLS::CipheredKey::fromBytes((*_ciphertexts)[0].data());
+        _vec.push_back(cipheredKey);
     }
 }
 
@@ -222,25 +336,30 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
 
     CHECK_STATE(_proposal);
 
-    auto encryptedAESKeys = _proposal->getEncryptedAESKeys();
+    ptr<TransactionCiphertextsMap> txsCiphertexts = _proposal->getTransactionCiphertexts();
     auto failedTransactionRef = _proposal->getFailedTransactionsRef();
-    auto publicDecryptionValues = make_shared<vector<ptr<string>>>();
-    publicDecryptionValues->resize(encryptedAESKeys->size());
+    auto publicDecryptionValues = make_shared<vector<string>>();
 
     std::vector< transaction_index > validGlobalIndices; // global indices of all valid txs
     std::vector< libBLS::CipheredKey > cipheredKeys;
-    cipheredKeys.reserve(encryptedAESKeys->size());
 
-    for ( auto && it: *encryptedAESKeys) {
+    publicDecryptionValues->reserve(txsCiphertexts->totalCiphertextCount());
+    cipheredKeys.reserve(txsCiphertexts->totalCiphertextCount());
+
+    for ( auto && it: *txsCiphertexts) {
+        size_t failingIdx = 0; // ciphertext idx for each tx starts at 0
         try {
-            auto encryptedAESKey = it.second;
-            CHECK_STATE(encryptedAESKey)
-            auto cipheredKey = libBLS::CipheredKey::fromBytes(*encryptedAESKey->getKey());
-            cipheredKeys.push_back(cipheredKey);
-            validGlobalIndices.push_back(it.first);
+            ptr<TransactionCiphertexts> ciphertexts = it.second;
+            CHECK_STATE(ciphertexts)
+            
+            appendCiphertextsToVector(ciphertexts, cipheredKeys, failingIdx);
+
+            for (size_t i = 0; i < ciphertexts->count(); ++i) {
+                validGlobalIndices.push_back(it.first); // repeat global index for each ciphertext
+            }
         }
         catch (exception &_e) {
-            CONS_LOG(err, fmt::format( "Could not build transaction from bytes: {} : {}" , static_cast<std::uint32_t>(it.first), _e.what()));
+            CONS_LOG(err, fmt::format( "Could not build ciphertext {} of transaction {} from bytes: {}" , failingIdx, static_cast<std::uint32_t>(it.first), _e.what()));
             failedTransactionRef.emplace(it.first,
                                             ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
         }
@@ -252,26 +371,28 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
     // If at least 1 is not valid - mark as failed, log and return
     bool allValid = std::all_of(validationResult.begin(), validationResult.end(),
                                   [](bool v) { return v; });
+
+    // some transactions failed validationgetDecryptionSharesFromAESKeys
     if (!allValid) {
-        // some transactions failed validation
-        for (size_t i = 0; i < validationResult.size(); ++i) {
-            if (!validationResult[i]) {
-                auto globalIndex = validGlobalIndices[i];
-                CONS_LOG(err, fmt::format("AES key encryption validation failed for transaction: {}", static_cast<std::uint32_t>(globalIndex)));
-                failedTransactionRef.emplace(globalIndex,
-                                                ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
+        size_t ciphertextGlobalIdx = 0;
+        for (auto& [idx, ciphertexts] : *txsCiphertexts) {
+            size_t numCiphertexts = ciphertexts->count();
+            for (size_t i = 0; i < numCiphertexts; ++i) {
+                if (!validationResult[ciphertextGlobalIdx]) {
+                    CONS_LOG(err, fmt::format("AES key encryption validation failed for ciphertext {} of transaction {}", i, (uint32_t)idx));
+                    failedTransactionRef.emplace(idx,
+                                                    ConnectionSubStatus::CONNECTION_ERROR_INVALID_AES_KEY_ENCRYPTION_IN_PROPOSAL_TRANSACTION);
+                }
+                ciphertextGlobalIdx++;
             }
         }
         return;
     }
 
     // convert to string all successful decryption shares
-    auto decryptionShareInput = libBLS::CipheredKey::getDecryptionShareInputBatch( cipheredKeys );
-
-    // set output decryption shares using global indices from all threads
-    for (size_t i = 0; i < cipheredKeys.size(); ++i) {
-        publicDecryptionValues->at(i) = make_shared<string>(decryptionShareInput[i]);
-    }
+    publicDecryptionValues = make_shared<vector<string>>(
+        libBLS::CipheredKey::getDecryptionShareInputBatch( cipheredKeys )
+    );
 
     _proposal->setSGXAESKeyBatch(publicDecryptionValues);
 }
@@ -279,11 +400,13 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
 
 
 ptr<DecryptedRegularTxsMap> BiteManager::verifyAndDecryptTransactionList(
-        TransactionList &_transactionList, DecryptedAESKeyList &_aesKeys) {
+        TransactionList &_transactionList,
+        DecryptedAESKeyList &_aesKeys) {
 
-    MONITOR( __CLASS_NAME__, __FUNCTION__ )
+    MONITOR(__CLASS_NAME__, __FUNCTION__);
 
-    auto decryptedFieldsMap = make_shared<DecryptedRegularTxsMap>();
+    auto decryptedFieldsMap = std::make_shared<DecryptedRegularTxsMap>();
+    auto catTxsMap          = std::make_shared<DecryptedCATxsMap>();
 
     auto txs = _transactionList.getItems();
     CHECK_STATE(txs);
@@ -291,64 +414,116 @@ ptr<DecryptedRegularTxsMap> BiteManager::verifyAndDecryptTransactionList(
     std::vector<folly::Future<folly::Unit>> futures;
     futures.reserve(_aesKeys.getSize());
 
-    std::mutex mapMutex;
+    std::mutex regularTxMapMutex;
+    std::mutex catTxsMapMutex;
+
+    // Helper to avoid repeating folly::via boilerplate
+    auto schedule = [&](auto &&fn) {
+        futures.emplace_back(
+            folly::via(threadPoolExecutor.get(), std::forward<decltype(fn)>(fn))
+        );
+    };
 
     try {
-        for (uint64_t i = 0; i < _transactionList.size(); i++) {
-            auto tx = txs->at(i);
-            auto bite = tryGetEncryptedRegularTxFields(tx, schain.getNode()->getCurrentEpochId());
+        const auto currentEpoch = schain.getNode()->getCurrentEpochId();
+        const std::size_t txCount = _transactionList.size();
+
+        for (std::size_t txIdx = 0; txIdx < txCount; ++txIdx) {
+            auto tx = txs->at(txIdx);
+
+#ifdef BITE2
+        bool allCATsParsed = false;
+            // ---------- Try CAT path first ----------
+            if (!allCATsParsed) {
+                auto encryptedArgs = tryGetEncryptedCATArgs(tx, currentEpoch);
+                if (encryptedArgs) {
+                    auto decryptedAESKey = _aesKeys.getKeys(txIdx);
+                    CHECK_STATE(decryptedAESKey);
+                    CHECK_STATE(encryptedArgs->size() == decryptedAESKey->size());
+
+                    try {
+                        schedule([this, encryptedArgs, decryptedAESKey, catTxsMap, txIdx, &catTxsMapMutex]() 
+                        -> folly::Unit {
+                            DecryptedCATArgs decryptedData;
+                            decryptedData.args.reserve(encryptedArgs->size());
+
+                            for (std::size_t argIdx = 0; argIdx < encryptedArgs->size(); ++argIdx) {
+                                decryptedData.args.push_back(
+                                    decryptCiphertext(
+                                        encryptedArgs->at(argIdx),
+                                        decryptedAESKey->at(argIdx)
+                                    )
+                                );
+                            }
+
+                            std::lock_guard<std::mutex> lock(catTxsMapMutex);
+                            catTxsMap->emplace(txIdx, std::move(decryptedData));
+
+                            return folly::unit;
+                        });
+                    } catch (const std::exception &e) {
+                        CONS_LOG(err, fmt::format("Corrupt CAT tx:{} that doesn't decrypt: {}", txIdx, e.what()));
+                    }
+
+                    // This tx is CAT, do not treat it as regular
+                    continue;
+                }
+                else {
+                    // No more CAT transactions expected after the first non-CAT one
+                    allCATsParsed = true;
+                }
+            }
+
+#endif // BITE2
+
+            // ---------- Regular BITE1-style encryption ----------
+            auto bite = tryGetEncryptedRegularTxFields(tx, currentEpoch);
             if (bite) {
-                auto decryptedAESKey = _aesKeys.getKey(i);
+                auto decryptedAESKey = _aesKeys.getKeys(txIdx);
                 CHECK_STATE(decryptedAESKey);
+                CHECK_STATE(decryptedAESKey->size() == 1); // single AES key expected
 
                 try {
-                    auto future = folly::via(threadPoolExecutor.get(), [this, bite, decryptedAESKey, &decryptedFieldsMap, i, &mapMutex]() -> folly::Unit {
-                        auto decryptedTransactionFields = decryptFields(bite, *decryptedAESKey);
-                        std::lock_guard<std::mutex> lock(mapMutex);
-                        decryptedFieldsMap->emplace(i, decryptedTransactionFields);
+                    schedule([this, bite, decryptedAESKey, decryptedFieldsMap, txIdx, &regularTxMapMutex]() 
+                    -> folly::Unit {
+                        auto decryptedTransactionFields =
+                            decryptCiphertext(bite, decryptedAESKey->at(0));
+
+                        auto parsedRegularTx =
+                            parseDecryptedDataAsRegularTx(decryptedTransactionFields);
+
+                        std::lock_guard<std::mutex> lock(regularTxMapMutex);
+                        decryptedFieldsMap->emplace(txIdx, std::move(parsedRegularTx));
+
                         return folly::unit;
                     });
-                    futures.push_back(std::move(future));
                 } catch (const std::exception &e) {
-                    CONS_LOG(err, fmt::format("Corrupt tx:{} that doesnt decrypt: {}", i, e.what()));
+                    CONS_LOG(err, fmt::format("Corrupt regular tx:{} that doesn't decrypt: {}", txIdx, e.what()));
                 }
-            } else {
-                CHECK_STATE(!_aesKeys.getKey(i));
+
+                continue;
             }
+
+            // ---------- No BITE data at all ----------
+            // If it's neither CAT nor regular encrypted, we must not have AES keys
+            CHECK_STATE(!_aesKeys.getKeys(txIdx));
         }
     }
     CATCH_LOG_AND_RETHROW_ANY_EXCEPTION(err, "Could not parse BITE transaction");
-    auto allResults = folly::collectAll(futures).get();
 
-    return decryptedFieldsMap;
+    folly::collectAll(futures).get();
+
+    return decryptedFieldsMap;  // catTxsMap is still local; decide its final ownership/model
 }
 
-DecryptedRegularTxFields BiteManager::decryptFields(const ptr<BiteCiphertext> &_bite, DecryptedAESKey &_decryptedAESKey) const {
-    CHECK_STATE(_bite);
 
-
-
-    ptr<vector<uint8_t> > biteDataField = nullptr;
-
-    if (doRealCrypto) {
-        auto encryptedData = _bite->getKeyPlusEncryptedData();
-        CHECK_STATE(encryptedData != nullptr);
-
-        libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes(*encryptedData);
-        biteDataField = make_shared<vector<uint8_t>>(
-                libBLS::ThresholdEncryption::decrypt(ciphertext, _decryptedAESKey.getAesKey()));
-    } else {
-        auto keyPlusEncryptedData = _bite->getKeyPlusEncryptedData();
-        CHECK_STATE(keyPlusEncryptedData);
-        auto decryptedOriginalDataField =
-                libBLS::ThresholdEncryption::mockupDecrypt(*keyPlusEncryptedData);
-        biteDataField = make_shared<vector<uint8_t> >(decryptedOriginalDataField);
-    }
-
-    CHECK_STATE2(biteDataField->size() >= ADDRESS_SIZE,
+DecryptedRegularTxFields BiteManager::parseDecryptedDataAsRegularTx(
+        const vector<uint8_t> &_data) const {
+    
+    CHECK_STATE2(_data.size() >= ADDRESS_SIZE,
                  "Decrypted data is not long enough to include the original tx.to field!");
 
-    RLPItem decryptedDataRlp(*biteDataField);
+    RLPItem decryptedDataRlp(_data);
     CHECK_STATE2(decryptedDataRlp.isList(), "Encrypted data rlp size must be a list");
     CHECK_STATE2(decryptedDataRlp.size() == 2,
                  "Encrypted data rlp lsit must have exactly 2 elements");
@@ -364,6 +539,25 @@ DecryptedRegularTxFields BiteManager::decryptFields(const ptr<BiteCiphertext> &_
     };
 
     return decryptedFields;
+}
+
+
+vector<uint8_t> BiteManager::decryptCiphertext(const ptr<BiteCiphertext> &_bite, DecryptedAESKey &_decryptedAESKey) const {
+    CHECK_STATE(_bite);
+
+    vector<uint8_t> decryptedData;
+
+    if (doRealCrypto) {
+        auto encryptedData = _bite->getKeyPlusEncryptedData();
+        CHECK_STATE(encryptedData != nullptr);
+
+        libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes(*encryptedData);
+        return libBLS::ThresholdEncryption::decrypt(ciphertext, _decryptedAESKey.getAesKey());
+    } else {
+        auto keyPlusEncryptedData = _bite->getKeyPlusEncryptedData();
+        CHECK_STATE(keyPlusEncryptedData);
+        return libBLS::ThresholdEncryption::mockupDecrypt(*keyPlusEncryptedData);
+    }
 }
 
 void BiteManager::corruptFromTimeToTime(shared_ptr<vector<unsigned char> >) {
@@ -407,23 +601,51 @@ ptr<vector<uint8_t> > BiteManager::teEncryptDataAndToAddress(const vector<uint8_
 }
 
 
-ptr<AESKeyDecryptionShare> BiteManager::createAESDecryptionShare(
-        const string& _aesKeyDecryptionShare, schain_index _decryptorIndex, bool _decryptionFailed) {
-    if (doRealCrypto) {
-        return make_shared<ConsensusAESKeyDecryptionShare>(
-                _aesKeyDecryptionShare, _decryptorIndex, _decryptionFailed);
-    } else {
-        return make_shared<MockupAESKeyDecryptionShare>(
-                _aesKeyDecryptionShare, _decryptorIndex, _decryptionFailed);
+
+// Helper function to split string_view by commas
+std::vector<std::string_view> splitByComma(std::string_view s) {
+    std::vector<std::string_view> out;
+
+    while (!s.empty()) {
+        size_t pos = s.find(',');
+        if (pos == std::string_view::npos) {
+            out.push_back(s);
+            break;
+        }
+        out.push_back(s.substr(0, pos));
+        s.remove_prefix(pos + 1);
     }
+
+    return out;
+}
+
+
+ptr<AESKeyDecryptionShares> BiteManager::createAESDecryptionShares(
+        const string& _aesKeyDecryptionShares, schain_index _decryptorIndex, bool _decryptionFailed) {
+    
+    ptr<AESKeyDecryptionShares> decryptionShares = make_shared<AESKeyDecryptionShares>();
+    auto decryptionSharesStrs = splitByComma(_aesKeyDecryptionShares);
+    for (const auto& shareStr : decryptionSharesStrs) {
+        std::string shareString(shareStr);
+        if (doRealCrypto) {
+            decryptionShares->push_back(
+                make_shared<ConsensusAESKeyDecryptionShare>(
+                    shareString, _decryptorIndex, _decryptionFailed));
+        } else {
+            decryptionShares->push_back(
+                make_shared<MockupAESKeyDecryptionShare>(
+                    shareString, _decryptorIndex, _decryptionFailed));
+        }
+    }
+    return decryptionShares;
 }
 
 
 ptr<AESKeyDecryptionShareSet> BiteManager::createAESDecryptionShareSet(
-        block_id _blockId, transaction_index _transactionIndex) {
+        block_id _blockId, transaction_index _transactionIndex, size_t numberOfCiphertexts) {
     if (doRealCrypto) {
         return make_shared<ConsensusAESKeyDecryptionShareSet>(
-                _blockId, _transactionIndex, schain.getTotalSigners(), schain.getRequiredSigners());
+                _blockId, _transactionIndex, numberOfCiphertexts, schain.getTotalSigners(), schain.getRequiredSigners());
     } else {
         return make_shared<MockupAESKeyDecryptionShareSet>(
                 _blockId, _transactionIndex, schain.getTotalSigners(), schain.getRequiredSigners());

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -476,6 +476,8 @@ DecryptedTransactions BiteManager::verifyAndDecryptTransactionList(
                         });
                     } catch (const std::exception &e) {
                         CONS_LOG(err, fmt::format("Corrupt CAT tx:{} that doesn't decrypt: {}", txIdx, e.what()));
+                        std::lock_guard<std::mutex> lock(catTxsMapMutex);
+                        catTxsMap->emplace(txIdx, std::nullopt);
                     }
 
                     // This tx is CAT, do not treat it as regular
@@ -512,6 +514,8 @@ DecryptedTransactions BiteManager::verifyAndDecryptTransactionList(
                     });
                 } catch (const std::exception &e) {
                     CONS_LOG(err, fmt::format("Corrupt regular tx:{} that doesn't decrypt: {}", txIdx, e.what()));
+                    std::lock_guard<std::mutex> lock(regularTxMapMutex);
+                    decryptedFieldsMap->emplace(txIdx, std::nullopt);
                 }
 
                 continue;

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -97,11 +97,11 @@ ptr<std::vector<ptr<BiteCiphertext>>> BiteManager::tryGetEncryptedCATArgs(
         CHECK_STATE(dataField);
 
         // compare first 4 bytes to BITE2 expected function selector
-        if (dataField->size() < BITE_FUNCTION_SELECTOR_SIZE_BYTES || 
+        if (dataField->size() < BITE2_FUNCTION_SELECTOR_SIZE_BYTES || 
             std::memcmp(
                 dataField->data(),
                 BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY,
-                BITE_FUNCTION_SELECTOR_SIZE_BYTES
+                BITE2_FUNCTION_SELECTOR_SIZE_BYTES
             ) != 0
         ) {
             return nullptr;
@@ -111,7 +111,7 @@ ptr<std::vector<ptr<BiteCiphertext>>> BiteManager::tryGetEncryptedCATArgs(
         // Data comes as:
         // [funcSelector, RLP( RLP(cipher1, cipher2, ...), RLP(plaintext1, plaintext2, ...) )]
         // offset function selector
-        auto dataWithoutSelector = std::vector<uint8_t>(dataField->begin() + BITE_FUNCTION_SELECTOR_SIZE_BYTES, dataField->end());
+        auto dataWithoutSelector = std::vector<uint8_t>(dataField->begin() + BITE2_FUNCTION_SELECTOR_SIZE_BYTES, dataField->end());
         RLPItem rlpItem(dataWithoutSelector);
         CHECK_STATE(rlpItem.isList());
         CHECK_STATE(rlpItem.size() == 2); // RLP(ciphertexts, plaintexts)
@@ -406,8 +406,8 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
 
 
 DecryptedTransactions BiteManager::verifyAndDecryptTransactionList(
-        TransactionList &_transactionList,
-        DecryptedAESKeyList &_aesKeys) {
+        const TransactionList &_transactionList,
+        const DecryptedAESKeyList &_aesKeys) {
 
     MONITOR(__CLASS_NAME__, __FUNCTION__);
 
@@ -562,7 +562,7 @@ DecryptedRegularTxFields BiteManager::parseDecryptedDataAsRegularTx(
 }
 
 
-vector<uint8_t> BiteManager::decryptCiphertext(const ptr<BiteCiphertext> &_bite, DecryptedAESKey &_decryptedAESKey) const {
+vector<uint8_t> BiteManager::decryptCiphertext(const ptr<BiteCiphertext> &_bite, const DecryptedAESKey &_decryptedAESKey) const {
     CHECK_STATE(_bite);
 
     vector<uint8_t> decryptedData;
@@ -663,13 +663,13 @@ ptr<vector<uint8_t> > BiteManager::generateEncryptedCATData() {
     auto finalData = allArgs.encode();
 
     std::vector<uint8_t> data;
-    data.reserve(BITE_FUNCTION_SELECTOR_SIZE_BYTES + finalData.size());
+    data.reserve(BITE2_FUNCTION_SELECTOR_SIZE_BYTES + finalData.size());
 
     // prefix with function selector 
     data.insert(
         data.end(),
         BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY,
-        BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY + BITE_FUNCTION_SELECTOR_SIZE_BYTES
+        BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY + BITE2_FUNCTION_SELECTOR_SIZE_BYTES
     );
 
     // append RLP data

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -23,6 +23,7 @@
 #include "rlp/ParsedEthTransaction.h"
 
 #include "BiteManager.h"
+#include "node/ConsensusInterface.h"
 
 #include <crypto/ConsensusAESKeyDecryptionShare.h>
 #include <crypto/ConsensusAESKeyDecryptionShareSet.h>
@@ -94,15 +95,18 @@ ptr<std::vector<ptr<BiteCiphertext>>> BiteManager::tryGetEncryptedCATArgs(
 
         // compare first 4 bytes to BITE2 expected function selector
         if (dataField->size() < BITE_FUNCTION_SELECTOR_SIZE_BYTES || 
-            !std::equal(BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY, BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY + BITE_FUNCTION_SELECTOR_SIZE_BYTES,
-                        dataField->begin())) {
+            std::memcmp(
+                dataField->data(),
+                BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY,
+                BITE_FUNCTION_SELECTOR_SIZE_BYTES
+            ) != 0
+        ) {
             return nullptr;
         }
 
         // Parse args as RLP list
         // Data comes as:
         // [funcSelector, RLP( RLP(cipher1, cipher2, ...), RLP(plaintext1, plaintext2, ...) )]
-
         // offset function selector
         auto dataWithoutSelector = std::vector<uint8_t>(dataField->begin() + BITE_FUNCTION_SELECTOR_SIZE_BYTES, dataField->end());
         RLPItem rlpItem(dataWithoutSelector);
@@ -143,7 +147,7 @@ void BiteManager::parseBITETransactions(
             auto catArgs = tryGetEncryptedCATArgs(tx, _proposal->getEpochID());
 
             if (catArgs) {
-                auto txCiphertexts = make_shared<TransactionCiphertexts>(catArgs);
+                auto txCiphertexts = make_shared<TransactionCiphertexts>(*catArgs);
                 encryptedAESKeyMap->emplace(i, txCiphertexts);
             } else {
                 // the first non-CAT transaction indicates the start of regular transactions
@@ -157,7 +161,7 @@ void BiteManager::parseBITETransactions(
         }
     }
 #endif
-                
+
     // Parse regular txs
     for (size_t i = regularTxsStartIdx; i < transactions->size(); i++) {
         try {
@@ -398,14 +402,19 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
 
 
 
-ptr<DecryptedRegularTxsMap> BiteManager::verifyAndDecryptTransactionList(
+DecryptedTransactions BiteManager::verifyAndDecryptTransactionList(
         TransactionList &_transactionList,
         DecryptedAESKeyList &_aesKeys) {
 
     MONITOR(__CLASS_NAME__, __FUNCTION__);
 
     auto decryptedFieldsMap = std::make_shared<DecryptedRegularTxsMap>();
+    std::mutex regularTxMapMutex;
+    
+#ifdef BITE2
     auto catTxsMap          = std::make_shared<DecryptedCATxsMap>();
+    std::mutex catTxsMapMutex;
+#endif
 
     auto txs = _transactionList.getItems();
     CHECK_STATE(txs);
@@ -413,8 +422,7 @@ ptr<DecryptedRegularTxsMap> BiteManager::verifyAndDecryptTransactionList(
     std::vector<folly::Future<folly::Unit>> futures;
     futures.reserve(_aesKeys.getSize());
 
-    std::mutex regularTxMapMutex;
-    std::mutex catTxsMapMutex;
+
 
     // Helper to avoid repeating folly::via boilerplate
     auto schedule = [&](auto &&fn) {
@@ -515,7 +523,12 @@ ptr<DecryptedRegularTxsMap> BiteManager::verifyAndDecryptTransactionList(
 
     folly::collectAll(futures).get();
 
-    return decryptedFieldsMap;  // catTxsMap is still local; decide its final ownership/model
+    return DecryptedTransactions(
+#ifdef BITE2 
+        catTxsMap,
+#endif 
+        decryptedFieldsMap 
+    );
 }
 
 
@@ -579,21 +592,23 @@ void BiteManager::corruptFromTimeToTime(shared_ptr<vector<unsigned char> >) {
     }
 }
 
-ptr<vector<uint8_t> > BiteManager::teEncryptDataAndToAddress(const vector<uint8_t> &_data, const vector<uint8_t> &_to) {
+ptr<vector<uint8_t>> BiteManager::encryptData(const vector<uint8_t>& data) {
+    auto [primaryKey, secondaryKey] = schain.getCryptoManager()->getSgxBlsPublicKey();
+    CHECK_STATE(primaryKey);
+    auto blsKey = primaryKey->getPublicKey();
+    libBLS::TEPublicKey teKey(blsKey);
+
+    auto cipherText = libBLS::ThresholdEncryption::encrypt(data, teKey);
+    return std::make_shared<vector<uint8_t>>(cipherText.toBytes());
+}
+
+ptr<vector<uint8_t> > BiteManager::encryptRegularTx(const vector<uint8_t> &_data, const vector<uint8_t> &_to) {
     // RLP encode
     RLPStream stream;
     stream << _data << _to;
 
     if (this->doRealCrypto) {
-        auto [primaryKey, secondaryKey] = schain.getCryptoManager()->getSgxBlsPublicKey();
-        CHECK_STATE(primaryKey);
-        auto blsKey = primaryKey->getPublicKey();
-        libBLS::TEPublicKey teKey(blsKey);
-
-        auto cipherText = libBLS::ThresholdEncryption::encrypt(stream.encode(), teKey);
-        auto bytes = std::make_shared<vector<uint8_t>>(cipherText.toBytes());
-
-
+        auto bytes = encryptData(stream.encode());
         corruptFromTimeToTime(bytes);
 
         return bytes;
@@ -601,6 +616,63 @@ ptr<vector<uint8_t> > BiteManager::teEncryptDataAndToAddress(const vector<uint8_
         return make_shared<vector<uint8_t> >(libBLS::ThresholdEncryption::mockupEncrypt(stream.encode()));
     }
 }
+
+#ifdef BITE2
+ptr<vector<uint8_t> > BiteManager::generateEncryptedCATData() {
+    static size_t numberOfCiphertexts = 2;
+
+    // Keep ciphertext count between 3 and 5 (inclusive)
+    numberOfCiphertexts++;
+    if (numberOfCiphertexts % 6 == 0) {
+        numberOfCiphertexts = 2;
+    }
+
+    RLPStream allArgs;
+    
+    RLPStream encryptedArgs;
+    for (size_t i = 0; i < numberOfCiphertexts; ++i) {
+        std::vector<uint8_t> rndData;
+        std::vector<uint8_t> encryptedData;
+        rndData.resize(numberOfCiphertexts * 10);
+        if (this->doRealCrypto) {
+            encryptedData = *encryptData(rndData);
+        }
+        else {
+            encryptedData = libBLS::ThresholdEncryption::mockupEncrypt(rndData);
+        }
+        BiteCiphertext biteCiphertext(
+            make_shared<vector<uint8_t>>(std::move(encryptedData)),
+            0 // epoch id not relevant here
+        );
+        encryptedArgs << *biteCiphertext.getSerializedData();
+    }
+    RLPStream plainArgs;
+    size_t numPlaintexts = numberOfCiphertexts - 1;
+    for (size_t i = 0; i < numPlaintexts; ++i) {
+        std::vector<uint8_t> rndData;
+        rndData.resize(numberOfCiphertexts * 5);
+        plainArgs << rndData;
+    }
+
+    allArgs << encryptedArgs << plainArgs;
+    auto finalData = allArgs.encode();
+
+    std::vector<uint8_t> data;
+    data.reserve(BITE_FUNCTION_SELECTOR_SIZE_BYTES + finalData.size());
+
+    // prefix with function selector 
+    data.insert(
+        data.end(),
+        BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY,
+        BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY + BITE_FUNCTION_SELECTOR_SIZE_BYTES
+    );
+
+    // append RLP data
+    data.insert(data.end(), finalData.begin(), finalData.end());
+
+    return std::make_shared<std::vector<uint8_t>>(std::move(data));
+}
+#endif
 
 
 

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -128,12 +128,11 @@ ptr<std::vector<ptr<BiteCiphertext>>> BiteManager::tryGetEncryptedCATArgs(
 
 void BiteManager::parseBITETransactions(
     ptr<BlockProposal> _proposal) {
-    transaction_index index = 0;
 
     auto encryptedAESKeyMap = make_shared<TransactionCiphertextsMap>();
     auto biteDataFields     = make_shared<std::map<transaction_index, ptr<BiteCiphertext> > >();
 
-    bool regularTxsStartIdx = 0;
+    size_t regularTxsStartIdx = 0;
     ptr<vector<ptr<Transaction> > > transactions = _proposal->getTransactionList()->getItems(); 
 
 #ifdef BITE2
@@ -145,7 +144,7 @@ void BiteManager::parseBITETransactions(
 
             if (catArgs) {
                 auto txCiphertexts = make_shared<TransactionCiphertexts>(catArgs);
-                encryptedAESKeyMap->emplace(index, txCiphertexts);
+                encryptedAESKeyMap->emplace(i, txCiphertexts);
             } else {
                 // the first non-CAT transaction indicates the start of regular transactions
                 regularTxsStartIdx = i;
@@ -166,7 +165,7 @@ void BiteManager::parseBITETransactions(
             auto ciphertext = tryGetEncryptedRegularTxFields(tx, _proposal->getEpochID());
             if (ciphertext) {
                 auto txCiphertexts = make_shared<TransactionCiphertexts>(ciphertext);
-                encryptedAESKeyMap->emplace(index, txCiphertexts);
+                encryptedAESKeyMap->emplace(i, txCiphertexts);
             }
         } catch (exception &e) {
             CONS_LOG(err, string("Could not parse transaction:") + e.what());

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -11,7 +11,7 @@
 #include <crypto/MockupAESKeyDecryptionShareSet.h>
 #include <algorithm>
 
-#include "BiteDataField.h"
+#include "BiteCiphertext.h"
 #include "datastructures/BlockProposal.h"
 #include "datastructures/Transaction.h"
 #include "datastructures/TransactionList.h"
@@ -36,7 +36,7 @@ BiteManager::BiteManager(Schain &_schain) : schain(_schain) {
 }
 
 
-ptr<BiteDataField> BiteManager::tryGetEncryptedRegularTxFields(
+ptr<BiteCiphertext> BiteManager::tryGetEncryptedRegularTxFields(
             const ptr<Transaction> &_transaction, epoch_id _currentEpochId) {
     CHECK_STATE(_transaction);
 
@@ -50,7 +50,7 @@ ptr<BiteDataField> BiteManager::tryGetEncryptedRegularTxFields(
 
     auto ethTx = _transaction->getAsEthereumTransaction();
     
-    ptr<BiteDataField> result;
+    ptr<BiteCiphertext> result;
     if (ethTx->hasToField()) {
         
         auto to = ethTx->getToField();
@@ -65,7 +65,7 @@ ptr<BiteDataField> BiteManager::tryGetEncryptedRegularTxFields(
         auto dataField = ethTx->getTransactionDataField();
         CHECK_STATE(dataField);
 
-        result = ptr<BiteDataField>(new BiteDataField(dataField, _currentEpochId));
+        result = ptr<BiteCiphertext>(new BiteCiphertext(dataField, _currentEpochId));
         _transaction->setRegularTxEncryptedData(result); // cache it
     }
 
@@ -73,7 +73,7 @@ ptr<BiteDataField> BiteManager::tryGetEncryptedRegularTxFields(
 }
 
 
-ptr<std::vector<BiteDataField>> BiteManager::tryGetEncryptedCATArgs(
+ptr<std::vector<BiteCiphertext>> BiteManager::tryGetEncryptedCATArgs(
             const ptr<Transaction> &, epoch_id ) {
     // TODO
 }
@@ -84,7 +84,7 @@ void BiteManager::parseBITETransactions(
     transaction_index index = 0;
 
     auto encryptedAESKeyMap = make_shared<EncryptedAESKeyMap>();
-    auto biteDataFields     = make_shared<std::map<transaction_index, ptr<BiteDataField> > >();
+    auto biteDataFields     = make_shared<std::map<transaction_index, ptr<BiteCiphertext> > >();
 
     ptr<vector<ptr<Transaction> > > transactions = _proposal->getTransactionList()->getItems();
     for (size_t i = 0; i < transactions->size(); i++) {
@@ -323,7 +323,7 @@ ptr<DecryptedRegularTxsMap> BiteManager::verifyAndDecryptTransactionList(
     return decryptedFieldsMap;
 }
 
-DecryptedRegularTxFields BiteManager::decryptFields(const ptr<BiteDataField> &_bite, DecryptedAESKey &_decryptedAESKey) const {
+DecryptedRegularTxFields BiteManager::decryptFields(const ptr<BiteCiphertext> &_bite, DecryptedAESKey &_decryptedAESKey) const {
     CHECK_STATE(_bite);
 
 

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -283,11 +283,11 @@ ptr<vector<ptr<AESKeyDecryptionShares> > > BiteManager::getDecryptionSharesFromA
         CHECK_STATE(sgxAESKeyBatch->size() == ciphertexts->totalCiphertextCount());
 
         auto flatDecryptionShares = schain.getCryptoManager()->sgxDecryptAESKeyShareBatch(*sgxAESKeyBatch);
-        addShareForCurrentTx = [&](ptr<AESKeyDecryptionShares>& decryptSharesForTx, EncryptedAESKey&, size_t globalCiphertextIdxForCurrTx) {
+        addShareForCurrentTx = [flatDecryptionShares](ptr<AESKeyDecryptionShares>& decryptSharesForTx, EncryptedAESKey&, size_t globalCiphertextIdxForCurrTx) {
             decryptSharesForTx->push_back(flatDecryptionShares->at(globalCiphertextIdxForCurrTx));
         };
     } else {
-        addShareForCurrentTx = [&](ptr<AESKeyDecryptionShares>& decryptSharesForTx, EncryptedAESKey& ciphertext, size_t) {
+        addShareForCurrentTx = [_decryptorIndex](ptr<AESKeyDecryptionShares>& decryptSharesForTx, EncryptedAESKey& ciphertext, size_t) {
             decryptSharesForTx->push_back(MockupAESKeyDecryptionShare::mockupDecrypt(ciphertext, _decryptorIndex));
         }; 
     }
@@ -427,11 +427,14 @@ ptr<DecryptedRegularTxsMap> BiteManager::verifyAndDecryptTransactionList(
         const auto currentEpoch = schain.getNode()->getCurrentEpochId();
         const std::size_t txCount = _transactionList.size();
 
+#ifdef BITE2
+        bool allCATsParsed = false;
+#endif
+
         for (std::size_t txIdx = 0; txIdx < txCount; ++txIdx) {
             auto tx = txs->at(txIdx);
 
 #ifdef BITE2
-        bool allCATsParsed = false;
             // ---------- Try CAT path first ----------
             if (!allCATsParsed) {
                 auto encryptedArgs = tryGetEncryptedCATArgs(tx, currentEpoch);

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -11,7 +11,7 @@
 #include <crypto/MockupAESKeyDecryptionShareSet.h>
 #include <algorithm>
 
-#include "BiteDataFiled.h"
+#include "BiteDataField.h"
 #include "datastructures/BlockProposal.h"
 #include "datastructures/Transaction.h"
 #include "datastructures/TransactionList.h"
@@ -36,22 +36,61 @@ BiteManager::BiteManager(Schain &_schain) : schain(_schain) {
 }
 
 
+ptr<BiteDataField> BiteManager::tryGetEncryptedRegularTxFields(
+            const ptr<Transaction> &_transaction, epoch_id _currentEpochId) {
+    CHECK_STATE(_transaction);
+
+    auto encryptedRegularTxData = _transaction->getRegularTxEncryptedData();
+
+    if (encryptedRegularTxData) {
+        return encryptedRegularTxData;
+    }
+
+    // if not set bite data already - try parse it
+
+    auto ethTx = _transaction->getAsEthereumTransaction();
+    
+    ptr<BiteDataField> result;
+    if (ethTx->hasToField()) {
+        
+        auto to = ethTx->getToField();
+        CHECK_STATE(to);
+
+        // compare _to field to BITE magic number
+        if (!std::equal(BITE_ADDRESS_AS_BYTE_ARRAY, BITE_ADDRESS_AS_BYTE_ARRAY + ADDRESS_SIZE,
+                        to->begin())) {
+            return nullptr;
+        }
+
+        auto dataField = ethTx->getTransactionDataField();
+        CHECK_STATE(dataField);
+
+        result = ptr<BiteDataField>(new BiteDataField(dataField, _currentEpochId));
+        _transaction->setRegularTxEncryptedData(result); // cache it
+    }
+
+    return result;
+}
+
+
+ptr<std::vector<BiteDataField>> BiteManager::tryGetEncryptedCATArgs(
+            const ptr<Transaction> &, epoch_id ) {
+    // TODO
+}
+
+
 void BiteManager::parseBITETransactions(
     ptr<BlockProposal> _proposal) {
-    // do simple parsing and validation of BITE format
-    // unparsable transactions will be added to failedTransactions
-    // transactions starting from the magic number but with incorrect format will be added
-    // to failedTransactions
     transaction_index index = 0;
 
     auto encryptedAESKeyMap = make_shared<EncryptedAESKeyMap>();
+    auto biteDataFields     = make_shared<std::map<transaction_index, ptr<BiteDataField> > >();
 
-    auto biteDataFields = make_shared<std::map<transaction_index, ptr<BiteDataField> > >();
-
-    for (auto &tx: *_proposal->getTransactionList()->getItems()) {
+    ptr<vector<ptr<Transaction> > > transactions = _proposal->getTransactionList()->getItems();
+    for (size_t i = 0; i < transactions->size(); i++) {
         try {
-            tx->parseAndValidate();
-            auto biteDataField = tx->tryGetBiteData(_proposal->getEpochID());
+            auto tx = transactions->at(i);
+            auto biteDataField = tryGetEncryptedRegularTxFields(tx, _proposal->getEpochID());
             if (biteDataField) {
                 encryptedAESKeyMap->emplace(index, biteDataField->getEncryptedAESKey());
             }
@@ -238,12 +277,13 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
 }
 
 
-ptr<DecryptedTransactionFieldsMap> BiteManager::verifyAndDecryptTransactionList(
+
+ptr<DecryptedRegularTxsMap> BiteManager::verifyAndDecryptTransactionList(
         TransactionList &_transactionList, DecryptedAESKeyList &_aesKeys) {
 
     MONITOR( __CLASS_NAME__, __FUNCTION__ )
 
-    auto decryptedFieldsMap = make_shared<DecryptedTransactionFieldsMap>();
+    auto decryptedFieldsMap = make_shared<DecryptedRegularTxsMap>();
 
     auto txs = _transactionList.getItems();
     CHECK_STATE(txs);
@@ -256,8 +296,7 @@ ptr<DecryptedTransactionFieldsMap> BiteManager::verifyAndDecryptTransactionList(
     try {
         for (uint64_t i = 0; i < _transactionList.size(); i++) {
             auto tx = txs->at(i);
-            tx->parseAndValidate();
-            auto bite = tx->tryGetBiteData(schain.getNode()->getCurrentEpochId());
+            auto bite = tryGetEncryptedRegularTxFields(tx, schain.getNode()->getCurrentEpochId());
             if (bite) {
                 auto decryptedAESKey = _aesKeys.getKey(i);
                 CHECK_STATE(decryptedAESKey);
@@ -284,8 +323,7 @@ ptr<DecryptedTransactionFieldsMap> BiteManager::verifyAndDecryptTransactionList(
     return decryptedFieldsMap;
 }
 
-DecryptedTransactionFields
-BiteManager::decryptFields(const ptr<BiteDataField> &_bite, DecryptedAESKey &_decryptedAESKey) const {
+DecryptedRegularTxFields BiteManager::decryptFields(const ptr<BiteDataField> &_bite, DecryptedAESKey &_decryptedAESKey) const {
     CHECK_STATE(_bite);
 
 
@@ -315,12 +353,14 @@ BiteManager::decryptFields(const ptr<BiteDataField> &_bite, DecryptedAESKey &_de
     CHECK_STATE2(decryptedDataRlp.size() == 2,
                  "Encrypted data rlp lsit must have exactly 2 elements");
     // extract decrypted data and to fields
-    ptr<vector<uint8_t> > dataField = make_shared<std::vector<uint8_t> >(decryptedDataRlp[0].asBytes());
-    ptr<vector<uint8_t> > toField = make_shared<std::vector<uint8_t> >(decryptedDataRlp[1].asBytes());
+    vector<uint8_t> dataField = decryptedDataRlp[0].asBytes();
+    
+    std::array<uint8_t, 20> toField;
+    std::copy(decryptedDataRlp[1].asBytes().begin(), decryptedDataRlp[1].asBytes().end(), toField.begin());
 
-    auto decryptedFields = DecryptedTransactionFields{
-            .data = dataField,
-            .to = toField,
+    auto decryptedFields = DecryptedRegularTxFields {
+            .data = std::move(decryptedDataRlp[0].asBytes()),
+            .to = std::move(toField),
     };
 
     return decryptedFields;

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -19,7 +19,7 @@ class DecryptedAESKeyList;
 
 class AESKeyDecryptionShareList;
 
-class BiteDataField;
+class BiteCiphertext;
 
 class TransactionList;
 
@@ -52,14 +52,14 @@ public:
     static void parseBITETransactions(ptr<BlockProposal> _proposal);
 
     // Tries to match the TO field to BITE1 magic number. If it matches - tries to parse the BITE1 data field.
-    // If parsing is successful - returns BiteDataField object, else returns 'nullopt'
-    static ptr<BiteDataField> tryGetEncryptedRegularTxFields(
+    // If parsing is successful - returns BiteCiphertext object, else returns 'nullopt'
+    static ptr<BiteCiphertext> tryGetEncryptedRegularTxFields(
             const ptr<Transaction> &_transaction, epoch_id _currentEpochId);
 
     // Tries to match the beginning of DATA field to BITE2 function selector.
     // If it matches - tries to parse the BITE2 data field(s) for encrypted call arguments.
-    // If parsing is successful - returns vector of BiteDataField objects, else returns 'nullopt'
-    static ptr<std::vector<BiteDataField>> tryGetEncryptedCATArgs(
+    // If parsing is successful - returns vector of BiteCiphertext objects, else returns 'nullopt'
+    static ptr<std::vector<BiteCiphertext>> tryGetEncryptedCATArgs(
             const ptr<Transaction> &_transaction, epoch_id _currentEpochId);
 
     // =============== Ciphertext Parsing =============== //
@@ -92,7 +92,7 @@ public:
             block_id _blockId, transaction_index _transactionIndex);
 
     // TODO - change the name of this method - should be made generic for both BITE1 & BITE2
-    [[nodiscard]] DecryptedRegularTxFields decryptFields(const ptr<BiteDataField> &bite, DecryptedAESKey &_key) const;
+    [[nodiscard]] DecryptedRegularTxFields decryptFields(const ptr<BiteCiphertext> &bite, DecryptedAESKey &_key) const;
 
     void corruptFromTimeToTime(shared_ptr<vector<unsigned char> > result);
 

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -87,8 +87,8 @@ public:
             ptr<BlockProposal> _proposal,
             schain_index _decryptorIndex);
 
-    [[nodiscard]] DecryptedTransactions verifyAndDecryptTransactionList(TransactionList &_transactionList,
-                                                                                     DecryptedAESKeyList &_aesKeys);
+    [[nodiscard]] DecryptedTransactions verifyAndDecryptTransactionList(const TransactionList &_transactionList,
+                                                                                     const DecryptedAESKeyList &_aesKeys);
 
 
     /**
@@ -146,7 +146,7 @@ public:
 
 private:
     // Decrypts a single ciphertext using the provided AES key 
-    vector<uint8_t> decryptCiphertext(const ptr<BiteCiphertext> &_bite, DecryptedAESKey &_decryptedAESKey) const;
+    vector<uint8_t> decryptCiphertext(const ptr<BiteCiphertext> &_bite, const DecryptedAESKey &_decryptedAESKey) const;
 
     // Parses decrypted data as a regular transaction, extracting 'data' and 'to' fields
     DecryptedRegularTxFields parseDecryptedDataAsRegularTx(const vector<uint8_t> &_data) const;

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -86,7 +86,7 @@ public:
             ptr<BlockProposal> _proposal,
             schain_index _decryptorIndex);
 
-    [[nodiscard]] ptr<DecryptedRegularTxsMap> verifyAndDecryptTransactionList(TransactionList &_transactionList,
+    [[nodiscard]] DecryptedTransactions verifyAndDecryptTransactionList(TransactionList &_transactionList,
                                                                                      DecryptedAESKeyList &_aesKeys);
 
 
@@ -108,9 +108,6 @@ public:
 
     void corruptFromTimeToTime(shared_ptr<vector<unsigned char> > result);
 
-    [[nodiscard]] ptr<vector<uint8_t> > teEncryptDataAndToAddress(const vector<uint8_t> &_data,
-                                                                  const vector<uint8_t> &_to);
-
 
     void callSGXToCreateMyDecryptionSharesForProposalTransactions(
             ptr<BlockProposal> _proposal);
@@ -119,6 +116,33 @@ public:
     [[nodiscard]] bool isRealCryptoEnabled() const;
 
     void computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal);
+
+
+    // =============== Test Encryption Calls =============== //
+
+    /**
+     * @brief Encrypts regular transaction data and to address using BITE1 scheme.
+     * @param _data - data field of the transaction
+     * @param _to - to address of the transaction
+     */
+    [[nodiscard]] ptr<vector<uint8_t> > encryptRegularTx(const vector<uint8_t> &_data,
+                                                                  const vector<uint8_t> &_to);
+
+
+#ifdef BITE2
+    /**
+     * @brief Encrypts CAT function arguments using BITE2 scheme.
+     * @param _data - Returned data follows the format:
+     * [
+     *      funcSelector,  // 4 bytes
+     *      RLP( 
+     *          RLP(cipher1, cipher2, ...), 
+     *          RLP(plaintext1, plaintext2, ...) 
+     *      ),
+     * ]
+     */
+    [[nodiscard]] ptr<vector<uint8_t> > generateEncryptedCATData();
+#endif
 
 private:
     // Decrypts a single ciphertext using the provided AES key 
@@ -129,4 +153,6 @@ private:
 
     // Parses decrypted data as a set of CAT function arguments
     DecryptedCATArgs parseDecryptedDataAsCATArgs(const vector<uint8_t> &_data) const;
+
+    ptr<vector<uint8_t>> encryptData(const vector<uint8_t>& data);
 };

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -25,6 +25,8 @@ class TransactionList;
 
 class EncryptedAESKey;
 
+class ParsedEthTransaction;
+
 namespace folly {
 class CPUThreadPoolExecutor;
 }
@@ -37,13 +39,34 @@ class BiteManager {
 public:
     explicit BiteManager(Schain &_schain);
 
+    // =============== Transaction Parsing Calls =============== //
+
+    // Runs through all transactions in the proposal and tries to parse all BITE transactions.
+    // This includes both:
+    // 1) BITE1 transactions - with both 'to' and 'data' fields encrypted
+    // 2) BITE2 transactions - with only function arguments encrypted, placed in the data field.
+    //
+    // Unparsable transactions will be added to failedTransactions.
+    // Transactions starting from the magic number but with incorrect format will be added
+    // to failedTransactions.
     static void parseBITETransactions(ptr<BlockProposal> _proposal);
+
+    // Tries to match the TO field to BITE1 magic number. If it matches - tries to parse the BITE1 data field.
+    // If parsing is successful - returns BiteDataField object, else returns 'nullopt'
+    static ptr<BiteDataField> tryGetEncryptedRegularTxFields(
+            const ptr<Transaction> &_transaction, epoch_id _currentEpochId);
+
+    // Tries to match the beginning of DATA field to BITE2 function selector.
+    // If it matches - tries to parse the BITE2 data field(s) for encrypted call arguments.
+    // If parsing is successful - returns vector of BiteDataField objects, else returns 'nullopt'
+    static ptr<std::vector<BiteDataField>> tryGetEncryptedCATArgs(
+            const ptr<Transaction> &_transaction, epoch_id _currentEpochId);
+
+    // =============== Ciphertext Parsing =============== //
 
     // this will return a map of failed transactions
     // if none of the transactions fails, the  proposal is set with decryption shares
-
-
-    [[nodiscard]][[nodiscard]] ptr<AESKeyDecryptionShareList> getDecryptionSharesForProposal(
+    [[nodiscard]] ptr<AESKeyDecryptionShareList> getDecryptionSharesForProposal(
             ptr<BlockProposal> _proposal);
 
     [[nodiscard]] Schain *getSchain() const {
@@ -58,7 +81,7 @@ public:
             ptr<BlockProposal> _proposal,
             schain_index _decryptorIndex);
 
-    [[nodiscard]] ptr<DecryptedTransactionFieldsMap> verifyAndDecryptTransactionList(TransactionList &_transactionList,
+    [[nodiscard]] ptr<DecryptedRegularTxsMap> verifyAndDecryptTransactionList(TransactionList &_transactionList,
                                                                                      DecryptedAESKeyList &_aesKeys);
 
     [[nodiscard]] ptr<AESKeyDecryptionShare> createAESDecryptionShare(const string& _aesKeyDecryptionShare,
@@ -68,8 +91,8 @@ public:
     [[nodiscard]] ptr<AESKeyDecryptionShareSet> createAESDecryptionShareSet(
             block_id _blockId, transaction_index _transactionIndex);
 
-    // TODO - change the name of this method
-    [[nodiscard]] DecryptedTransactionFields decryptFields(const ptr<BiteDataField> &bite, DecryptedAESKey &_key) const;
+    // TODO - change the name of this method - should be made generic for both BITE1 & BITE2
+    [[nodiscard]] DecryptedRegularTxFields decryptFields(const ptr<BiteDataField> &bite, DecryptedAESKey &_key) const;
 
     void corruptFromTimeToTime(shared_ptr<vector<unsigned char> > result);
 

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -56,11 +56,16 @@ public:
     static ptr<BiteCiphertext> tryGetEncryptedRegularTxFields(
             const ptr<Transaction> &_transaction, epoch_id _currentEpochId);
 
-    // Tries to match the beginning of DATA field to BITE2 function selector.
-    // If it matches - tries to parse the BITE2 data field(s) for encrypted call arguments.
-    // If parsing is successful - returns vector of BiteCiphertext objects, else returns 'nullopt'
-    static ptr<std::vector<BiteCiphertext>> tryGetEncryptedCATArgs(
+#ifdef BITE2
+    /**
+     * @brief Tries to match the beginning of DATA field to BITE2 function selector.
+     * If it matches - tries to parse the BITE2 data field(s) for encrypted call arguments.
+     * If parsing is successful - returns vector of BiteCiphertext objects, else returns 'nullopt'
+     * @throws if it matches the function selector but fails to parse the rest of the data
+     */
+    static ptr<std::vector<ptr<BiteCiphertext>>> tryGetEncryptedCATArgs(
             const ptr<Transaction> &_transaction, epoch_id _currentEpochId);
+#endif
 
     // =============== Ciphertext Parsing =============== //
 
@@ -77,22 +82,29 @@ public:
         return threadPoolExecutor;
     }
 
-    [[nodiscard]] ptr<vector<ptr<AESKeyDecryptionShare> > > getDecryptionSharesFromAESKeys(
+    [[nodiscard]] ptr<vector<ptr<AESKeyDecryptionShares> > > getDecryptionSharesFromAESKeys(
             ptr<BlockProposal> _proposal,
             schain_index _decryptorIndex);
 
     [[nodiscard]] ptr<DecryptedRegularTxsMap> verifyAndDecryptTransactionList(TransactionList &_transactionList,
                                                                                      DecryptedAESKeyList &_aesKeys);
 
-    [[nodiscard]] ptr<AESKeyDecryptionShare> createAESDecryptionShare(const string& _aesKeyDecryptionShare,
+
+    /**
+     * @brief Builds a vec of all decryptionShares for a given transaction from a serialized string format.
+     * @param _aesKeyDecryptionShares - serialized string format of decryption shares. Each share is in string format
+     * separated by commas.
+     * @param _decryptorIndex - index of the decryptor node that created these shares
+     * @param _decryptionFailed - whether decryption failed for this transaction
+     */
+    [[nodiscard]] ptr<AESKeyDecryptionShares> createAESDecryptionShares(const string& _aesKeyDecryptionShares,
                                                                       schain_index _decryptorIndex,
                                                                       bool _decryptionFailed);
 
-    [[nodiscard]] ptr<AESKeyDecryptionShareSet> createAESDecryptionShareSet(
-            block_id _blockId, transaction_index _transactionIndex);
 
-    // TODO - change the name of this method - should be made generic for both BITE1 & BITE2
-    [[nodiscard]] DecryptedRegularTxFields decryptFields(const ptr<BiteCiphertext> &bite, DecryptedAESKey &_key) const;
+
+    [[nodiscard]] ptr<AESKeyDecryptionShareSet> createAESDecryptionShareSet(
+            block_id _blockId, transaction_index _transactionIndex, size_t numberOfCiphertexts);
 
     void corruptFromTimeToTime(shared_ptr<vector<unsigned char> > result);
 
@@ -107,4 +119,14 @@ public:
     [[nodiscard]] bool isRealCryptoEnabled() const;
 
     void computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal);
+
+private:
+    // Decrypts a single ciphertext using the provided AES key 
+    vector<uint8_t> decryptCiphertext(const ptr<BiteCiphertext> &_bite, DecryptedAESKey &_decryptedAESKey) const;
+
+    // Parses decrypted data as a regular transaction, extracting 'data' and 'to' fields
+    DecryptedRegularTxFields parseDecryptedDataAsRegularTx(const vector<uint8_t> &_data) const;
+
+    // Parses decrypted data as a set of CAT function arguments
+    DecryptedCATArgs parseDecryptedDataAsCATArgs(const vector<uint8_t> &_data) const;
 };

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -526,6 +526,10 @@ bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
 #endif
             proposal = BlockProposal::makeFromNetworkSerialized(
                 fragmentList.serialize(), getSchain()->getCryptoManager());
+#ifdef BITE
+            auto biteManager = getSchain()->getBiteManager();
+            biteManager->parseBITETransactions(proposal);
+#endif
             CHECK_STATE(proposal)
             CHECK_STATE(proposal->getProposerIndex() == ( uint64_t ) proposerIndex);
             {
@@ -542,13 +546,12 @@ bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
 
             CHECK_STATE(proposal->getEncryptedAESKeys());
 
-            getSchain()->getBiteManager()->computeAndValidateSGXAESKeyBatch(proposal);
+            biteManager->computeAndValidateSGXAESKeyBatch(proposal);
 
             CHECK_STATE2(proposal->getFailedTransactionsRef().empty(),
                          "Proposal includes invalid format BITE transactions");
 
-            getSchain()->getBiteManager()->callSGXToCreateMyDecryptionSharesForProposalTransactions(
-                proposal);
+            biteManager->callSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
             CHECK_STATE2(proposal->getFailedTransactionsRef().empty(),
                          "Proposal includes invalid BITE transactions");
 #endif

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -544,7 +544,7 @@ bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
 #ifdef BITE
 
 
-            CHECK_STATE(proposal->getEncryptedAESKeys());
+            CHECK_STATE(proposal->getTransactionCiphertexts());
 
             biteManager->computeAndValidateSGXAESKeyBatch(proposal);
 

--- a/blockproposal/server/BlockProposalServerAgent.cpp
+++ b/blockproposal/server/BlockProposalServerAgent.cpp
@@ -421,7 +421,8 @@ pair<ConnectionStatus, ConnectionSubStatus> BlockProposalServerAgent::processPro
 
 
 #ifdef BITE
-    BiteManager::parseBITETransactions(proposal);
+    auto biteManager = sChain->getBiteManager();
+    biteManager->parseBITETransactions(proposal);
     if (!proposal->getFailedTransactionsRef().empty()) {
         // return the first failed transaction error
         finalResponseHeader =
@@ -447,7 +448,7 @@ pair<ConnectionStatus, ConnectionSubStatus> BlockProposalServerAgent::processPro
 
 
             // check for validity
-            getSchain()->getBiteManager()->computeAndValidateSGXAESKeyBatch(proposal);
+            biteManager->computeAndValidateSGXAESKeyBatch(proposal);
             if (!proposal->getFailedTransactionsRef().empty()) {
                 // return the first failed transaction error
                 finalResponseHeader =
@@ -483,7 +484,7 @@ pair<ConnectionStatus, ConnectionSubStatus> BlockProposalServerAgent::processPro
 
 #ifdef BITE
     // we talk to sgx after we sent response to the proposer since sgx is time consuming
-    getSchain()->getBiteManager()->callSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
+    biteManager->callSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
     if (!proposal->getFailedTransactionsRef().empty()) {
         CONS_LOG(err, "Can not create decryptions for network proposal" +
         to_string(proposal->getFailedTransactionsRef().begin()->second));

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -493,7 +493,7 @@ bool Schain::verifyBlsSyncPatch(uint64_t
 void Schain::blockCommitArrived(block_id _committedBlockID, schain_index _proposerIndex,
                                 const ptr<ThresholdSignature> &_thresholdSig, ptr<ThresholdSignature> _daSig
 #ifdef  BITE
-    , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedTransactionFieldsMap > _decryptedTransactionFields
+    , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedRegularTxsMap > _decryptedTransactionFields
 #endif
 ) {
     MONITOR2(__CLASS_NAME__, __FUNCTION__, getMaxExternalBlockProcessingTime())
@@ -825,8 +825,8 @@ void Schain::processCommittedBlock(const ptr<CommittedBlock> &_block) {
             // pending transaction ageent does not exist on a sync node
             CHECK_STATE(pendingTransactionsAgent);
 #ifdef BITE
-            CHECK_STATE(_block->getDecryptedTransactionFields())
-            auto biteDecryptedTransactions = _block->getDecryptedTransactionFields()->size();
+            CHECK_STATE(_block->getDecryptedRegularTxFields())
+            auto biteDecryptedTransactions = _block->getDecryptedRegularTxFields()->size();
 #endif
 
 
@@ -903,7 +903,7 @@ void Schain::pushBlockToExtFace(const ptr<CommittedBlock> &_block) {
     try {
         auto tv = _block->getTransactionList()->createTransactionVector(
 #ifdef BITE
-        _block->getDecryptedTransactionFields()
+        _block->getDecryptedRegularTxFields()
 #endif
         );
 
@@ -921,7 +921,7 @@ void Schain::pushBlockToExtFace(const ptr<CommittedBlock> &_block) {
 
 
 #ifdef BITE
-        CHECK_STATE(_block->getDecryptedTransactionFields() || _block->getProposerIndex() == 0)
+        CHECK_STATE(_block->getDecryptedRegularTxFields() || _block->getProposerIndex() == 0)
 #endif
 
         if (extFace) {
@@ -929,7 +929,7 @@ void Schain::pushBlockToExtFace(const ptr<CommittedBlock> &_block) {
                 inCreateBlock = true;
                 extFace->createBlock(*tv,
 #ifdef BITE
-                    _block->getDecryptedTransactionFields(),
+                    _block->getDecryptedRegularTxFields(),
 #endif
                                      _block->getTimeStampS(), _block->getTimeStampMs(),
                                      (__uint64_t) _block->getBlockID(), currentPrice, _block->getStateRoot(),
@@ -1449,7 +1449,7 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
             // default empty block
             blockCommitArrived(_blockId, _proposerIndex, _thresholdSig, nullptr
 #ifdef BITE
-            , make_shared<DecryptedAESKeyList>(), make_shared< DecryptedTransactionFieldsMap >()
+            , make_shared<DecryptedAESKeyList>(), make_shared< DecryptedRegularTxsMap >()
 #endif
             );
             return;

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -493,7 +493,7 @@ bool Schain::verifyBlsSyncPatch(uint64_t
 void Schain::blockCommitArrived(block_id _committedBlockID, schain_index _proposerIndex,
                                 const ptr<ThresholdSignature> &_thresholdSig, ptr<ThresholdSignature> _daSig
 #ifdef  BITE
-    , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedRegularTxsMap > _decryptedTransactionFields
+    , ptr< DecryptedAESKeyList > _aesKeyList, DecryptedTransactions _decryptedTransactions
 #endif
 ) {
     MONITOR2(__CLASS_NAME__, __FUNCTION__, getMaxExternalBlockProcessingTime())
@@ -503,7 +503,6 @@ void Schain::blockCommitArrived(block_id _committedBlockID, schain_index _propos
 
 #ifdef BITE
     CHECK_ARGUMENT(_aesKeyList)
-    CHECK_ARGUMENT(_decryptedTransactionFields)
 #endif
 
     // wait until the schain state is fully initialized and startup
@@ -557,7 +556,7 @@ void Schain::blockCommitArrived(block_id _committedBlockID, schain_index _propos
         auto newCommittedBlock =
                 CommittedBlock::makeFromProposal(committedProposal, _thresholdSig, _daSig
 #ifdef BITE
-            , _aesKeyList, _decryptedTransactionFields
+            , _aesKeyList, _decryptedTransactions
 #endif
                 );
 
@@ -825,8 +824,11 @@ void Schain::processCommittedBlock(const ptr<CommittedBlock> &_block) {
             // pending transaction ageent does not exist on a sync node
             CHECK_STATE(pendingTransactionsAgent);
 #ifdef BITE
-            CHECK_STATE(_block->getDecryptedRegularTxFields())
-            auto biteDecryptedTransactions = _block->getDecryptedRegularTxFields()->size();
+            auto decryptedTxs = _block->getDecryptedTransactions();
+            CHECK_STATE(decryptedTxs.regularTxsMap)
+#ifdef BITE2
+            CHECK_STATE(decryptedTxs.catTxsMap)
+#endif
 #endif
 
 
@@ -835,7 +837,10 @@ void Schain::processCommittedBlock(const ptr<CommittedBlock> &_block) {
                              + ":TLWT:" + to_string( pendingTransactionsAgent->getTransactionListWaitTime() )
                              + ":SBPT:" + to_string( cryptoManager->sgxBlockProcessingTime() )
 #ifdef BITE
-                    + ":BITE_DECRYPTED_TXS:" + to_string(biteDecryptedTransactions)
+                    + ":BITE_DECRYPTED_TXS:" + to_string(decryptedTxs.regularTxsMap->size())
+#ifdef BITE2
+                    + ":CAT_DECRYPTED_TXS:" + to_string(decryptedTxs.catTxsMap->size())
+#endif
 #endif
 
                              );
@@ -901,11 +906,8 @@ void Schain::pushBlockToExtFace(const ptr<CommittedBlock> &_block) {
     checkForExit();
 
     try {
-        auto tv = _block->getTransactionList()->createTransactionVector(
-#ifdef BITE
-        _block->getDecryptedRegularTxFields()
-#endif
-        );
+        // no need to pass biteManager to the call - we dont need to know about CATs here
+        auto tv = _block->getTransactionList()->createTransactionVector();
 
         // auto next_price = // VERIFY PRICING
 
@@ -927,13 +929,16 @@ void Schain::pushBlockToExtFace(const ptr<CommittedBlock> &_block) {
         if (extFace) {
             try {
                 inCreateBlock = true;
+
                 extFace->createBlock(*tv,
 #ifdef BITE
-                    _block->getDecryptedRegularTxFields(),
+                    _block->getDecryptedTransactions(),
 #endif
-                                     _block->getTimeStampS(), _block->getTimeStampMs(),
-                                     (__uint64_t) _block->getBlockID(), currentPrice, _block->getStateRoot(),
-                                     (uint64_t) _block->getProposerIndex());
+                    _block->getTimeStampS(), _block->getTimeStampMs(),
+                    (__uint64_t) _block->getBlockID(), currentPrice, _block->getStateRoot(),
+                    (uint64_t) _block->getProposerIndex()
+                );
+
                 inCreateBlock = false;
             } catch (...) {
                 inCreateBlock = false;
@@ -1189,7 +1194,7 @@ void Schain::bootstrap(block_id _lastCommittedBlockID, uint64_t _lastCommittedBl
         CONS_LOG(info, "Jump starting the system with block:" << to_string( _lastCommittedBlockID ));
 
         if (getLastCommittedBlockID() == 0)
-            this->pricingAgent->calculatePrice(ConsensusExtFace::transactions_vector(), 0, 0, 0);
+            this->pricingAgent->calculatePrice(ConsensusExtFace::Transactions(), 0, 0, 0);
 
         isStateInitialized = true;
 
@@ -1449,7 +1454,7 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
             // default empty block
             blockCommitArrived(_blockId, _proposerIndex, _thresholdSig, nullptr
 #ifdef BITE
-            , make_shared<DecryptedAESKeyList>(), make_shared< DecryptedRegularTxsMap >()
+            , make_shared<DecryptedAESKeyList>(), DecryptedTransactions()
 #endif
             );
             return;
@@ -1509,13 +1514,8 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
         CHECK_STATE(keys);
 
         auto transactions = proposal->getTransactionList();
-        auto decryptedTransactionDataFields = getBiteManager()->verifyAndDecryptTransactionList(*transactions, (*keys));
-
-        CHECK_STATE(decryptedTransactionDataFields);
-
-
+        auto decryptedTransactions = getBiteManager()->verifyAndDecryptTransactionList(*transactions, (*keys));
 #endif
-
 
         auto daProofSig = getNode()->getDaProofDB()->getDASig( _blockId, _proposerIndex );
         auto hash = proposal->getHash();
@@ -1524,7 +1524,7 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
 
         blockCommitArrived(_blockId, _proposerIndex, _thresholdSig, daSig
 #ifdef BITE
-                           , keys, decryptedTransactionDataFields
+                           , keys, decryptedTransactions
 #endif
         );
     } catch (ExitRequestedException &) {

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1500,7 +1500,7 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
 
         CHECK_STATE(count >= getRequiredSigners())
 
-        auto encryptedAESKeys = proposal->getEncryptedAESKeys();
+        auto encryptedAESKeys = proposal->getTransactionCiphertexts();
 
         CHECK_STATE(encryptedAESKeys);
 

--- a/chains/Schain.h
+++ b/chains/Schain.h
@@ -327,7 +327,7 @@ public:
     void blockCommitArrived( block_id _committedBlockID, schain_index _proposerIndex,
         const ptr< ThresholdSignature >& _thresholdSig, ptr< ThresholdSignature > _daSig
 #ifdef BITE
-        , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedTransactionFieldsMap > _decryptedTransactions
+        , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedRegularTxsMap > _decryptedTransactions
 #endif
         );
 

--- a/chains/Schain.h
+++ b/chains/Schain.h
@@ -327,7 +327,7 @@ public:
     void blockCommitArrived( block_id _committedBlockID, schain_index _proposerIndex,
         const ptr< ThresholdSignature >& _thresholdSig, ptr< ThresholdSignature > _daSig
 #ifdef BITE
-        , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedRegularTxsMap > _decryptedTransactions
+        , ptr< DecryptedAESKeyList > _aesKeyList, DecryptedTransactions _decryptedTransactions
 #endif
         );
 

--- a/crypto/AESKeyDecryptionShare.h
+++ b/crypto/AESKeyDecryptionShare.h
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #include <boost/container/flat_map.hpp>
+#include "datastructures/SmallVector.h"
 #pragma GCC diagnostic pop
 
 class BLAKE3Hash;
@@ -33,3 +34,5 @@ public:
 
     BLAKE3Hash computeHash();
 };
+
+using AESKeyDecryptionShares = small_vector<ptr<AESKeyDecryptionShare>>;

--- a/crypto/AESKeyDecryptionShareList.cpp
+++ b/crypto/AESKeyDecryptionShareList.cpp
@@ -15,11 +15,12 @@ void AESKeyDecryptionShareList::reserve(size_t _size) {
 }
 
 // Optional: Add public access methods
-void AESKeyDecryptionShareList::addShare(transaction_index _index, const ptr<AESKeyDecryptionShare> &_decryptShare) {
-    decryptionShares.emplace(_index, _decryptShare);
+void AESKeyDecryptionShareList::addShares(transaction_index _index, const ptr<AESKeyDecryptionShares> &_decryptShares) {
+    decryptionShares.emplace(_index, _decryptShares);
+    totalCiphertextShares += _decryptShares->size();
 }
 
-ptr<AESKeyDecryptionShare> AESKeyDecryptionShareList::getDecryptionShare(transaction_index _transactionIndex) const {
+ptr<AESKeyDecryptionShares> AESKeyDecryptionShareList::getDecryptionShares(transaction_index _transactionIndex) const {
     auto it = decryptionShares.find(_transactionIndex);
     return (it != decryptionShares.end()) ? it->second : nullptr;
 }

--- a/crypto/AESKeyDecryptionShareList.h
+++ b/crypto/AESKeyDecryptionShareList.h
@@ -3,18 +3,26 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #include <boost/container/flat_map.hpp>
+#include "datastructures/SmallVector.h"
+#include "crypto/AESKeyDecryptionShare.h"
 #pragma GCC diagnostic pop
-
 class AESKeyDecryptionShare;
 
+/**
+ * @brief Holds a list of AES key decryption shares from a specific decryptor node for all transactions in a block.
+ * For each transaction, there may be multiple ciphertexts, and thus multiple decryption shares.
+ * Decryption shares should all follow the same order - the order of ciphertexts in the original transaction.
+ * That is, share 1 for tx 1 corresponds to the same ciphertext as share 1 for tx 1 from another decryptor.
+ */
 class AESKeyDecryptionShareList {
     block_id blockId;
     schain_index proposerIndex;
     schain_index decryptorIndex;
 
-
 private:
-    boost::container::flat_map<transaction_index, ptr<AESKeyDecryptionShare> > decryptionShares;
+    // Maps a tx index to a list of shares - one per ciphertext in the current tx
+    boost::container::flat_map<transaction_index, ptr<AESKeyDecryptionShares>> decryptionShares;
+    size_t totalCiphertextShares = 0;
 
 public:
     AESKeyDecryptionShareList(const block_id &_blockId, schain_index _proposerIndex, const schain_index & _decryptorIndex )
@@ -31,20 +39,29 @@ public:
 
     schain_index getDecryptorIndex() const;
 
-    size_t getSize() const {
-
+    // returns number of transactions with decryption shares
+    size_t size() const {
         return decryptionShares.size();
     }
 
-    [[nodiscard]] const boost::container::flat_map<transaction_index, ptr<AESKeyDecryptionShare>>& getDecryptionShares() const {
+    // returns total count of ciphertext shares across all transactions
+    size_t totalCiphertextSharesCount() const {
+        return totalCiphertextShares;
+    }
+
+    [[nodiscard]] const boost::container::flat_map<transaction_index, ptr<AESKeyDecryptionShares>>& getDecryptionShares() const {
         return decryptionShares;
     }
 
     void reserve(size_t _size);
 
-    void addShare(transaction_index _index, const ptr<AESKeyDecryptionShare> &_decryptShare);
+    /**
+     * @brief Adds decryption shares for a given transaction index.
+     * Note that decryptShares may contain multiple shares, or a single share.
+     */
+    void addShares(transaction_index _index, const ptr<AESKeyDecryptionShares> &_decryptShares);
 
-    ptr<AESKeyDecryptionShare> getDecryptionShare(transaction_index _transactionIndex) const;
+    ptr<AESKeyDecryptionShares> getDecryptionShares(transaction_index _transactionIndex) const;
 
 };
 

--- a/crypto/AESKeyDecryptionShareSet.h
+++ b/crypto/AESKeyDecryptionShareSet.h
@@ -2,8 +2,10 @@
 #include <datastructures/BlockProposal.h>
 
 class EncryptedAESKey;
-class AESKeyDecryptionShare;
-class DecryptedAESKey;
+
+#include "crypto/AESKeyDecryptionShare.h"
+#include "crypto/DecryptedAESKey.h"
+#include "crypto/EncryptedAESKey.h"
 
 class AESKeyDecryptionShareSet {
 public:
@@ -22,9 +24,9 @@ public:
         return totalObjects;
     }
 
-    virtual ptr< DecryptedAESKey > verifyAndMergeAESKey(ptr<EncryptedAESKey> _encryptedAesKey) = 0;
+    virtual ptr< DecryptedAESKeys > verifyAndMergeAESKeys(EncryptedAESKeys& _encryptedAesKey) = 0;
 
     virtual bool isEnough() = 0;
 
-    virtual bool addDecryptionShare( const ptr< AESKeyDecryptionShare >& _decryptionShare ) = 0;
+    virtual bool addDecryptionShares( const ptr< AESKeyDecryptionShares >& _decryptionShare ) = 0;
 };

--- a/crypto/AESKeyDecryptionShareSet.h
+++ b/crypto/AESKeyDecryptionShareSet.h
@@ -28,5 +28,13 @@ public:
 
     virtual bool isEnough() = 0;
 
-    virtual bool addDecryptionShares( const ptr< AESKeyDecryptionShares >& _decryptionShare ) = 0;
+    /**
+     * @brief Adds a list of decryption shares corresponding to each ciphertext in a single transaction.
+     * @param _decryptionShares The decryption shares to be added. MUST be all from the same decryptor, since
+     * they refer to a set of shares all computed for a single transaction (multiple ciphertexts).
+     * Meaning index 0 will be share for ciphertext 0, index 1 for ciphertext 1, etc.
+     * @return true if the shares were added successfully, false otherwise
+     */
+    virtual bool addDecryptionSharesFromSameDecryptor(
+        const ptr< AESKeyDecryptionShares >& _decryptionShares ) = 0;
 };

--- a/crypto/ConsensusAESKeyDecryptionShareSet.cpp
+++ b/crypto/ConsensusAESKeyDecryptionShareSet.cpp
@@ -25,15 +25,14 @@
 
 #include "bls_include.h"
 #include <oids.h>
+#include <memory>
 #include "Log.h"
 #include "SkaleCommon.h"
 #include "libBLS/threshold_encryption/TEDecryptSet.h"
 
-
 #include "ConsensusAESKeyDecryptionShare.h"
 #include "ConsensusAESKeyDecryptionShareSet.h"
-#include "DecryptedAESKey.h"
-#include "EncryptedAESKey.h"
+#include "crypto/AESKeyDecryptionShare.h"
 #include "threshold_encryption/ThresholdEncryption.h"
 
 
@@ -41,49 +40,62 @@ using namespace std;
 
 
 ConsensusAESKeyDecryptionShareSet::ConsensusAESKeyDecryptionShareSet( block_id _blockId,
-    transaction_index _transactionIndex, size_t _totalDecryptors, size_t _requiredDecryptors )
-    : AESKeyDecryptionShareSet( _blockId, _transactionIndex ), 
-    decryptionShares(_requiredDecryptors, _totalDecryptors) {};
+    transaction_index _transactionIndex, size_t numCiphertexts, size_t _totalDecryptors, size_t _requiredDecryptors )
+    : AESKeyDecryptionShareSet( _blockId, _transactionIndex ) {
+        decryptionSets.reserve( numCiphertexts );
+        for ( size_t i = 0; i < numCiphertexts; i++ ) {
+            decryptionSets.emplace_back(libBLS::TEDecryptSet( _requiredDecryptors, _totalDecryptors ));
+        }
+    };
 
 ConsensusAESKeyDecryptionShareSet::~ConsensusAESKeyDecryptionShareSet() = default;
 
-ptr< DecryptedAESKey > ConsensusAESKeyDecryptionShareSet::verifyAndMergeAESKey(ptr<EncryptedAESKey> _encryptedAESKey) {
+ptr< DecryptedAESKeys > ConsensusAESKeyDecryptionShareSet::verifyAndMergeAESKeys(EncryptedAESKeys& _encryptedAESKeys) {
+    CHECK_STATE( _encryptedAESKeys.size() == decryptionSets.size() );
     LOCK( decryptionSharesLock )
 
     bool validateCiphertext = false;
-    auto cipheredKey = libBLS::CipheredKey::fromBytes( *_encryptedAESKey->getKey(), validateCiphertext );
+    auto decryptedKeys = make_shared< DecryptedAESKeys >();
+    for ( size_t i = 0; i < _encryptedAESKeys.size(); i++ ) {
+        auto cipheredKey = libBLS::CipheredKey::fromBytes( _encryptedAESKeys.at(i).data(), validateCiphertext );
+        // Checks if decryption set can be merged & merges if so
+        libBLS::AES256Key aesKey = libBLS::ThresholdEncryption::combineShares( cipheredKey, decryptionSets.at(i) );
+        decryptedKeys->push_back( DecryptedAESKey( aesKey ) );
+    }
 
-    // Checks if decryption set can be merged & merges if so
-    libBLS::AES256Key aesKey = libBLS::ThresholdEncryption::combineShares( cipheredKey, decryptionShares);
-
-    return make_shared< DecryptedAESKey >( aesKey );
+    return decryptedKeys;
 }
 
 bool ConsensusAESKeyDecryptionShareSet::isEnough() {
     {
         LOCK( decryptionSharesLock )
-        return decryptionShares.canMerge();
+        return decryptionSets.at(0).canMerge();
     }
 }
 
 
-bool ConsensusAESKeyDecryptionShareSet::addDecryptionShare(
-    const ptr< AESKeyDecryptionShare >& _decryptionShare ) {
-    CHECK_ARGUMENT( _decryptionShare );
+bool ConsensusAESKeyDecryptionShareSet::addDecryptionShares(
+    const ptr< AESKeyDecryptionShares >& _decryptionShares ) {
+    CHECK_ARGUMENT( _decryptionShares );
+    CHECK_STATE( _decryptionShares->size() == decryptionSets.size() );
 
     LOCK( decryptionSharesLock )
     
-    auto ds = dynamic_pointer_cast< ConsensusAESKeyDecryptionShare >( _decryptionShare );
-    CHECK_STATE( ds );
+    for ( size_t i = 0; i < decryptionSets.size(); i++ ) {
+        ptr< AESKeyDecryptionShare > val = _decryptionShares->at(i);
+        auto ds = std::dynamic_pointer_cast< ConsensusAESKeyDecryptionShare >( val );
+        CHECK_STATE( ds );
 
-    try {
-        decryptionShares.addDecryptShare( *ds->getTEDecryptionShare() );
-        totalObjects.fetch_add( 1 );
+        try {
+            decryptionSets.at(i).addDecryptShare( *ds->getTEDecryptionShare() );
+        }
+        catch ( const std::exception& e ) {
+            CONS_LOG( warn, "Failed to add decryption share: " << e.what() );
+            return false;
+        }
     }
-    catch ( const std::exception& e ) {
-        CONS_LOG( warn, "Failed to add decryption share: " << e.what() );
-        return false;
-    }
+    // count as a single share added (we count all shares for current tx as one)
+    totalObjects.fetch_add( 1 );
 
     return true;
 }

--- a/crypto/ConsensusAESKeyDecryptionShareSet.cpp
+++ b/crypto/ConsensusAESKeyDecryptionShareSet.cpp
@@ -34,6 +34,7 @@
 #include "ConsensusAESKeyDecryptionShareSet.h"
 #include "crypto/AESKeyDecryptionShare.h"
 #include "threshold_encryption/ThresholdEncryption.h"
+#include <cstdint>
 
 
 using namespace std;
@@ -73,8 +74,8 @@ bool ConsensusAESKeyDecryptionShareSet::isEnough() {
     }
 }
 
-
-bool ConsensusAESKeyDecryptionShareSet::addDecryptionShares(
+// TODO - not used (?) - remove from this and from base interface class
+bool ConsensusAESKeyDecryptionShareSet::addDecryptionSharesFromSameDecryptor(
     const ptr< AESKeyDecryptionShares >& _decryptionShares ) {
     CHECK_ARGUMENT( _decryptionShares );
     CHECK_STATE( _decryptionShares->size() == decryptionSets.size() );
@@ -90,7 +91,13 @@ bool ConsensusAESKeyDecryptionShareSet::addDecryptionShares(
             decryptionSets.at(i).addDecryptShare( *ds->getTEDecryptionShare() );
         }
         catch ( const std::exception& e ) {
-            CONS_LOG( warn, "Failed to add decryption share: " << e.what() );
+            CONS_LOG( warn, 
+                fmt::format("Failed to add decryption share {} from decryptor {} to ciphertext {}, when trying to add all shares from a single decryptor: {}", 
+                    decryptionSets.at(i).size(),
+                    static_cast<uint64_t>(val->getDecryptorIndex()),
+                    i,
+                    e.what()) 
+                );
             return false;
         }
     }

--- a/crypto/ConsensusAESKeyDecryptionShareSet.h
+++ b/crypto/ConsensusAESKeyDecryptionShareSet.h
@@ -6,23 +6,51 @@
 
 class PartialHashesList;
 class Schain;
-class AESKeyDecryptionShare;
 class BLAKE3Hash;
-class EncryptedAESKey;
 
+#include "crypto/DecryptedAESKey.h"
+#include "crypto/EncryptedAESKey.h"
+#include "crypto/AESKeyDecryptionShare.h"
+
+/**
+ * @brief Holds a set of AES key decryption shares from consensus nodes for a specific transaction.
+ * Each transaction may have multiple ciphertexts (EncryptedAESKeys), and for each ciphertext,
+ * there is a corresponding TEDecryptSet to hold the decryption shares.
+ * 
+ * This class treats each transaction (not each ciphertext) as a unit.
+ */
 class ConsensusAESKeyDecryptionShareSet : public AESKeyDecryptionShareSet {
-    ptr<EncryptedAESKey> encryptedAESKey;
-    libBLS::TEDecryptSet decryptionShares;  // tsafe
+    // N ciphertexts
+    ptr<EncryptedAESKeys> encryptedAESKeys;
+    // 1 decrypt set for each ciphertext within this transaction
+    small_vector<libBLS::TEDecryptSet> decryptionSets;  // tsafe
     recursive_mutex decryptionSharesLock;
 
 public:
-    ConsensusAESKeyDecryptionShareSet( block_id _blockId, transaction_index _transactionIndex,
+    ConsensusAESKeyDecryptionShareSet( block_id _blockId, transaction_index _transactionIndex, size_t numCiphertexts,
         size_t _totalDecryptors, size_t _requiredDecryptors);
 
-    ptr<DecryptedAESKey> verifyAndMergeAESKey(ptr<EncryptedAESKey> _encryptedAESKey) override;
 
-    virtual bool addDecryptionShare(
-        const ptr< AESKeyDecryptionShare >& _decryptionShare ) override;
+    /**
+     * @brief Verifies and merges the AES keys from all collected shares for all ciphertexts.
+     * @param _encryptedAESKey The encrypted AES keys corresponding to the ciphertexts.
+     * It uses the collected shares for each ciphertext, and merges each set of shares 
+     * individually to reconstruct the original AES keys, one at a time.
+     * @return Pointer to 1 decrypted AES key for each ciphertext.
+     * If input contains 3 args, then the set will contain N * 3 total shares, and will output 3 decrypted AES keys.
+     * Index 0 of the returned value corresponds to ciphertext 0, index 1 to ciphertext 1, and so on.
+     * Same for input.
+     */
+    ptr<DecryptedAESKeys> verifyAndMergeAESKeys(EncryptedAESKeys& _encryptedAESKey) override;
+
+    /**
+     * @brief Adds a list of decryption shares corresponding to each ciphertext in a single transaction.
+     * @param _decryptionShares The decryption shares to be added. MUST be all from the same decryptor, since
+     * they refer to a set of shares all computed for a single transaction (multiple ciphertexts).
+     * @return true if the shares were added successfully, false otherwise
+     */
+    virtual bool addDecryptionShares(
+        const ptr< AESKeyDecryptionShares >& _decryptionShares ) override;
 
 
     bool isEnough() override;

--- a/crypto/ConsensusAESKeyDecryptionShareSet.h
+++ b/crypto/ConsensusAESKeyDecryptionShareSet.h
@@ -43,15 +43,8 @@ public:
      */
     ptr<DecryptedAESKeys> verifyAndMergeAESKeys(EncryptedAESKeys& _encryptedAESKey) override;
 
-    /**
-     * @brief Adds a list of decryption shares corresponding to each ciphertext in a single transaction.
-     * @param _decryptionShares The decryption shares to be added. MUST be all from the same decryptor, since
-     * they refer to a set of shares all computed for a single transaction (multiple ciphertexts).
-     * @return true if the shares were added successfully, false otherwise
-     */
-    virtual bool addDecryptionShares(
+    virtual bool addDecryptionSharesFromSameDecryptor(
         const ptr< AESKeyDecryptionShares >& _decryptionShares ) override;
-
 
     bool isEnough() override;
 

--- a/crypto/CryptoManager.cpp
+++ b/crypto/CryptoManager.cpp
@@ -865,7 +865,7 @@ ptr<ThresholdSigShare> CryptoManager::signSigShare(
 
 #ifdef BITE
 ptr<vector<ptr<AESKeyDecryptionShare> > > CryptoManager::sgxDecryptAESKeyShareBatch(
-    std::vector<std::shared_ptr<std::string> > &_publicDecryptionValues) {
+    std::vector<std::string> &_publicDecryptionValues) {
 
     MONITOR(__CLASS_NAME__, __FUNCTION__)
 
@@ -891,8 +891,7 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > CryptoManager::sgxDecryptAESKeyShareBa
         CHECK_STATE(stringShares);
         result->reserve( stringShares->size() );
         for (auto&& stringShare : *stringShares) {
-            CHECK_STATE(stringShare);
-            auto share = make_shared<libBLS::TEDecryptionShare>(*stringShare, (uint64_t) getSchain()->getSchainIndex());
+            auto share = make_shared<libBLS::TEDecryptionShare>(stringShare, (uint64_t) getSchain()->getSchainIndex());
             auto consensusDecryptShare =
                 make_shared<ConsensusAESKeyDecryptionShare>(share, sChain->getSchainIndex(), false);
             result->push_back(consensusDecryptShare);
@@ -931,9 +930,6 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > CryptoManager::sgxDecryptAESKeyShareBa
 
         JSONFactory::checkSGXStatus(jsonShares);
     }
-
-
-
 
     if (measureTime) {
         addTEDecryptStats(Time::getCurrentTimeMs() - time );

--- a/crypto/CryptoManager.h
+++ b/crypto/CryptoManager.h
@@ -185,7 +185,7 @@ public:
     static ifstream urandom;
 
 #ifdef BITE
-    ptr<vector<ptr<AESKeyDecryptionShare>>> sgxDecryptAESKeyShareBatch( std::vector<std::shared_ptr<std::string>>& _publicDecryptionValues);
+    ptr<vector<ptr<AESKeyDecryptionShare>>> sgxDecryptAESKeyShareBatch( std::vector<std::string>& _publicDecryptionValues);
 #endif
 
 

--- a/crypto/DecryptedAESKey.cpp
+++ b/crypto/DecryptedAESKey.cpp
@@ -42,13 +42,13 @@ int DecryptedAESKey::compare( DecryptedAESKey& _key2 ) {
 
 
 ptr<EncryptedAESKey> DecryptedAESKey::generate() {
-    auto randomKey = std::make_shared<std::array<std::uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>>();
+    auto randomKey = std::array<std::uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>();
     // thread safe permanent objects
     thread_local std::random_device rd;
     thread_local std::mt19937 gen(rd());
     thread_local  std::uniform_int_distribution<std::uint8_t> dis(0, 255);
 
-    for (auto& byte : *randomKey) {
+    for (auto& byte : randomKey) {
         byte = dis(gen);
     }
 

--- a/crypto/DecryptedAESKey.h
+++ b/crypto/DecryptedAESKey.h
@@ -28,3 +28,5 @@ public:
 
     virtual ~DecryptedAESKey();
 };
+
+using DecryptedAESKeys = small_vector<DecryptedAESKey>;

--- a/crypto/DecryptedAESKeyList.cpp
+++ b/crypto/DecryptedAESKeyList.cpp
@@ -5,6 +5,6 @@
 
 #include "DecryptedAESKeyList.h"
 
-boost::container::flat_map<transaction_index, ptr<DecryptedAESKey>>& DecryptedAESKeyList::getKeys()  {
+boost::container::flat_map<transaction_index, ptr<DecryptedAESKeys>>& DecryptedAESKeyList::getKeys()  {
     return decryptedAESKeys;
 }

--- a/crypto/DecryptedAESKeyList.cpp
+++ b/crypto/DecryptedAESKeyList.cpp
@@ -5,6 +5,10 @@
 
 #include "DecryptedAESKeyList.h"
 
-boost::container::flat_map<transaction_index, ptr<DecryptedAESKeys>>& DecryptedAESKeyList::getKeys()  {
+const boost::container::flat_map<transaction_index, ptr<DecryptedAESKeys>>& DecryptedAESKeyList::getKeys() const {
+    return decryptedAESKeys;
+}
+
+boost::container::flat_map<transaction_index, ptr<DecryptedAESKeys>>& DecryptedAESKeyList::getKeys() {
     return decryptedAESKeys;
 }

--- a/crypto/DecryptedAESKeyList.h
+++ b/crypto/DecryptedAESKeyList.h
@@ -3,24 +3,26 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #include <boost/container/flat_map.hpp>
+#include "datastructures/SmallVector.h"
 #pragma GCC diagnostic pop
 #include "DecryptedAESKey.h"
 
 class DecryptedAESKeyList {
 public:
 
-    [[nodiscard]] boost::container::flat_map<transaction_index, ptr<DecryptedAESKey>>& getKeys();
+    [[nodiscard]] boost::container::flat_map<transaction_index, ptr<DecryptedAESKeys>>& getKeys();
 
     // Optional: Constructor
     DecryptedAESKeyList() = default;
 
 
     // Optional: Add public access methods
-    void addKey(transaction_index _index, const DecryptedAESKey& key) {
-        decryptedAESKeys.emplace(_index, make_shared<DecryptedAESKey>(key));
+    void addKeys(transaction_index _index, const DecryptedAESKeys& keys) {
+        decryptedAESKeys.emplace(_index, make_shared<DecryptedAESKeys>(keys));
+        totalDecryptedCiphertexts += keys.size();
     }
 
-    const  ptr<DecryptedAESKey> getKey(transaction_index _transactionIndex) const {
+    const  ptr<DecryptedAESKeys> getKeys(transaction_index _transactionIndex) const {
         auto result = decryptedAESKeys.find(_transactionIndex);
         if (result == decryptedAESKeys.end()) {
             return nullptr;
@@ -32,8 +34,13 @@ public:
         return decryptedAESKeys.size();
     }
 
+    size_t totalDecryptedCiphertextsCount() const {
+        return totalDecryptedCiphertexts;
+    }
+
 
 private:
-    boost::container::flat_map<transaction_index, ptr<DecryptedAESKey>> decryptedAESKeys;
+    boost::container::flat_map<transaction_index, ptr<DecryptedAESKeys>> decryptedAESKeys;
+    size_t totalDecryptedCiphertexts;
 };
 

--- a/crypto/DecryptedAESKeyList.h
+++ b/crypto/DecryptedAESKeyList.h
@@ -18,7 +18,7 @@ public:
     [[nodiscard]] boost::container::flat_map<transaction_index, ptr<DecryptedAESKeys>>& getKeys();
 
     // Optional: Constructor
-    DecryptedAESKeyList() = default;
+    DecryptedAESKeyList() : totalDecryptedCiphertexts(0) {}
 
 
     // Optional: Add public access methods

--- a/crypto/DecryptedAESKeyList.h
+++ b/crypto/DecryptedAESKeyList.h
@@ -7,6 +7,11 @@
 #pragma GCC diagnostic pop
 #include "DecryptedAESKey.h"
 
+
+/**
+ * @brief Holds a list of decrypted AES keys for transactions in a block.
+ * Each transaction may have multiple ciphertexts, thus multiple decrypted AES keys.
+ */
 class DecryptedAESKeyList {
 public:
 

--- a/crypto/DecryptedAESKeyList.h
+++ b/crypto/DecryptedAESKeyList.h
@@ -15,7 +15,9 @@
 class DecryptedAESKeyList {
 public:
 
-    [[nodiscard]] boost::container::flat_map<transaction_index, ptr<DecryptedAESKeys>>& getKeys();
+    const boost::container::flat_map<transaction_index, ptr<DecryptedAESKeys>>& getKeys() const;
+
+    boost::container::flat_map<transaction_index, ptr<DecryptedAESKeys>>& getKeys();
 
     // Optional: Constructor
     DecryptedAESKeyList() : totalDecryptedCiphertexts(0) {}

--- a/crypto/EncryptedAESKey.cpp
+++ b/crypto/EncryptedAESKey.cpp
@@ -7,14 +7,12 @@
 #include "EncryptedAESKey.h"
 
 
-EncryptedAESKey::EncryptedAESKey(std::shared_ptr<std::array<std::uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>> key)
-    : key(key) {
-    CHECK_STATE(key);
+EncryptedAESKey::EncryptedAESKey(std::array<std::uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> _key)
+    : regularTxKey(_key) {
 }
 
 
 ptr<string> EncryptedAESKey::toHex() const {
-    CHECK_STATE(key);
-    return  make_shared<string>(Utils::carray2Hex(key->data(), key->size()));
+    return  make_shared<string>(Utils::carray2Hex(regularTxKey.data(), regularTxKey.size()));
  }
 

--- a/crypto/EncryptedAESKey.h
+++ b/crypto/EncryptedAESKey.h
@@ -3,19 +3,22 @@
 #include <memory>
 #include <array>
 #include <cstdint>
+#include "datastructures/SmallVector.h"
+#include "node/ConsensusInterface.h"
 
 using namespace std;
 
-
 class EncryptedAESKey {
-   shared_ptr< array< uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> > key;
+   array< uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> regularTxKey;
 
 public:
-   explicit EncryptedAESKey(shared_ptr<array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>> key);
+   explicit EncryptedAESKey(array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> key);
 
-   [[nodiscard]] shared_ptr<array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>> getKey() const {
-      return key;
+   [[nodiscard]] array<uint8_t, BITE_ENCRYPTED_AES_KEY_LEN> data() const {
+      return regularTxKey;
    }
 
    [[nodiscard]] shared_ptr<string> toHex() const;
 };
+
+using EncryptedAESKeys = small_vector< EncryptedAESKey >;

--- a/crypto/MockupAESKeyDecryptionShare.cpp
+++ b/crypto/MockupAESKeyDecryptionShare.cpp
@@ -18,8 +18,8 @@ string MockupAESKeyDecryptionShare::toString() {
 }
 
 
-ptr<MockupAESKeyDecryptionShare> MockupAESKeyDecryptionShare::mockupDecrypt(ptr<EncryptedAESKey> _key,
+ptr<MockupAESKeyDecryptionShare> MockupAESKeyDecryptionShare::mockupDecrypt(EncryptedAESKey& _key,
                                                       schain_index _decryptorIndex) {
-    return make_shared<MockupAESKeyDecryptionShare>(*_key->toHex(),
+    return make_shared<MockupAESKeyDecryptionShare>(*_key.toHex(),
                                                     _decryptorIndex, false);
 }

--- a/crypto/MockupAESKeyDecryptionShare.h
+++ b/crypto/MockupAESKeyDecryptionShare.h
@@ -16,6 +16,6 @@ public:
 
     ~MockupAESKeyDecryptionShare() override;
 
-    static ptr<MockupAESKeyDecryptionShare> mockupDecrypt(ptr <EncryptedAESKey> _key, schain_index _decryptorIndex);
+    static ptr<MockupAESKeyDecryptionShare> mockupDecrypt(EncryptedAESKey& _key, schain_index _decryptorIndex);
 };
 

--- a/crypto/MockupAESKeyDecryptionShareSet.cpp
+++ b/crypto/MockupAESKeyDecryptionShareSet.cpp
@@ -68,7 +68,7 @@
         return ( decryptionShares.size() >= requiredDecryptors );
     }
 
-    bool MockupAESKeyDecryptionShareSet::addDecryptionShares(
+    bool MockupAESKeyDecryptionShareSet::addDecryptionSharesFromSameDecryptor(
         const ptr< AESKeyDecryptionShares >& _decryptionShares ) {
         CHECK_ARGUMENT( _decryptionShares );
 

--- a/crypto/MockupAESKeyDecryptionShareSet.cpp
+++ b/crypto/MockupAESKeyDecryptionShareSet.cpp
@@ -27,16 +27,11 @@
         totalObjects--;
     }
 
-    ptr< DecryptedAESKey > MockupAESKeyDecryptionShareSet::verifyAndMergeAESKey(ptr<EncryptedAESKey>) {
-        string h( "" );
-
+    ptr< DecryptedAESKeys > MockupAESKeyDecryptionShareSet::verifyAndMergeAESKeys(EncryptedAESKeys& _encryptedAESKeys) {
         READ_LOCK( decryptionSharesLock )
-
         CHECK_STATE(decryptionShares.size() >= requiredDecryptors);
 
-
         //check all shares are the same
-
         std::string first;
         for (auto&& item : decryptionShares) {
             CHECK_STATE(item.second);
@@ -46,6 +41,7 @@
                 CHECK_STATE(item.second->toString() == first);  // Add this line
             }
         }
+
         CHECK_STATE( !first.empty() );
         CHECK_STATE(first.size() == BITE_ENCRYPTED_AES_KEY_LEN * 2);
 
@@ -54,9 +50,13 @@
 
         Utils::cArrayFromHex(first, encryptedKey.data(), BITE_ENCRYPTED_AES_KEY_LEN);
 
-        std::copy_n(encryptedKey.begin(), BITE_AES_KEY_LEN, decryptedKey.begin());
+        ptr< DecryptedAESKeys > decryptedKeys = std::make_shared<DecryptedAESKeys>();
+        for (size_t i = 0 ; i < _encryptedAESKeys.size(); i++) {
+            std::copy_n(encryptedKey.begin(), BITE_AES_KEY_LEN, decryptedKey.begin());
+            decryptedKeys->push_back( DecryptedAESKey( decryptedKey ) );
+        }
 
-        return make_shared< DecryptedAESKey >(decryptedKey);
+        return decryptedKeys;
     }
 
     bool MockupAESKeyDecryptionShareSet::isEnough() {
@@ -68,24 +68,24 @@
         return ( decryptionShares.size() >= requiredDecryptors );
     }
 
-    bool MockupAESKeyDecryptionShareSet::addDecryptionShare(
-        const ptr< AESKeyDecryptionShare >& _decryptionShare ) {
-        CHECK_ARGUMENT( _decryptionShare );
+    bool MockupAESKeyDecryptionShareSet::addDecryptionShares(
+        const ptr< AESKeyDecryptionShares >& _decryptionShares ) {
+        CHECK_ARGUMENT( _decryptionShares );
 
         WRITE_LOCK( decryptionSharesLock )
 
         if ( isEnoughUnsafe() )
             return false;
 
-        if ( decryptionShares.count( ( uint64_t ) _decryptionShare->getDecryptorIndex() ) > 0 ) {
+        if ( decryptionShares.count( ( uint64_t ) _decryptionShares->at(0)->getDecryptorIndex() ) > 0 ) {
             return false;
         }
 
-        auto ds = dynamic_pointer_cast< MockupAESKeyDecryptionShare >( _decryptionShare );
-
+        // only add the 1st share
+        ptr< MockupAESKeyDecryptionShare > ds = dynamic_pointer_cast< MockupAESKeyDecryptionShare >( _decryptionShares->at(0) );
         CHECK_STATE( ds );
+        decryptionShares[( uint64_t ) _decryptionShares->at(0)->getDecryptorIndex()] = ds;
 
-        decryptionShares[( uint64_t ) _decryptionShare->getDecryptorIndex()] = ds;
 
         return true;
     }

--- a/crypto/MockupAESKeyDecryptionShareSet.h
+++ b/crypto/MockupAESKeyDecryptionShareSet.h
@@ -15,6 +15,7 @@ class BLAKE3Hash;
 
 class MockupAESKeyDecryptionShareSet : public AESKeyDecryptionShareSet {
 
+    // stores single share from each decryptor
     std::map< size_t, ptr< MockupAESKeyDecryptionShare > > decryptionShares;  // tsafe
     
     size_t totalDecryptors; 
@@ -28,11 +29,11 @@ public:
     MockupAESKeyDecryptionShareSet( block_id _blockId, transaction_index _transactionIndex,
         size_t _totalDecryptors, size_t _requiredDecryptors );
 
-    ptr< DecryptedAESKey > verifyAndMergeAESKey(ptr<EncryptedAESKey>  _encryptedAESKey) override;
+    ptr< DecryptedAESKeys > verifyAndMergeAESKeys(EncryptedAESKeys&  _encryptedAESKey) override;
 
-    bool addDecryptionShare( const ptr< AESKeyDecryptionShare >& _sigShare );
+    bool addDecryptionShares( const ptr< AESKeyDecryptionShares >& _sigShare ) override;
 
-    bool isEnough();
+    bool isEnough() override;
 
     virtual ~MockupAESKeyDecryptionShareSet();
 };

--- a/crypto/MockupAESKeyDecryptionShareSet.h
+++ b/crypto/MockupAESKeyDecryptionShareSet.h
@@ -31,7 +31,7 @@ public:
 
     ptr< DecryptedAESKeys > verifyAndMergeAESKeys(EncryptedAESKeys&  _encryptedAESKey) override;
 
-    bool addDecryptionShares( const ptr< AESKeyDecryptionShares >& _sigShare ) override;
+    bool addDecryptionSharesFromSameDecryptor( const ptr< AESKeyDecryptionShares >& _sigShare ) override;
 
     bool isEnough() override;
 

--- a/crypto/MockupTEPublicKey.cpp
+++ b/crypto/MockupTEPublicKey.cpp
@@ -12,25 +12,25 @@ ptr<EncryptedAESKey> MockupTEPublicKey::encryptAESKey(ptr<DecryptedAESKey>& _dec
     CHECK_STATE(_decryptedAESKey);
 
     // Allocate encrypted key bytes and random bytes
-    auto encryptedKeyBytes = std::make_shared<std::array<std::uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>>();
-    auto randomBytes = std::make_shared<std::array<std::uint8_t, BITE_TE_RANDOM_LEN>>();
+    auto encryptedKeyBytes = std::array<std::uint8_t, BITE_ENCRYPTED_AES_KEY_LEN>();
+    auto randomBytes = std::array<std::uint8_t, BITE_TE_RANDOM_LEN>();
 
-    std::iota(randomBytes->begin(), randomBytes->end(), 0);
+    std::iota(randomBytes.begin(), randomBytes.end(), 0);
 
-    encryptedKeyBytes->at(0) = 1;
+    encryptedKeyBytes.at(0) = 1;
 
     // Copy AES key into encryptedKeyBytes starting from index 1
     std::copy_n(
         _decryptedAESKey->getAesKey().begin(),
         BITE_AES_KEY_LEN,
-        encryptedKeyBytes->begin() + 1
+        encryptedKeyBytes.begin() + 1
     );
 
     // Copy random bytes after the AES key in the encryptedKeyBytes
     std::copy(
-        randomBytes->begin(),
-        randomBytes->end(),
-        encryptedKeyBytes->begin() + 1 + BITE_AES_KEY_LEN
+        randomBytes.begin(),
+        randomBytes.end(),
+        encryptedKeyBytes.begin() + 1 + BITE_AES_KEY_LEN
     );
 
     return std::make_shared<EncryptedAESKey>(encryptedKeyBytes);

--- a/crypto/ThresholdSigShareSet.cpp
+++ b/crypto/ThresholdSigShareSet.cpp
@@ -37,3 +37,7 @@ ThresholdSigShareSet::ThresholdSigShareSet(
     : blockId( _blockId ), totalSigners( _totalSigners ), requiredSigners( _requiredSigners ) {}
 
 ThresholdSigShareSet::~ThresholdSigShareSet() {}
+
+uint64_t ThresholdSigShareSet::getRequiredSigners() const {
+    return requiredSigners;
+}

--- a/crypto/ThresholdSigShareSet.h
+++ b/crypto/ThresholdSigShareSet.h
@@ -42,6 +42,8 @@ public:
 
     static int64_t getTotalObjects();
 
+    uint64_t getRequiredSigners() const;
+
     virtual ptr< ThresholdSignature > mergeSignature() = 0;
 
     virtual bool isEnough() = 0;

--- a/crypto/TransactionCiphertexts.cpp
+++ b/crypto/TransactionCiphertexts.cpp
@@ -1,0 +1,12 @@
+#include "TransactionCiphertexts.h"
+#include "libBLS/threshold_encryption/threshold_encryption.h"
+
+TransactionCiphertexts::TransactionCiphertexts(ptr<BiteCiphertext> ciphertext) {
+    ciphertexts.push_back(ciphertext->getEncryptedAESKey());
+}
+
+TransactionCiphertexts::TransactionCiphertexts(std::vector<ptr<BiteCiphertext>>& ciphertextsVec) {
+    for (const auto& ciphertext : ciphertextsVec) {
+        ciphertexts.push_back(ciphertext->getEncryptedAESKey());
+    }
+}

--- a/crypto/TransactionCiphertexts.h
+++ b/crypto/TransactionCiphertexts.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <memory>
+#include <array>
+#include <vector>
+#include <cstdint>
+#include "EncryptedAESKey.h"
+#include <SkaleCommon.h>
+#include <bite/BiteCiphertext.h>
+#include "datastructures/SmallVector.h"
+
+namespace libBLS {
+    class CipheredKey;
+}
+
+/**
+ * @brief Holds ciphertexts (EncryptedAESKeys) for a transaction. Transactions may have
+ * 1 or multiple ciphertexts, depending on whether they are:
+ * 
+ * 1) A regular transaction - with a single EncryptedAESKey (single ciphertext)
+ * 
+ * 2) A CAT transaction - with multiple EncryptedAESKeys (multiple ciphertexts)
+ */
+class TransactionCiphertexts {
+    
+    small_vector<EncryptedAESKey> ciphertexts;
+
+public:
+    TransactionCiphertexts( ptr<BiteCiphertext> ciphertext);
+    TransactionCiphertexts(std::vector<ptr<BiteCiphertext>>& ciphertextsVec);
+
+    auto begin() const { return ciphertexts.begin(); }
+    auto end()   const { return ciphertexts.end();   }
+    auto cbegin() const { return ciphertexts.cbegin(); }
+    auto cend()   const { return ciphertexts.cend();   }
+    size_t count() const { return ciphertexts.size(); }
+
+    EncryptedAESKeys& getCiphertexts() {
+        return ciphertexts;
+    }
+
+    const EncryptedAESKey& operator[](size_t i) const {
+        return ciphertexts[i];
+    }
+
+    EncryptedAESKey& operator[](size_t i) {
+        return ciphertexts[i];
+    }
+
+    [[nodiscard]] std::shared_ptr<std::string> toHex() const;
+};

--- a/datastructures/BlockProposal.cpp
+++ b/datastructures/BlockProposal.cpp
@@ -333,7 +333,7 @@ ptr<BlockProposal>  BlockProposal::makeFromDBSerialized(
 #ifdef BITE
     BiteManager::parseBITETransactions(proposal);
     CHECK_STATE2(proposal->getFailedTransactionsRef().empty(), "Invalid BITE proposal received");
-    CHECK_STATE2(proposal->getEncryptedAESKeys(), "Missing encrypted AES keys");
+    CHECK_STATE2(proposal->getTransactionCiphertexts(), "Missing encrypted AES keys");
 #endif
 
     return proposal;

--- a/datastructures/BlockProposal.h
+++ b/datastructures/BlockProposal.h
@@ -49,7 +49,7 @@ class BasicHeader;
 class BlockProposalHeader;
 class BlockProposalFragment;
 class BlockProposalFragmentList;
-class BiteDataField;
+class BiteCiphertext;
 
 #define SERIALIZE_AS_PROPOSAL 1
 

--- a/datastructures/BlockProposal.h
+++ b/datastructures/BlockProposal.h
@@ -54,12 +54,11 @@ class BiteCiphertext;
 #define SERIALIZE_AS_PROPOSAL 1
 
 #ifdef BITE
+#include "crypto/TransactionCiphertexts.h"
 #include "abstracttcpserver/ConnectionStatus.h"
 class AESKeyDecryptionShareList;
+class TransactionCiphertextsMap;
 #endif
-
-class EncryptedAESKey;
-using EncryptedAESKeyMap = boost::container::flat_map<transaction_index, ptr<EncryptedAESKey> >;
 
 
 class BlockProposal : public SendableItem {
@@ -207,12 +206,14 @@ public:
 
 private:
     ptr<AESKeyDecryptionShareList> myDecryptionShares = nullptr;
-    ptr<EncryptedAESKeyMap> encryptedAESKeys = nullptr;
+
+    // Stores 1 or more ciphertexts associated with some transaction index
+    ptr<TransactionCiphertextsMap> transactionCiphertexts = nullptr;
 
     // this will normally be empty
     map<transaction_index, ConnectionSubStatus> failedTransactions;
     // the encrypted AES key batch to send to SGX server
-    ptr<vector<ptr<string>>> sgxAESKeyBatch;
+    ptr<vector<string>> sgxAESKeyBatch;
 
 public:
     [[nodiscard]] map<transaction_index, ConnectionSubStatus>& getFailedTransactionsRef() {
@@ -226,13 +227,12 @@ public:
     }
 
 
-    [[nodiscard]] ptr<vector<ptr<string>>> getSGXAESKeyBatch() const {
+    [[nodiscard]] ptr<vector<string>> getSGXAESKeyBatch() const {
         auto result = std::atomic_load(&sgxAESKeyBatch);
         return result;
     }
 
-    void setSGXAESKeyBatch(
-            ptr<vector<ptr<string>>>  _sgxAESKeyBatch) {
+    void setSGXAESKeyBatch(ptr<vector<string>>  _sgxAESKeyBatch) {
         CHECK_STATE(!sgxAESKeyBatch)
         sgxAESKeyBatch = _sgxAESKeyBatch;
     }
@@ -245,16 +245,16 @@ public:
     }
 
 
-    void setAESKeyMap(ptr<EncryptedAESKeyMap> _EncryptedAESKeyMap) {
+    void setTransactionCiphertexts(ptr<TransactionCiphertextsMap> _EncryptedAESKeyMap) {
         CHECK_STATE(_EncryptedAESKeyMap)
         // verify we are not setting it twice
-        CHECK_STATE(std::atomic_exchange(&encryptedAESKeys, _EncryptedAESKeyMap) == nullptr);
+        CHECK_STATE(std::atomic_exchange(&transactionCiphertexts, _EncryptedAESKeyMap) == nullptr);
     }
 
 
-    [[nodiscard]] ptr<EncryptedAESKeyMap> getEncryptedAESKeys() const {
-        auto result = std::atomic_load(&encryptedAESKeys);
-        CHECK_STATE(encryptedAESKeys);
+    [[nodiscard]] ptr<TransactionCiphertextsMap> getTransactionCiphertexts() const {
+        auto result = std::atomic_load(&transactionCiphertexts);
+        CHECK_STATE(transactionCiphertexts);
         return result;
     }
 #endif

--- a/datastructures/BlockProposalFragment.cpp
+++ b/datastructures/BlockProposalFragment.cpp
@@ -136,7 +136,7 @@ ptr< vector< uint8_t > > BlockProposalFragment::serialize(
         fbData = builder.CreateVector( *data );
     }
 
-    // ✅ Create empty vector of raw pointers for Hash*
+    // Create empty vector of raw pointers for Hash*
     auto emptyHashVec = builder.CreateVector< const skale_fb::Hash* >( {} );
     std::vector< flatbuffers::Offset< skale_fb::DecryptionShare > > decryptionShareOffsets;
 
@@ -146,10 +146,15 @@ ptr< vector< uint8_t > > BlockProposalFragment::serialize(
     }
 
 
-    for ( const auto& decryptionShare : decryptionShares->getDecryptionShares() ) {
-        uint32_t transactionIndex = ( uint32_t ) decryptionShare.first;
-        const auto decryptionData =
-            decryptionShare.second->toString();  // Assumes std::string or std::vector<uint8_t>
+    for ( const auto& [txId, decryptionShares] : decryptionShares->getDecryptionShares() ) {
+        uint32_t transactionIndex = ( uint32_t ) txId;
+        std::string decryptionData;
+        for ( size_t i = 0; i < decryptionShares->size(); i++ ) {
+            decryptionData += decryptionShares->at(i)->toString();
+            if ( i != decryptionShares->size() - 1 ) {
+                decryptionData += ",";
+            }
+        }
         auto dataOffset =
             builder.CreateVector( reinterpret_cast< const uint8_t* >( decryptionData.data() ), decryptionData.size() );
 

--- a/datastructures/CommittedBlock.cpp
+++ b/datastructures/CommittedBlock.cpp
@@ -48,7 +48,8 @@ ptr<CommittedBlock> CommittedBlock::makeFromProposal(const ptr<BlockProposal> &_
                                                      ptr<ThresholdSignature> _daSig
 #ifdef  BITE
                                                      , ptr<DecryptedAESKeyList> _aesKeyList,
-                                                     ptr< DecryptedRegularTxsMap > _decryptedTransactionFields
+                                                     DecryptedTransactions _decryptedTransactions
+
 #endif
 ) {
     CHECK_ARGUMENT(_proposal);
@@ -56,7 +57,6 @@ ptr<CommittedBlock> CommittedBlock::makeFromProposal(const ptr<BlockProposal> &_
     CHECK_ARGUMENT(_daSig || _proposal->getProposerIndex() == 0)
 #ifdef BITE
     CHECK_ARGUMENT(_aesKeyList);
-    CHECK_ARGUMENT(_decryptedTransactionFields);
 #endif
 
 
@@ -76,7 +76,7 @@ ptr<CommittedBlock> CommittedBlock::makeFromProposal(const ptr<BlockProposal> &_
                                 _proposal->getStateRoot(), _proposal->getTimeStampS(), _proposal->getTimeStampMs(),
                                 _proposal->getSignature(), _thresholdSig->toString(), daSig
 #ifdef  BITE
-                                , _aesKeyList, _decryptedTransactionFields
+                                , _aesKeyList, _decryptedTransactions
 #endif
     );
 }
@@ -93,7 +93,7 @@ ptr<CommittedBlock> CommittedBlock::make(const schain_id _sChainId,
                                          const string &_daSig
 #ifdef  BITE
                                          , ptr<DecryptedAESKeyList> _aesKeyList,
-                                         ptr< DecryptedRegularTxsMap > _decryptedTransactionFields
+                                         DecryptedTransactions _decryptedTransactions
 #endif
 ) {
     CHECK_ARGUMENT(_transactions);
@@ -102,21 +102,20 @@ ptr<CommittedBlock> CommittedBlock::make(const schain_id _sChainId,
 
 #ifdef BITE
     CHECK_ARGUMENT(_aesKeyList);
-    CHECK_ARGUMENT(_decryptedTransactionFields);
 #endif
 
 
     return ptr<CommittedBlock>(new CommittedBlock(_sChainId, _proposerNodeId, _blockId,
 #ifdef BITE
-                                                  _epochId,
+    _epochId,
 #endif
     _proposerIndex,
-                                                  _transactions, _stateRoot, _timeStamp, _timeStampMs, _signature,
-                                                  _thresholdSig, _daSig
+    _transactions, _stateRoot, _timeStamp, _timeStampMs, _signature,
+    _thresholdSig, _daSig
 
 #ifdef BITE
     , _aesKeyList,
-    _decryptedTransactionFields
+    _decryptedTransactions
 #endif
 
     ));
@@ -163,7 +162,7 @@ ptr<CommittedBlock> CommittedBlock::createRandomSample(const ptr<CryptoManager> 
                                 p->getTimeStampMs(), p->getSignature(), "EMPTY", "EMPTY"
 #ifdef BITE
                                 , make_shared<DecryptedAESKeyList>(),
-                                make_shared<DecryptedRegularTxsMap>()
+                                DecryptedTransactions()
 #endif
         );
 }
@@ -243,7 +242,7 @@ ptr<CommittedBlock> CommittedBlock::deserialize(const ptr<vector<uint8_t> > &_se
                                      blockHeader->getSignature(), blockHeader->getThresholdSig(),
                                      blockHeader->getDaSig()
 #ifdef BITE
-                                     , make_shared<DecryptedAESKeyList>(), make_shared<DecryptedRegularTxsMap>()
+                                     , make_shared<DecryptedAESKeyList>(), DecryptedTransactions()
 #endif
             );
     } catch (...) {
@@ -312,7 +311,7 @@ CommittedBlock::CommittedBlock(const schain_id &_schainId, const node_id &_propo
                                __uint32_t timeStampMs, const string &_signature, const string &_thresholdSig,
                                const string &_daSig
 #ifdef  BITE
-                               , ptr<DecryptedAESKeyList> _aesKeyList, ptr<DecryptedRegularTxsMap> _decryptedTransactionFields
+                               , ptr<DecryptedAESKeyList> _aesKeyList, DecryptedTransactions _decryptedTransactions
 #endif
 )
     : BlockProposal(_schainId, _proposerNodeId, _blockId,
@@ -326,14 +325,13 @@ CommittedBlock::CommittedBlock(const schain_id &_schainId, const node_id &_propo
     CHECK_ARGUMENT(!_thresholdSig.empty());
 #ifdef BITE
     CHECK_ARGUMENT(_aesKeyList);
-    CHECK_ARGUMENT(_decryptedTransactionFields);
 #endif
 
     this->thresholdSig = _thresholdSig;
     this->daSig = _daSig;
 #ifdef BITE
     this->decryptedAesKeyList = _aesKeyList;
-    this->decryptedTransactionFields = _decryptedTransactionFields;
+    this->decryptedTransactions = _decryptedTransactions;
 #endif
 }
 
@@ -397,9 +395,19 @@ void CommittedBlock::verifyDaSig(ptr<CryptoManager> _cryptoManager) {
 }
 
 #ifdef BITE
-ptr< DecryptedRegularTxsMap > CommittedBlock::getDecryptedRegularTxFields() const {
-    return decryptedTransactionFields;
+DecryptedTransactions CommittedBlock::getDecryptedTransactions() const {
+    return decryptedTransactions;
 }
+
+ptr< DecryptedRegularTxsMap > CommittedBlock::getDecryptedRegularTxFields() const {
+    return decryptedTransactions.regularTxsMap;
+}
+
+#ifdef BITE2
+ptr< DecryptedCATxsMap > CommittedBlock::getDecryptedCATArgs() const {
+    return decryptedTransactions.catTxsMap;
+}
+#endif
 #endif
 
 void CommittedBlock::setCachedSerializedBlock(

--- a/datastructures/CommittedBlock.cpp
+++ b/datastructures/CommittedBlock.cpp
@@ -48,7 +48,7 @@ ptr<CommittedBlock> CommittedBlock::makeFromProposal(const ptr<BlockProposal> &_
                                                      ptr<ThresholdSignature> _daSig
 #ifdef  BITE
                                                      , ptr<DecryptedAESKeyList> _aesKeyList,
-                                                     ptr< DecryptedTransactionFieldsMap > _decryptedTransactionFields
+                                                     ptr< DecryptedRegularTxsMap > _decryptedTransactionFields
 #endif
 ) {
     CHECK_ARGUMENT(_proposal);
@@ -93,7 +93,7 @@ ptr<CommittedBlock> CommittedBlock::make(const schain_id _sChainId,
                                          const string &_daSig
 #ifdef  BITE
                                          , ptr<DecryptedAESKeyList> _aesKeyList,
-                                         ptr< DecryptedTransactionFieldsMap > _decryptedTransactionFields
+                                         ptr< DecryptedRegularTxsMap > _decryptedTransactionFields
 #endif
 ) {
     CHECK_ARGUMENT(_transactions);
@@ -163,7 +163,7 @@ ptr<CommittedBlock> CommittedBlock::createRandomSample(const ptr<CryptoManager> 
                                 p->getTimeStampMs(), p->getSignature(), "EMPTY", "EMPTY"
 #ifdef BITE
                                 , make_shared<DecryptedAESKeyList>(),
-                                make_shared<DecryptedTransactionFieldsMap>()
+                                make_shared<DecryptedRegularTxsMap>()
 #endif
         );
 }
@@ -243,7 +243,7 @@ ptr<CommittedBlock> CommittedBlock::deserialize(const ptr<vector<uint8_t> > &_se
                                      blockHeader->getSignature(), blockHeader->getThresholdSig(),
                                      blockHeader->getDaSig()
 #ifdef BITE
-                                     , make_shared<DecryptedAESKeyList>(), make_shared<DecryptedTransactionFieldsMap>()
+                                     , make_shared<DecryptedAESKeyList>(), make_shared<DecryptedRegularTxsMap>()
 #endif
             );
     } catch (...) {
@@ -312,7 +312,7 @@ CommittedBlock::CommittedBlock(const schain_id &_schainId, const node_id &_propo
                                __uint32_t timeStampMs, const string &_signature, const string &_thresholdSig,
                                const string &_daSig
 #ifdef  BITE
-                               , ptr<DecryptedAESKeyList> _aesKeyList, ptr<DecryptedTransactionFieldsMap> _decryptedTransactionFields
+                               , ptr<DecryptedAESKeyList> _aesKeyList, ptr<DecryptedRegularTxsMap> _decryptedTransactionFields
 #endif
 )
     : BlockProposal(_schainId, _proposerNodeId, _blockId,
@@ -397,7 +397,7 @@ void CommittedBlock::verifyDaSig(ptr<CryptoManager> _cryptoManager) {
 }
 
 #ifdef BITE
-ptr< DecryptedTransactionFieldsMap > CommittedBlock::getDecryptedTransactionFields() const {
+ptr< DecryptedRegularTxsMap > CommittedBlock::getDecryptedRegularTxFields() const {
     return decryptedTransactionFields;
 }
 #endif

--- a/datastructures/CommittedBlock.h
+++ b/datastructures/CommittedBlock.h
@@ -49,10 +49,16 @@ class CommittedBlock : public BlockProposal {
     string daSig;
 #ifdef BITE
     ptr<DecryptedAESKeyList> decryptedAesKeyList = nullptr;
-    ptr< DecryptedRegularTxsMap > decryptedTransactionFields = nullptr;
+    DecryptedTransactions decryptedTransactions;
 
 public:
-    [[nodiscard]] ptr< std::map<TxId, DecryptedRegularTxFields> > getDecryptedRegularTxFields() const;
+    DecryptedTransactions getDecryptedTransactions() const;
+    [[nodiscard]] ptr< DecryptedRegularTxsMap > getDecryptedRegularTxFields() const;
+
+#ifdef BITE2
+    [[nodiscard]] ptr< DecryptedCATxsMap > getDecryptedCATArgs() const;
+#endif
+
 #endif
 
 
@@ -80,7 +86,7 @@ protected:
         __uint32_t _timeStampMs, const string& _signature, const string& _thresholdSig,
         const string& _daSig
 #ifdef  BITE
-, ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedRegularTxsMap > _decryptedTransactionFields
+, ptr< DecryptedAESKeyList > _aesKeyList, DecryptedTransactions _decryptedTransactions
 #endif
         );
 
@@ -96,7 +102,7 @@ public:
     static ptr< CommittedBlock > makeFromProposal( const ptr< BlockProposal >& _proposal,
         const ptr< ThresholdSignature >& _thresholdSig, ptr< ThresholdSignature > _daSig
 #ifdef  BITE
-    , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedRegularTxsMap > _decryptedTransactions
+    , ptr< DecryptedAESKeyList > _aesKeyList, DecryptedTransactions _decryptedTransactions
 #endif
         );
 
@@ -109,7 +115,7 @@ public:
         const u256& _stateRoot, uint64_t _timeStamp, uint64_t _timeStampMs,
         const string& _signature, const string& _thresholdSig, const string& _daSig
 #ifdef  BITE
-    , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedRegularTxsMap > _decryptedTransactrions
+    , ptr< DecryptedAESKeyList > _aesKeyList, DecryptedTransactions _decryptedTransactions
 #endif
         );
 

--- a/datastructures/CommittedBlock.h
+++ b/datastructures/CommittedBlock.h
@@ -49,10 +49,10 @@ class CommittedBlock : public BlockProposal {
     string daSig;
 #ifdef BITE
     ptr<DecryptedAESKeyList> decryptedAesKeyList = nullptr;
-    ptr< DecryptedTransactionFieldsMap > decryptedTransactionFields = nullptr;
+    ptr< DecryptedRegularTxsMap > decryptedTransactionFields = nullptr;
 
 public:
-    [[nodiscard]] ptr< std::map<TxId, DecryptedTransactionFields> > getDecryptedTransactionFields() const;
+    [[nodiscard]] ptr< std::map<TxId, DecryptedRegularTxFields> > getDecryptedRegularTxFields() const;
 #endif
 
 
@@ -80,7 +80,7 @@ protected:
         __uint32_t _timeStampMs, const string& _signature, const string& _thresholdSig,
         const string& _daSig
 #ifdef  BITE
-, ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedTransactionFieldsMap > _decryptedTransactionFields
+, ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedRegularTxsMap > _decryptedTransactionFields
 #endif
         );
 
@@ -96,7 +96,7 @@ public:
     static ptr< CommittedBlock > makeFromProposal( const ptr< BlockProposal >& _proposal,
         const ptr< ThresholdSignature >& _thresholdSig, ptr< ThresholdSignature > _daSig
 #ifdef  BITE
-    , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedTransactionFieldsMap > _decryptedTransactions
+    , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedRegularTxsMap > _decryptedTransactions
 #endif
         );
 
@@ -109,7 +109,7 @@ public:
         const u256& _stateRoot, uint64_t _timeStamp, uint64_t _timeStampMs,
         const string& _signature, const string& _thresholdSig, const string& _daSig
 #ifdef  BITE
-    , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedTransactionFieldsMap > _decryptedTransactrions
+    , ptr< DecryptedAESKeyList > _aesKeyList, ptr< DecryptedRegularTxsMap > _decryptedTransactrions
 #endif
         );
 

--- a/datastructures/MyBlockProposal.cpp
+++ b/datastructures/MyBlockProposal.cpp
@@ -64,6 +64,7 @@ ptr<MyBlockProposal> MyBlockProposal::createMyProposal(
     const schain_index &_proposerIndex,
     const ptr<TransactionList> &_transactions, u256 _stateRoot, uint64_t _timeStamp,
     uint32_t _timeStampMs, const ptr<CryptoManager> &_cryptoManager) {
+
     auto proposal = shared_ptr<MyBlockProposal>(new MyBlockProposal(
         _sChain, _blockID,
 #ifdef BITE
@@ -71,7 +72,7 @@ ptr<MyBlockProposal> MyBlockProposal::createMyProposal(
 #endif
         _proposerIndex, _transactions, _stateRoot, _timeStamp, _timeStampMs, _cryptoManager));
 
-#ifdef BITE
+        #ifdef BITE
     BiteManager::parseBITETransactions(proposal);
     CHECK_STATE(proposal->getFailedTransactionsRef().empty());
 #endif

--- a/datastructures/MyBlockProposal.cpp
+++ b/datastructures/MyBlockProposal.cpp
@@ -72,7 +72,7 @@ ptr<MyBlockProposal> MyBlockProposal::createMyProposal(
 #endif
         _proposerIndex, _transactions, _stateRoot, _timeStamp, _timeStampMs, _cryptoManager));
 
-        #ifdef BITE
+#ifdef BITE
     BiteManager::parseBITETransactions(proposal);
     CHECK_STATE(proposal->getFailedTransactionsRef().empty());
 #endif

--- a/datastructures/SmallVector.h
+++ b/datastructures/SmallVector.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <boost/container/small_vector.hpp>
+
+template< typename T >
+using small_vector = typename boost::container::small_vector< T, 1 >;

--- a/datastructures/Transaction.cpp
+++ b/datastructures/Transaction.cpp
@@ -35,7 +35,7 @@
 
 #ifdef  BITE
 #include "rlp/ParsedEthTransaction.h"
-#include "bite/BiteDataField.h"
+#include "bite/BiteCiphertext.h"
 #include "rlp/EthTransactionEncoder.h"
 #endif
 
@@ -186,12 +186,12 @@ ptr<ParsedEthTransaction> Transaction::getAsEthereumTransaction() {
 }
 
 
-ptr<BiteDataField> Transaction::getRegularTxEncryptedData() {
+ptr<BiteCiphertext> Transaction::getRegularTxEncryptedData() {
     // thread safe
     return std::atomic_load(&parsedBiteDataField );
 }
 
-void Transaction::setRegularTxEncryptedData( ptr<BiteDataField> _biteDataField ) {
+void Transaction::setRegularTxEncryptedData( ptr<BiteCiphertext> _biteDataField ) {
     // thread safe
     std::atomic_store(&parsedBiteDataField, _biteDataField);
 }

--- a/datastructures/Transaction.cpp
+++ b/datastructures/Transaction.cpp
@@ -173,6 +173,18 @@ ptr< Transaction > Transaction::createRandomSample( uint64_t _size, boost::rando
 
 #ifdef BITE
 
+ptr< vector< uint8_t > > Transaction::emplaceAndReencodeTransaction(
+    vector< uint8_t >& _originalDataField ) {
+
+    // thread safe
+    auto pt = std::atomic_load(&parsedAndValidatedEthTransaction );
+    CHECK_STATE(pt);
+    pt->setTransactionDataField(_originalDataField);
+    return EthTransactionEncoder::rlpEncodeWithoutSig(*pt);
+};
+
+// ------- Cached Fields -----------
+
 ptr<ParsedEthTransaction> Transaction::getAsEthereumTransaction() {
     // thread safe
     auto pt = std::atomic_load(&parsedAndValidatedEthTransaction );
@@ -185,24 +197,24 @@ ptr<ParsedEthTransaction> Transaction::getAsEthereumTransaction() {
     return pt;
 }
 
-
 ptr<BiteCiphertext> Transaction::getRegularTxEncryptedData() {
     // thread safe
-    return std::atomic_load(&parsedBiteDataField );
+    return std::atomic_load(&parsedEncryptedRegularTx );
 }
-
 void Transaction::setRegularTxEncryptedData( ptr<BiteCiphertext> _biteDataField ) {
     // thread safe
-    std::atomic_store(&parsedBiteDataField, _biteDataField);
+    std::atomic_store(&parsedEncryptedRegularTx, _biteDataField);
 }
 
-ptr< vector< uint8_t > > Transaction::emplaceAndReencodeTransaction(
-    vector< uint8_t >& _originalDataField ) {
-
+#ifdef BITE2
+ptr<std::vector<ptr<BiteCiphertext>>> Transaction::getCATEncryptedArgs() {
     // thread safe
-    auto pt = std::atomic_load(&parsedAndValidatedEthTransaction );
-    CHECK_STATE(pt);
-    pt->setTransactionDataField(_originalDataField);
-    return EthTransactionEncoder::rlpEncodeWithoutSig(*pt);
-};
+    return std::atomic_load(&parsedEncryptedCATArgs );
+}
+void Transaction::setCATEncryptedArgs( ptr<std::vector<ptr<BiteCiphertext>>> _biteDataField ) {
+    // thread safe
+    std::atomic_store(&parsedEncryptedCATArgs, _biteDataField);
+}
+#endif
+
 #endif

--- a/datastructures/Transaction.cpp
+++ b/datastructures/Transaction.cpp
@@ -35,7 +35,7 @@
 
 #ifdef  BITE
 #include "rlp/ParsedEthTransaction.h"
-#include "bite/BiteDataFiled.h"
+#include "bite/BiteDataField.h"
 #include "rlp/EthTransactionEncoder.h"
 #endif
 
@@ -173,34 +173,27 @@ ptr< Transaction > Transaction::createRandomSample( uint64_t _size, boost::rando
 
 #ifdef BITE
 
-void Transaction::parseAndValidate() {
+ptr<ParsedEthTransaction> Transaction::getAsEthereumTransaction() {
     // thread safe
     auto pt = std::atomic_load(&parsedAndValidatedEthTransaction );
-    if (pt)
-        return;
+    
+    if (pt) return pt;
+    
     pt = ParsedEthTransaction::parse( *data);
     CHECK_STATE(pt)
     std::atomic_store(&parsedAndValidatedEthTransaction, pt );
+    return pt;
 }
 
 
-ptr< BiteDataField > Transaction::tryGetBiteData(epoch_id _currentEpochId) {
-    auto pt = std::atomic_load(&parsedBiteDataField);
-    if (pt)
-        return pt;
+ptr<BiteDataField> Transaction::getRegularTxEncryptedData() {
+    // thread safe
+    return std::atomic_load(&parsedBiteDataField );
+}
 
-    auto tx = std::atomic_load(&parsedAndValidatedEthTransaction );
-
-    ptr< BiteDataField > result = nullptr;
-    
-    if (tx->hasToField()) {
-        auto dataField = tx->getTransactionDataField();
-        auto to = tx->getToField();
-        result = BiteDataField::createIfMagicMatches(dataField, to, _currentEpochId);
-        std::atomic_store(&parsedBiteDataField, result);
-    }
-
-    return result;
+void Transaction::setRegularTxEncryptedData( ptr<BiteDataField> _biteDataField ) {
+    // thread safe
+    std::atomic_store(&parsedBiteDataField, _biteDataField);
 }
 
 ptr< vector< uint8_t > > Transaction::emplaceAndReencodeTransaction(

--- a/datastructures/Transaction.h
+++ b/datastructures/Transaction.h
@@ -41,7 +41,7 @@ class BLAKE3Hash;
 
 
 #ifdef BITE
-class BiteDataField;
+class BiteCiphertext;
 class ParsedEthTransaction;
 #endif
 
@@ -58,7 +58,7 @@ class Transaction : public DataStructure {
 
 #ifdef BITE
     ptr<ParsedEthTransaction> parsedAndValidatedEthTransaction = nullptr;
-    ptr<BiteDataField> parsedBiteDataField = nullptr;
+    ptr<BiteCiphertext> parsedBiteDataField = nullptr;
 #endif
 public:
     Transaction( const ptr< vector< uint8_t > >& _data, bool _includesPartialHash );
@@ -95,8 +95,8 @@ public:
     ptr<ParsedEthTransaction> getAsEthereumTransaction();
 
     // Allows caching parsed encrypted regular transactions' data field
-    ptr<BiteDataField> getRegularTxEncryptedData();
-    void setRegularTxEncryptedData( ptr<BiteDataField> _biteDataField );
+    ptr<BiteCiphertext> getRegularTxEncryptedData();
+    void setRegularTxEncryptedData( ptr<BiteCiphertext> _biteDataField );
 
     ptr<vector<uint8_t>> emplaceAndReencodeTransaction(vector<uint8_t>& _originalDataField );
 #endif

--- a/datastructures/Transaction.h
+++ b/datastructures/Transaction.h
@@ -91,10 +91,13 @@ public:
         boost::random::uniform_int_distribution<>& _ubyte );
 
 #ifdef BITE
-    void parseAndValidate();
+    // parses the data bytes of current transaction as an Ethereum RLP-encoded transaction 
+    ptr<ParsedEthTransaction> getAsEthereumTransaction();
 
-    // this returns nullptr for non-BITE transactions
-    ptr<BiteDataField> tryGetBiteData(epoch_id _currentEpochId);
+    // Allows caching parsed encrypted regular transactions' data field
+    ptr<BiteDataField> getRegularTxEncryptedData();
+    void setRegularTxEncryptedData( ptr<BiteDataField> _biteDataField );
+
     ptr<vector<uint8_t>> emplaceAndReencodeTransaction(vector<uint8_t>& _originalDataField );
 #endif
 

--- a/datastructures/Transaction.h
+++ b/datastructures/Transaction.h
@@ -57,8 +57,18 @@ class Transaction : public DataStructure {
     ptr< partial_sha_hash > partialHash = nullptr;
 
 #ifdef BITE
+    // --------- Cached Fields -----------
+
+    // Stores transaction bytes parsed as Ethereum transaction
     ptr<ParsedEthTransaction> parsedAndValidatedEthTransaction = nullptr;
-    ptr<BiteCiphertext> parsedBiteDataField = nullptr;
+    // Stores parsed BITE ciphertext for regular transactions
+    ptr<BiteCiphertext> parsedEncryptedRegularTx = nullptr;
+    
+#ifdef BITE2
+    // Stores a list of encrypted arguments from CAT transaction
+    ptr<std::vector<ptr<BiteCiphertext>>> parsedEncryptedCATArgs = nullptr;
+#endif
+
 #endif
 public:
     Transaction( const ptr< vector< uint8_t > >& _data, bool _includesPartialHash );
@@ -97,6 +107,12 @@ public:
     // Allows caching parsed encrypted regular transactions' data field
     ptr<BiteCiphertext> getRegularTxEncryptedData();
     void setRegularTxEncryptedData( ptr<BiteCiphertext> _biteDataField );
+
+#ifdef BITE2
+    // Allows caching parsed encrypted CAT transaction arguments
+    ptr<std::vector<ptr<BiteCiphertext>>> getCATEncryptedArgs();
+    void setCATEncryptedArgs( ptr<std::vector<ptr<BiteCiphertext>>> _biteDataField );
+#endif
 
     ptr<vector<uint8_t>> emplaceAndReencodeTransaction(vector<uint8_t>& _originalDataField );
 #endif

--- a/datastructures/TransactionCiphertextsMap.h
+++ b/datastructures/TransactionCiphertextsMap.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <memory>
+#include <boost/container/flat_map.hpp>
+#include <SkaleCommon.h>
+#include "crypto/TransactionCiphertexts.h"
+
+/**
+ * @brief A wrapper around a flat_map to keep track of total number of ciphertexts stored.
+ * Each item of the map is a TransactionCiphertexts object, which can store one or more EncryptedAESKey ciphertexts.
+ * This class keeps a cached total count of all ciphertexts across all transactions.
+ */
+class TransactionCiphertextsMap {
+
+private:
+    boost::container::flat_map<
+        transaction_index,
+        std::shared_ptr<TransactionCiphertexts>
+    > map;
+
+    // stores sum of ciphertext counts across all TransactionCiphertexts in the map
+    std::size_t totalCount = 0;
+
+public:
+    // Iterators
+    auto begin() { return map.begin(); }
+    auto end()   { return map.end();   }
+    auto begin() const { return map.begin(); }
+    auto end()   const { return map.end();   }
+
+    // Size of map
+    std::size_t size() const { return map.size(); }
+
+    // Cached total ciphertext count
+    std::size_t totalCiphertextCount() const { return totalCount; }
+
+    // Insert/Emplace
+    template<typename... Args>
+    auto emplace(Args&&... args) {
+        auto [it, inserted] = map.emplace(std::forward<Args>(args)...);
+        if (inserted) {
+            totalCount += countOf(it->second);
+        }
+        return std::make_pair(it, inserted);
+    }
+
+    // Insert or assign
+    auto insert_or_assign(const transaction_index& idx,
+                          std::shared_ptr<TransactionCiphertexts> val) {
+        auto it = map.find(idx);
+        if (it == map.end()) {
+            totalCount += countOf(val);
+            return map.insert_or_assign(idx, std::move(val));
+        } else {
+            // subtract old, add new
+            totalCount -= countOf(it->second);
+            totalCount += countOf(val);
+            return map.insert_or_assign(idx, std::move(val));
+        }
+    }
+
+    // Erase
+    std::size_t erase(const transaction_index& idx) {
+        auto it = map.find(idx);
+        if (it == map.end()) return 0;
+
+        totalCount -= countOf(it->second);
+        return map.erase(idx);
+    }
+
+    // Access operator
+    std::shared_ptr<TransactionCiphertexts>& at(const transaction_index& idx) {
+        return map.at(idx);
+    }
+
+private:
+    // helper function - normalize count to 0 if pointer is null
+    static std::size_t countOf(const std::shared_ptr<TransactionCiphertexts>& p) {
+        return p ? p->count() : 0;
+    }
+};

--- a/datastructures/TransactionList.cpp
+++ b/datastructures/TransactionList.cpp
@@ -101,7 +101,7 @@ TransactionList::TransactionList( const ptr< vector< uint64_t > >& _transactionS
 };
 
 
-ptr< vector< ptr< Transaction > > > TransactionList::getItems() {
+ptr< vector< ptr< Transaction > > > TransactionList::getItems() const {
     CHECK_STATE( transactions );
     return transactions;
 }
@@ -140,7 +140,7 @@ TransactionList::~TransactionList() {
 
 atomic< int64_t > TransactionList::totalObjects( 0 );
 
-size_t TransactionList::size() {
+size_t TransactionList::size() const {
     CHECK_STATE( transactions );
     return transactions->size();
 }

--- a/datastructures/TransactionList.cpp
+++ b/datastructures/TransactionList.cpp
@@ -145,7 +145,7 @@ size_t TransactionList::size() {
 
 ptr< ConsensusExtFace::transactions_vector > TransactionList::createTransactionVector(
 #ifdef BITE
-ptr< DecryptedTransactionFieldsMap >
+ptr< DecryptedRegularTxsMap >
 #endif
 ) {
     LOCK( m )

--- a/datastructures/TransactionList.cpp
+++ b/datastructures/TransactionList.cpp
@@ -161,9 +161,10 @@ ptr< ConsensusExtFace::Transactions > TransactionList::createTransactionVector(
 
 #ifdef BITE2
     if (biteManager) {
+        auto epochId = biteManager->getSchain()->getNode()->getCurrentEpochId();
         for (size_t i = 0; i < transactions->size(); i++) {
             auto tx = transactions->at(i);
-            if (biteManager->tryGetEncryptedCATArgs(tx, biteManager->getSchain()->getNode()->getCurrentEpochId())) {
+            if (biteManager->tryGetEncryptedCATArgs(tx, epochId)) {
                 tv->pushBackCAT(*(tx->getData()));
             }
             else {

--- a/datastructures/TransactionList.cpp
+++ b/datastructures/TransactionList.cpp
@@ -30,7 +30,10 @@
 
 #include "Transaction.h"
 #include "TransactionList.h"
-
+#ifdef BITE2
+#include "bite/BiteManager.h"
+#include "chains/Schain.h"
+#endif
 
 TransactionList::TransactionList( const ptr< vector< ptr< Transaction > > >& _transactions ) {
     CHECK_ARGUMENT( _transactions );
@@ -143,22 +146,43 @@ size_t TransactionList::size() {
 }
 
 
-ptr< ConsensusExtFace::transactions_vector > TransactionList::createTransactionVector(
-#ifdef BITE
-ptr< DecryptedRegularTxsMap >
+ptr< ConsensusExtFace::Transactions > TransactionList::createTransactionVector(
+#ifdef BITE2
+    ptr< BiteManager> biteManager
 #endif
 ) {
     LOCK( m )
 
-    auto tv = make_shared< ConsensusExtFace::transactions_vector >();
+    auto tv = make_shared< ConsensusExtFace::Transactions >();
 
     CHECK_STATE( transactions );
 
-    for ( auto&& t : *transactions ) {
-        tv->push_back( *( t->getData() ) );
+    size_t startRegularTxsIdx = 0;
+
+#ifdef BITE2
+    if (biteManager) {
+        for (size_t i = 0; i < transactions->size(); i++) {
+            auto tx = transactions->at(i);
+            if (biteManager->tryGetEncryptedCATArgs(tx, biteManager->getSchain()->getNode()->getCurrentEpochId())) {
+                tv->pushBackCAT(*(tx->getData()));
+            }
+            else {
+                // first regular tx found
+                startRegularTxsIdx = i;
+                break;
+            }
+        }
     }
+#endif
+
+    for (size_t i = startRegularTxsIdx; i < transactions->size(); i++) {
+        auto tx = transactions->at(i);
+        tv->pushBackRegular(*(tx->getData()));
+    }
+
     return tv;
 }
+
 ptr< TransactionList > TransactionList::deserialize(
     const ptr< vector< uint64_t > >& _transactionSizes,
     const ptr< vector< uint8_t > >& _serializedTransactions, uint32_t _offset,

--- a/datastructures/TransactionList.h
+++ b/datastructures/TransactionList.h
@@ -65,7 +65,7 @@ public:
 
     ptr< ConsensusExtFace::transactions_vector > createTransactionVector(
 #ifdef BITE
-    ptr< DecryptedTransactionFieldsMap > _decryptedTransactions
+    ptr< DecryptedRegularTxsMap > _decryptedTransactions
 #endif
     );
 

--- a/datastructures/TransactionList.h
+++ b/datastructures/TransactionList.h
@@ -56,11 +56,11 @@ public:
 
     explicit TransactionList( const ptr< vector< ptr< Transaction > > >& _transactions );
 
-    ptr< vector< ptr< Transaction > > > getItems();
+    ptr< vector< ptr< Transaction > > > getItems() const;
 
     ptr< vector< uint8_t > > serialize( bool _writeTxPartialHash );
 
-    size_t size();
+    size_t size() const;
 
     ~TransactionList() override;
 

--- a/datastructures/TransactionList.h
+++ b/datastructures/TransactionList.h
@@ -28,13 +28,14 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 
-
 #include "DataStructure.h"
-
 
 #include "ListOfHashes.h"
 #include "node/ConsensusEngine.h"
 
+#ifdef BITE2
+#include "bite/BiteManager.h"
+#endif
 
 class Transaction;
 class ConsensusExtFace;
@@ -63,9 +64,18 @@ public:
 
     ~TransactionList() override;
 
-    ptr< ConsensusExtFace::transactions_vector > createTransactionVector(
-#ifdef BITE
-    ptr< DecryptedRegularTxsMap > _decryptedTransactions
+    /**
+     * @brief Runs trough each transaction, and identifies the N first CAT transactions,
+     * placing all these transactions at the beginning of the returned Transactions structure.
+     * TODO - need to refactor this class - maybe we should also serialize the number of CATs, such that
+     * we avoid parsing them again here.
+     * 
+     * @param biteManager - optional BiteManager pointer, needed to identify CAT transactions.
+     * If none is passed, all transactions are considered regular.
+     */
+    ptr< ConsensusExtFace::Transactions > createTransactionVector(
+#ifdef BITE2
+        ptr< BiteManager> biteManager = nullptr
 #endif
     );
 

--- a/db/BlockProposalDB.cpp
+++ b/db/BlockProposalDB.cpp
@@ -198,21 +198,23 @@ ptr< BlockProposal > BlockProposalDB::getBlockProposal(
     // dont check signatures on proposals stored in the db since they have already been verified
     auto proposal =
         BlockProposal::makeFromDBSerialized( serializedProposal, getSchain()->getCryptoManager());
-
+    
     if ( !proposal )
         return nullptr;
 
     CHECK_STATE( !proposal->getSignature().empty() );
 
 #ifdef BITE
+    auto biteManager = getSchain()->getBiteManager();
 
+    
 
-    getSchain()->getBiteManager()->computeAndValidateSGXAESKeyBatch(proposal);
-
+    biteManager->computeAndValidateSGXAESKeyBatch(proposal);
     CHECK_STATE2(proposal->getFailedTransactionsRef().empty(),
                  "Proposal in database includes invalid format BITE transactions");
 
-    getSchain()->getBiteManager()->callSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
+
+    biteManager->callSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
     CHECK_STATE2(proposal->getFailedTransactionsRef().empty(),
                  "Proposal in database includes invalid BITE transactions");
 #endif

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -215,11 +215,10 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
 
     auto aesKeys = make_shared< DecryptedAESKeyList >();
     std::mutex aesKeysMutex;
-    const auto totalSigners = this->totalSigners;
 
     for ( auto&& [txId, decryptionSet]: decryptionShareSets ) {
         auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareMap,
-                                 &decryptionShareSets, decryptionSet, &totalSigners,
+                                 &decryptionShareSets, decryptionSet, totalSigners = this->totalSigners,
                                  &aesKeys, &aesKeysMutex, &tePublicKeys,
                                  &_transactionCiphertextsMap, txId, &encryptions,
                                  sChain = this->sChain]() -> folly::Unit {

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -199,7 +199,11 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
     vector<libBLS::TEPublicKeyShare> tePublicKeys;
     if (sChain->getNode()->isSgxEnabled()) {
         ptr<vector<ptr<libBLS::BLSPublicKeyShare>>> keyShares =
-                std::make_shared<vector<ptr<libBLS::BLSPublicKeyShare>>>(sChain->getCryptoManager()->getAllBlsPublicKeyShares());
+                std::make_shared<vector<ptr<libBLS::BLSPublicKeyShare>>>(
+                    sChain->getCryptoManager()->getAllBlsPublicKeyShares());
+
+        CHECK_STATE(keyShares->size() == totalSigners);
+        
         for (size_t i = 0; i < totalSigners; ++i) {
             tePublicKeys.push_back(libBLS::TEPublicKeyShare(keyShares->at(i)->getPublicKey(),
                                                        i + 1, requiredSigners, totalSigners) );
@@ -214,28 +218,30 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
 
     for ( auto&& [txId, decryptionSet]: decryptionShareSets ) {
         auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareMap,
-                                 &decryptionShareSets, &decryptionSet, &aesKeys, &aesKeysMutex, &tePublicKeys,
+                                 &decryptionShareSets, decryptionSet,
+                                 &aesKeys, &aesKeysMutex, &tePublicKeys,
                                  &_transactionCiphertextsMap, txId, &encryptions,
                                  sChain = this->sChain]() -> folly::Unit {
+
+            size_t numberOfCiphertexts = _transactionCiphertextsMap->at(txId)->count();
             // still not enough shares - validate & add more
             if ( !decryptionSet->isEnough() ) {
 
-                // data to send to the batch validation
-                std::vector< libBLS::CipheredKey > cipheredKeys;
                 // shares at libBLS level (ciphertext idx -> list of shares for that ciphertext)
                 std::vector< std::vector< libBLS::TEDecryptionShare > > teShares;
                 std::vector< std::vector< libBLS::TEPublicKeyShare > > publicKeys;
-                teShares.reserve(decryptionShareMap.size());
-                publicKeys.reserve(decryptionShareMap.size());
-
                 // additional data to track decryptor indices
                 std::vector< schain_index > decryptorIndices;
                 // shares at consensus level
                 // ciphertext -> shares from all decryptors for that ciphertext
                 std::vector< ptr< AESKeyDecryptionShares > > sharesList;
-                sharesList.reserve(decryptionShareMap.size());
-
-                size_t numberOfCiphertexts = encryptions.at(txId).size();
+                // initialize vectors
+                teShares.assign(numberOfCiphertexts, {});
+                publicKeys.assign(numberOfCiphertexts, {});
+                sharesList.resize(numberOfCiphertexts);
+                for (size_t i = 0; i < numberOfCiphertexts; ++i) {
+                    sharesList[i] = std::make_shared<AESKeyDecryptionShares>();
+                }
 
                 // collect all shares from all nodes for current Tx
                 for ( auto&& [decryptorIdx, decryptionSharesList]: decryptionShareMap) {

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -133,7 +133,7 @@ void TEDecryptionDB::addDecryptionShares(
 
     for (const auto& [txIdx, shares]: _decryptionShareList->getDecryptionShares()) {
         auto future = folly::via(threadPoolExecutor.get(), [blockId, this, shares, txIdx]() -> folly::Unit {
-            decryptionShareSets[blockId][txIdx]->addDecryptionShares( shares );
+            decryptionShareSets[blockId][txIdx]->addDecryptionSharesFromSameDecryptor( shares );
             return folly::unit;
         });
         futures.push_back(std::move(future));
@@ -215,10 +215,11 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
 
     auto aesKeys = make_shared< DecryptedAESKeyList >();
     std::mutex aesKeysMutex;
+    const auto totalSigners = this->totalSigners;
 
     for ( auto&& [txId, decryptionSet]: decryptionShareSets ) {
         auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareMap,
-                                 &decryptionShareSets, decryptionSet,
+                                 &decryptionShareSets, decryptionSet, &totalSigners,
                                  &aesKeys, &aesKeysMutex, &tePublicKeys,
                                  &_transactionCiphertextsMap, txId, &encryptions,
                                  sChain = this->sChain]() -> folly::Unit {
@@ -231,34 +232,31 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
                 std::vector< std::vector< libBLS::TEDecryptionShare > > teShares;
                 std::vector< std::vector< libBLS::TEPublicKeyShare > > publicKeys;
                 // additional data to track decryptor indices
-                std::vector< schain_index > decryptorIndices;
+                std::vector< size_t > decryptorIndices;
                 // shares at consensus level
-                // ciphertext -> shares from all decryptors for that ciphertext
+                // each index holds a list of shares for all ciphertexts within current tx for some decryptor
                 std::vector< ptr< AESKeyDecryptionShares > > sharesList;
                 // initialize vectors
                 teShares.assign(numberOfCiphertexts, {});
                 publicKeys.assign(numberOfCiphertexts, {});
-                sharesList.resize(numberOfCiphertexts);
-                for (size_t i = 0; i < numberOfCiphertexts; ++i) {
-                    sharesList[i] = std::make_shared<AESKeyDecryptionShares>();
+                sharesList.resize(totalSigners);
+                for (size_t i = 0; i < totalSigners; ++i) {
+                    sharesList[i] = make_shared<AESKeyDecryptionShares>();
                 }
 
                 // collect all shares from all nodes for current Tx
                 for ( auto&& [decryptorIdx, decryptionSharesList]: decryptionShareMap) {
                     try {
-                        decryptorIndices.push_back(decryptorIdx);
-
                         // shares for all ciphertexts within current tx from current decryptor
                         ptr<AESKeyDecryptionShares> ciphertextsShares = decryptionSharesList->getDecryptionShares(txId);
                         CHECK_STATE(ciphertextsShares);
+                        // every decryptor should provide shares for all ciphertexts
                         CHECK_STATE(ciphertextsShares->size() == numberOfCiphertexts);
 
-                        for ( size_t i = 0; i < numberOfCiphertexts; ++i ) {
-                            sharesList.at(i)->push_back( ciphertextsShares->at(i) );
-                        }
-                    
-                        size_t decryptorIndex = (size_t)decryptorIdx;
-
+                        size_t decryptorIndex = (size_t)decryptorIdx - 1;
+                        decryptorIndices.push_back(decryptorIndex);
+                        sharesList.at(decryptorIndex) = ciphertextsShares;
+                
                         // Only add share for validation if real signatures are enabled
                         if (sChain->getNode()->isSgxEnabled()) {
 
@@ -270,7 +268,7 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
 
                                 auto shareTE = shareConsensus->getTEDecryptionShare();
                                 teShares.at(i).push_back(*shareTE);
-                                publicKeys.at(i).push_back(tePublicKeys.at(decryptorIndex - 1));
+                                publicKeys.at(i).push_back(tePublicKeys.at(decryptorIndex));
                             }
                         }
                         
@@ -282,42 +280,39 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
                 // verify shares batch if real signatures are enabled
                 if (sChain->getNode()->isSgxEnabled() ) {
 
-                    for (size_t ciphertextId = 0; ciphertextId < numberOfCiphertexts; ++ciphertextId) {
-                        // tmp list to hold all valid shares for current ciphertext
-                        ptr<AESKeyDecryptionShares> sharesForCurrCiphertext = std::make_shared<AESKeyDecryptionShares>();
+                    std::vector<bool> allSharesFromNodeAreValid;
+                    allSharesFromNodeAreValid.resize(totalSigners, true);
 
+                    for (size_t ciphertextId = 0; ciphertextId < numberOfCiphertexts; ++ciphertextId) {
                         std::vector<libBLS::CipheredKey> cipheredKeys{ encryptions.at(txId).at(ciphertextId) };
 
                         auto result = libBLS::ThresholdEncryption::validateDecryptionSharesBatch(
                                 cipheredKeys, teShares.at(ciphertextId), publicKeys.at(ciphertextId));
 
                         for (size_t shareId = 0; shareId < result.size(); ++shareId) {
-                            if (result[shareId]) {
-                                // Only add valid shares
-                                sharesForCurrCiphertext->push_back(sharesList[ciphertextId]->at(shareId));
-                            }
-                            else {
+                            if (!result[shareId]) {
+                                // shares from this node are invalid
+                                allSharesFromNodeAreValid[decryptorIndices[shareId]] = false;
                                 CONS_LOG(err, fmt::format(
                                     "Decryption share validation failed: tx_id={}, ciphertext_id={}, share_id={}",
                                     (uint32_t)txId, ciphertextId, shareId)
                                 );
                             }
                         }
-                        // add all valid shares
-                        decryptionSet->addDecryptionShares(sharesForCurrCiphertext);
                     }
 
+                    // Only add shares for current transaction if all shares for all ciphertexts are valid for some node
+                    for (size_t i = 0; i < decryptorIndices.size(); ++i) {
+                        if (allSharesFromNodeAreValid[decryptorIndices[i]]) {
+                            // add all valid shares
+                            decryptionSet->addDecryptionSharesFromSameDecryptor(sharesList[decryptorIndices[i]]);
+                        }
+                    }
                 }
                 else {
-                    for (size_t ciphertextId = 0; ciphertextId < numberOfCiphertexts; ++ciphertextId) {
-                        // tmp list to hold all valid shares for current ciphertext
-                        ptr<AESKeyDecryptionShares> sharesForCurrCiphertext = std::make_shared<AESKeyDecryptionShares>();
-
-                        for (size_t shareId = 0; shareId < sharesList[ciphertextId]->size(); ++shareId) {
-                            sharesForCurrCiphertext->push_back(sharesList[ciphertextId]->at(shareId));
-                        }
+                    for (size_t i = 0; i < decryptorIndices.size(); ++i) {
                         // add all valid shares
-                        decryptionSet->addDecryptionShares(sharesForCurrCiphertext);
+                        decryptionSet->addDecryptionSharesFromSameDecryptor(sharesList[decryptorIndices[i]]);
                     }
                 }
             }

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -38,6 +38,7 @@
 #include "datastructures/BlockProposal.h"
 #include "crypto/CryptoManager.h"
 #include "crypto/DecryptedAESKeyList.h"
+#include "crypto/AESKeyDecryptionShare.h"
 #include "crypto/AESKeyDecryptionShareList.h"
 
 
@@ -53,6 +54,8 @@
 #include <crypto/ConsensusAESKeyDecryptionShare.h>
 
 #include <bls/BLSPublicKeyShare.h>
+
+#include "datastructures/TransactionCiphertextsMap.h"
 
 
 using namespace std;
@@ -102,9 +105,9 @@ void TEDecryptionDB::addDecryptionShares(
     {
         WRITE_LOCK(decryptionSetsMutex);
 
+        // decryptor - all shares for all txs
         map< schain_index, ptr< AESKeyDecryptionShareList > >& decryptionShareListSet =
             decryptionsStore[_decryptionShareList->getBlockId()];
-
 
         if ( decryptionShareListSet.size() >= requiredSigners ) {
             return;
@@ -113,23 +116,24 @@ void TEDecryptionDB::addDecryptionShares(
         if (!decryptionShareListSet.empty()) {
             auto firstShare = decryptionShareListSet.begin()->second;
             CHECK_STATE( firstShare->getProposerIndex() == _decryptionShareList->getProposerIndex() );
-            CHECK_STATE( firstShare->getSize() == _decryptionShareList->getSize() );
+            // all decryptors should send shares for same number of ciphertexts
+            CHECK_STATE( firstShare->totalCiphertextSharesCount() == _decryptionShareList->totalCiphertextSharesCount() );
         }
 
         decryptionShareListSet[index] = _decryptionShareList;
 
         if (decryptionShareSets[blockId].empty()) {
-            for ( auto&& decryptionShareIterator : _decryptionShareList->getDecryptionShares() ) {
-                decryptionShareSets[blockId][decryptionShareIterator.first] =
+            for ( auto&& [txId, shares] : _decryptionShareList->getDecryptionShares() ) {
+                decryptionShareSets[blockId][txId] =
                     sChain->getBiteManager()->createAESDecryptionShareSet(
-                            blockId, decryptionShareIterator.first );
+                            blockId, txId, shares->size() );
             }
         }
     }
 
-    for (const auto& share: _decryptionShareList->getDecryptionShares()) {
-        auto future = folly::via(threadPoolExecutor.get(), [blockId, this, share]() -> folly::Unit {
-            decryptionShareSets[blockId][share.first]->addDecryptionShare( share.second );
+    for (const auto& [txIdx, shares]: _decryptionShareList->getDecryptionShares()) {
+        auto future = folly::via(threadPoolExecutor.get(), [blockId, this, shares, txIdx]() -> folly::Unit {
+            decryptionShareSets[blockId][txIdx]->addDecryptionShares( shares );
             return folly::unit;
         });
         futures.push_back(std::move(future));
@@ -151,11 +155,12 @@ bool TEDecryptionDB::haveDecryptionShares(block_id _blockID, schain_index _decry
 
 };
 
-ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<EncryptedAESKeyMap> _EncryptedAESKeyMap) {
-    CHECK_STATE(_EncryptedAESKeyMap);
+ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<TransactionCiphertextsMap> _transactionCiphertextsMap) {
+    CHECK_STATE(_transactionCiphertextsMap);
 
     WRITE_LOCK(decryptionSetsMutex);
 
+    // nodeId -> decryption shares (each may hold decryption shares for multiple ciphertexts)
     map< schain_index, ptr< AESKeyDecryptionShareList > >& decryptionShareMap =
         decryptionsStore[_blockId];
 
@@ -164,31 +169,33 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
     auto firstDecryptionShareList = decryptionShareMap.begin()->second;
     // TODO - count of decryption shares need to be in DA header
     CHECK_STATE( firstDecryptionShareList );
-    auto size = firstDecryptionShareList->getSize();
+    auto size = firstDecryptionShareList->totalCiphertextSharesCount();
 
-    for (auto&& it : decryptionShareMap) {
-        auto list = it.second;
-        CHECK_STATE(list->getSize() == size);
+    for (auto&& [_, list] : decryptionShareMap) {
+        CHECK_STATE(list->totalCiphertextSharesCount() == size);
     }
 
+    // 1 per transaction (but each tx may contain multiple ciphertexts)
     map<transaction_index, ptr<AESKeyDecryptionShareSet>> decryptionShareSets;
-    map<transaction_index, libBLS::CipheredKey> encryptions;
+    map<transaction_index, std::vector<libBLS::CipheredKey>> encryptions;
 
-    for ( auto&& decryptionShareIterator : firstDecryptionShareList->getDecryptionShares() ) {
-        decryptionShareSets[decryptionShareIterator.first] =
+    bool toValidate = false;
+    for ( auto&& [idx, aesDecryptionShare] : firstDecryptionShareList->getDecryptionShares() ) {
+        decryptionShareSets[idx] =
             sChain->getBiteManager()->createAESDecryptionShareSet(
-                _blockId, decryptionShareIterator.first );
+                _blockId, idx, aesDecryptionShare->size() );
         if (sChain->getNode()->isSgxEnabled()) {
             // fill the map to use in multiple threads later if real signatures are enabled
             // dont validate inputs - were already validated before
-            bool toValidate = false;
-            encryptions[decryptionShareIterator.first] =
-                    libBLS::CipheredKey::fromBytes(*_EncryptedAESKeyMap->at(decryptionShareIterator.first)->getKey(),
-                                                   toValidate);
+            auto& ciphertextsForCurrTx = *_transactionCiphertextsMap->at(idx);
+            for (auto& ciphertext : ciphertextsForCurrTx) {
+                encryptions[idx].push_back(
+                    libBLS::CipheredKey::fromBytes(ciphertext.data(), toValidate));
+            }
         }
     }
 
-    // prepare TE public key shares if real signatures are enabled
+    // 1 key for each signer (index = signerId)
     vector<libBLS::TEPublicKeyShare> tePublicKeys;
     if (sChain->getNode()->isSgxEnabled()) {
         ptr<vector<ptr<libBLS::BLSPublicKeyShare>>> keyShares =
@@ -205,49 +212,60 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
     auto aesKeys = make_shared< DecryptedAESKeyList >();
     std::mutex aesKeysMutex;
 
-    for ( auto&& decryptionSharesSetIterator: decryptionShareSets ) {
-        auto transactionIndex = decryptionSharesSetIterator.first;
+    for ( auto&& [txId, decryptionSet]: decryptionShareSets ) {
         auto future = folly::via(threadPoolExecutor.get(), [&decryptionShareMap,
-                                 &decryptionShareSets, &aesKeys, &aesKeysMutex, &tePublicKeys,
-                                 &_EncryptedAESKeyMap, transactionIndex, &encryptions,
+                                 &decryptionShareSets, &decryptionSet, &aesKeys, &aesKeysMutex, &tePublicKeys,
+                                 &_transactionCiphertextsMap, txId, &encryptions,
                                  sChain = this->sChain]() -> folly::Unit {
-            auto decryptionSharesSet = decryptionShareSets[transactionIndex];
-
             // still not enough shares - validate & add more
-            if ( !decryptionSharesSet->isEnough() ) {
+            if ( !decryptionSet->isEnough() ) {
+
                 // data to send to the batch validation
                 std::vector< libBLS::CipheredKey > cipheredKeys;
-                // shares at libBLS level
-                std::vector< libBLS::TEDecryptionShare > shares;
-                std::vector< libBLS::TEPublicKeyShare > publicKeys;
-                shares.reserve(decryptionShareMap.size());
+                // shares at libBLS level (ciphertext idx -> list of shares for that ciphertext)
+                std::vector< std::vector< libBLS::TEDecryptionShare > > teShares;
+                std::vector< std::vector< libBLS::TEPublicKeyShare > > publicKeys;
+                teShares.reserve(decryptionShareMap.size());
                 publicKeys.reserve(decryptionShareMap.size());
 
                 // additional data to track decryptor indices
                 std::vector< schain_index > decryptorIndices;
                 // shares at consensus level
-                std::vector< ptr< AESKeyDecryptionShare > > sharesList;
+                // ciphertext -> shares from all decryptors for that ciphertext
+                std::vector< ptr< AESKeyDecryptionShares > > sharesList;
                 sharesList.reserve(decryptionShareMap.size());
 
-                // collect all shares for this transaction index
-                for ( auto&& [_, decryptionSharesList]: decryptionShareMap) {
-                    try {
+                size_t numberOfCiphertexts = encryptions.at(txId).size();
 
-                        // add consensus level share
-                        auto share = decryptionSharesList->getDecryptionShare(transactionIndex);
-                        CHECK_STATE(share);
-                        sharesList.push_back(share);
-                        size_t decryptorIndex = (size_t)share->getDecryptorIndex();
+                // collect all shares from all nodes for current Tx
+                for ( auto&& [decryptorIdx, decryptionSharesList]: decryptionShareMap) {
+                    try {
+                        decryptorIndices.push_back(decryptorIdx);
+
+                        // shares for all ciphertexts within current tx from current decryptor
+                        ptr<AESKeyDecryptionShares> ciphertextsShares = decryptionSharesList->getDecryptionShares(txId);
+                        CHECK_STATE(ciphertextsShares);
+                        CHECK_STATE(ciphertextsShares->size() == numberOfCiphertexts);
+
+                        for ( size_t i = 0; i < numberOfCiphertexts; ++i ) {
+                            sharesList.at(i)->push_back( ciphertextsShares->at(i) );
+                        }
+                    
+                        size_t decryptorIndex = (size_t)decryptorIdx;
 
                         // Only add share for validation if real signatures are enabled
                         if (sChain->getNode()->isSgxEnabled()) {
-                            // this conversion only works when using real validation. Else, it will be of Mockup type
-                            auto shareConsensus = dynamic_cast<ConsensusAESKeyDecryptionShare*>(share.get());
-                            CHECK_STATE(shareConsensus);
 
-                            auto shareTE = shareConsensus->getTEDecryptionShare();
-                            shares.push_back(*shareTE);
-                            publicKeys.push_back(tePublicKeys.at(decryptorIndex - 1));
+                            for (size_t i = 0; i < numberOfCiphertexts; ++i) {
+
+                                // this conversion only works when using real validation. Else, it will be of Mockup type
+                                auto shareConsensus = std::dynamic_pointer_cast<ConsensusAESKeyDecryptionShare>(ciphertextsShares->at(i));
+                                CHECK_STATE(shareConsensus);
+
+                                auto shareTE = shareConsensus->getTEDecryptionShare();
+                                teShares.at(i).push_back(*shareTE);
+                                publicKeys.at(i).push_back(tePublicKeys.at(decryptorIndex - 1));
+                            }
                         }
                         
                     }  catch ( const std::exception& ex ) {
@@ -257,36 +275,53 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
 
                 // verify shares batch if real signatures are enabled
                 if (sChain->getNode()->isSgxEnabled() ) {
-                    // push the 1 ciphertext (our batch is only for 1 ciphertext)
-                    cipheredKeys.push_back(encryptions.at(transactionIndex));
-                    auto result = libBLS::ThresholdEncryption::validateDecryptionSharesBatch(
-                            cipheredKeys, shares, publicKeys);
 
-                    for (size_t i = 0; i < result.size(); ++i) {
-                        if (result[i]) {
-                            // Only add valid shares
-                            decryptionSharesSet->addDecryptionShare(sharesList[i]);
+                    for (size_t ciphertextId = 0; ciphertextId < numberOfCiphertexts; ++ciphertextId) {
+                        // tmp list to hold all valid shares for current ciphertext
+                        ptr<AESKeyDecryptionShares> sharesForCurrCiphertext = std::make_shared<AESKeyDecryptionShares>();
+
+                        std::vector<libBLS::CipheredKey> cipheredKeys{ encryptions.at(txId).at(ciphertextId) };
+
+                        auto result = libBLS::ThresholdEncryption::validateDecryptionSharesBatch(
+                                cipheredKeys, teShares.at(ciphertextId), publicKeys.at(ciphertextId));
+
+                        for (size_t shareId = 0; shareId < result.size(); ++shareId) {
+                            if (result[shareId]) {
+                                // Only add valid shares
+                                sharesForCurrCiphertext->push_back(sharesList[ciphertextId]->at(shareId));
+                            }
+                            else {
+                                CONS_LOG(err, fmt::format(
+                                    "Decryption share validation failed: tx_id={}, ciphertext_id={}, share_id={}",
+                                    (uint32_t)txId, ciphertextId, shareId)
+                                );
+                            }
                         }
-                        else {
-                            CONS_LOG(err, "Decryption share validation failed for transaction: " + 
-                                std::to_string(static_cast<uint32_t>(transactionIndex)));
-                        }
+                        // add all valid shares
+                        decryptionSet->addDecryptionShares(sharesForCurrCiphertext);
                     }
+
                 }
                 else {
-                    // no real signatures - just add all shares
-                    for ( auto&& share: sharesList ) {
-                        decryptionSharesSet->addDecryptionShare( share );
+                    for (size_t ciphertextId = 0; ciphertextId < numberOfCiphertexts; ++ciphertextId) {
+                        // tmp list to hold all valid shares for current ciphertext
+                        ptr<AESKeyDecryptionShares> sharesForCurrCiphertext = std::make_shared<AESKeyDecryptionShares>();
+
+                        for (size_t shareId = 0; shareId < sharesList[ciphertextId]->size(); ++shareId) {
+                            sharesForCurrCiphertext->push_back(sharesList[ciphertextId]->at(shareId));
+                        }
+                        // add all valid shares
+                        decryptionSet->addDecryptionShares(sharesForCurrCiphertext);
                     }
                 }
             }
 
             // enough shares - merge
-            if ( decryptionSharesSet->isEnough() ) {
-                auto key = decryptionSharesSet->verifyAndMergeAESKey(_EncryptedAESKeyMap->at(transactionIndex));
-                CHECK_STATE( key );
+            if ( decryptionSet->isEnough() ) {
+                auto keys = decryptionSet->verifyAndMergeAESKeys(_transactionCiphertextsMap->at(txId)->getCiphertexts());
+                CHECK_STATE( keys );
                 std::lock_guard<std::mutex> lock(aesKeysMutex);
-                aesKeys->addKey( transactionIndex, *key );
+                aesKeys->addKeys( txId, *keys );
             }
 
             return folly::unit;
@@ -304,7 +339,8 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<E
     }
 
     CHECK_STATE(decryptionsStore.size() <= 2 * totalSigners);
-    CHECK_STATE2(aesKeys->getSize() == _EncryptedAESKeyMap->size(), "Not all aes keys could be decrypted");
+    CHECK_STATE2(aesKeys->totalDecryptedCiphertextsCount() == _transactionCiphertextsMap->totalCiphertextCount(), 
+        "Not all aes keys could be decrypted");
     return aesKeys;
 }
 
@@ -313,18 +349,14 @@ void TEDecryptionDB::addMyDecryptionShares(
     const ::std::shared_ptr< AESKeyDecryptionShareList >& _decryptionShareList ) {
     CHECK_ARGUMENT( _decryptionShareList )
 
-
     addDecryptionShares(_decryptionShareList);
-
 
     auto serializedList = BiteAESDecryptionShareSerializer::serialize( _decryptionShareList );
     CHECK_STATE( serializedList );
 
-
     auto key = createKey( ( _decryptionShareList->getBlockId() ),
                    _decryptionShareList->getProposerIndex() ) +
                ".my";
-
 
     writeByteArray( key, serializedList );
 }

--- a/db/TEDecryptionDB.h
+++ b/db/TEDecryptionDB.h
@@ -11,12 +11,12 @@ class BlockProposal;
 class AESKeyDecryptionShareList;
 class AESKeyDecryptionShareSet;
 class EncryptedAESKey;
+class TransactionCiphertextsMap;
 
 namespace folly {
 class CPUThreadPoolExecutor;
 }
 
-using EncryptedAESKeyMap = boost::container::flat_map<transaction_index, ptr<EncryptedAESKey> >;
 
 
 #include "CacheLevelDB.h"
@@ -39,7 +39,7 @@ public:
 
     bool haveDecryptionShares(block_id _blockID, schain_index _decryptorIndex);
 
-    ptr<DecryptedAESKeyList> mergeAESKeys(block_id _blockId, ptr<EncryptedAESKeyMap> _EncryptedAESKeyMap);
+    ptr<DecryptedAESKeyList> mergeAESKeys(block_id _blockId, ptr<TransactionCiphertextsMap> _ciphertextsMap);
 
     void addMyDecryptionShares(const ptr<AESKeyDecryptionShareList> &_decryptionShareList);
 

--- a/node/BiteConstants.h
+++ b/node/BiteConstants.h
@@ -14,9 +14,9 @@ constexpr uint8_t BITE_ADDRESS_AS_BYTE_ARRAY[ADDRESS_SIZE] = {0x42, 0x49, 0x54, 
     0x59, 0x50, 0x54, 0x44};
 
 #ifdef BITE2
-constexpr uint64_t BITE_FUNCTION_SELECTOR_SIZE_BYTES = 4;
+constexpr uint64_t BITE2_FUNCTION_SELECTOR_SIZE_BYTES = 4;
 // TODO - update to the actual function selector once decided
-constexpr uint8_t BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY[BITE_FUNCTION_SELECTOR_SIZE_BYTES] = {0x42, 0x49, 0x54, 0x45};
+constexpr uint8_t BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY[BITE2_FUNCTION_SELECTOR_SIZE_BYTES] = {0x42, 0x49, 0x54, 0x45};
 #endif
 
 static constexpr uint64_t BITE_EPOCH_ID_LEN = sizeof(uint64_t);

--- a/node/BiteConstants.h
+++ b/node/BiteConstants.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <string_view>
+#include <cstdint>
+#include "libBLS/threshold_encryption/ThresholdEncryption.h"
+
+constexpr uint64_t BITE_CHAIN_ID = 0xD1D2D3;
+constexpr std::string_view BITE_CHAIN_ID_AS_STRING = "D1D2D3";
+constexpr uint8_t BITE_CHAIN_ID_AS_BYTE_ARRAY[3] = {0xD1, 0xD2, 0xD3};
+
+constexpr uint64_t ADDRESS_SIZE = 20;
+constexpr std::string_view BITE_ADDRESS_AS_STRING = "42495445204D452049274D20454E435259505444";
+constexpr uint8_t BITE_ADDRESS_AS_BYTE_ARRAY[ADDRESS_SIZE] = {0x42, 0x49, 0x54, 0x45, 0x20, 0x4D, 0x45, 0x20,
+    0x49, 0x27, 0x4D, 0x20, 0x45, 0x4E, 0x43, 0x52,
+    0x59, 0x50, 0x54, 0x44};
+
+#ifdef BITE2
+constexpr uint64_t BITE_FUNCTION_SELECTOR_SIZE_BYTES = 4;
+// TODO - update to the actual function selector once decided
+constexpr uint8_t BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY[BITE_FUNCTION_SELECTOR_SIZE_BYTES] = {0x42, 0x49, 0x54, 0x45};
+#endif
+
+static constexpr uint64_t BITE_EPOCH_ID_LEN = sizeof(uint64_t);
+static constexpr uint64_t BITE_AES_KEY_LEN = libBLS::AES_256_KEY_SIZE_BYTES;
+static constexpr uint64_t BITE_ENCRYPTED_AES_KEY_LEN = libBLS::CipheredKey::CIPHERED_KEY_SIZE_BYTES;
+static constexpr uint64_t BITE_TE_PUBLIC_KEY_LEN = libBLS::G2_SIZE_BYTES;
+static constexpr uint64_t BITE_TE_RANDOM_LEN = libBLS::RANDOM_SECRET_SIZE_BYTES;
+static constexpr uint64_t BITE_CIPHERTEXT_MIN_LEN = BITE_ENCRYPTED_AES_KEY_LEN + BITE_TE_RANDOM_LEN + ADDRESS_SIZE;

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -1139,7 +1139,7 @@ ConsensusEngine::getBlock( block_id _blockId ) {
     auto currentPrice = schain->getPriceForBlockId( ( uint64_t ) committedBlock->getBlockID() - 1 );
     auto tv = committedBlock->getTransactionList()->createTransactionVector(
 #ifdef BITE
-        committedBlock->getDecryptedTransactionFields()
+        committedBlock->getDecryptedRegularTxFields()
 #endif
 
         );

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -1137,7 +1137,11 @@ ConsensusEngine::getBlock( block_id _blockId ) {
     auto timeStampMs = committedBlock->getTimeStampMs();
     auto stateRoot = committedBlock->getStateRoot();
     auto currentPrice = schain->getPriceForBlockId( ( uint64_t ) committedBlock->getBlockID() - 1 );
-    auto tv = committedBlock->getTransactionList()->createTransactionVector( schain->getBiteManager() );
+    auto tv = committedBlock->getTransactionList()->createTransactionVector( 
+#ifdef BITE2
+        schain->getBiteManager()
+#endif 
+    );
     return { tv, timeStampS, timeStampMs, currentPrice, stateRoot };
 }
 

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -1117,7 +1117,7 @@ ptr< StorageLimits > ConsensusEngine::getStorageLimits() const {
     return storageLimits;
 }
 
-tuple< ptr< ConsensusExtFace::transactions_vector >, uint32_t, uint32_t, u256, u256 >
+tuple< ptr< ConsensusExtFace::Transactions >, uint32_t, uint32_t, u256, u256 >
 ConsensusEngine::getBlock( block_id _blockId ) {
     CHECK_STATE( nodes.size() > 0 )
     auto node = nodes.begin()->second;
@@ -1137,12 +1137,7 @@ ConsensusEngine::getBlock( block_id _blockId ) {
     auto timeStampMs = committedBlock->getTimeStampMs();
     auto stateRoot = committedBlock->getStateRoot();
     auto currentPrice = schain->getPriceForBlockId( ( uint64_t ) committedBlock->getBlockID() - 1 );
-    auto tv = committedBlock->getTransactionList()->createTransactionVector(
-#ifdef BITE
-        committedBlock->getDecryptedRegularTxFields()
-#endif
-
-        );
+    auto tv = committedBlock->getTransactionList()->createTransactionVector( schain->getBiteManager() );
     return { tv, timeStampS, timeStampMs, currentPrice, stateRoot };
 }
 

--- a/node/ConsensusEngine.h
+++ b/node/ConsensusEngine.h
@@ -200,7 +200,7 @@ public:
      *   }
      */
 
-    tuple< ptr< ConsensusExtFace::transactions_vector >, uint32_t, uint32_t, u256, u256 > getBlock(
+    tuple< ptr< ConsensusExtFace::Transactions >, uint32_t, uint32_t, u256, u256 > getBlock(
         block_id _blockID );
 
     set< node_id >& getNodeIDs();

--- a/node/ConsensusInterface.h
+++ b/node/ConsensusInterface.h
@@ -58,9 +58,9 @@ constexpr uint8_t BITE_ADDRESS_AS_BYTE_ARRAY[ADDRESS_SIZE] = {0x42, 0x49, 0x54, 
     0x59, 0x50, 0x54, 0x44};
 
 #ifdef BITE2
-constexpr uint64_t FUNCTION_SELECTOR_SIZE_BYTES = 4;
+constexpr uint64_t BITE_FUNCTION_SELECTOR_SIZE_BYTES = 4;
 // TODO - update to the actual function selector once decided
-constexpr uint8_t BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY[FUNCTION_SELECTOR_SIZE_BYTES] = {0x42, 0x49, 0x54, 0x45};
+constexpr uint8_t BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY[BITE_FUNCTION_SELECTOR_SIZE_BYTES] = {0x42, 0x49, 0x54, 0x45};
 #endif
 
 static constexpr uint64_t BITE_EPOCH_ID_LEN = sizeof(uint64_t);

--- a/node/ConsensusInterface.h
+++ b/node/ConsensusInterface.h
@@ -33,43 +33,13 @@
 
 #pragma GCC diagnostic pop
 
-#include <map>
-#include <string>
-#include <vector>
-#include <string_view>
-#include <memory>
-
-#include "libBLS/threshold_encryption/ThresholdEncryption.h"
+#include "node/ConsensusTypes.h"
+#include "node/BiteConstants.h"
 
 enum consensus_engine_status {
     CONSENSUS_ACTIVE = 0,
     CONSENSUS_EXITED = 1,
 };
-
-
-constexpr uint64_t BITE_CHAIN_ID = 0xD1D2D3;
-constexpr std::string_view BITE_CHAIN_ID_AS_STRING = "D1D2D3";
-constexpr uint8_t BITE_CHAIN_ID_AS_BYTE_ARRAY[3] = {0xD1, 0xD2, 0xD3};
-
-constexpr uint64_t ADDRESS_SIZE = 20;
-constexpr std::string_view BITE_ADDRESS_AS_STRING = "42495445204D452049274D20454E435259505444";
-constexpr uint8_t BITE_ADDRESS_AS_BYTE_ARRAY[ADDRESS_SIZE] = {0x42, 0x49, 0x54, 0x45, 0x20, 0x4D, 0x45, 0x20,
-    0x49, 0x27, 0x4D, 0x20, 0x45, 0x4E, 0x43, 0x52,
-    0x59, 0x50, 0x54, 0x44};
-
-#ifdef BITE2
-constexpr uint64_t BITE_FUNCTION_SELECTOR_SIZE_BYTES = 4;
-// TODO - update to the actual function selector once decided
-constexpr uint8_t BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY[BITE_FUNCTION_SELECTOR_SIZE_BYTES] = {0x42, 0x49, 0x54, 0x45};
-#endif
-
-static constexpr uint64_t BITE_EPOCH_ID_LEN = sizeof(uint64_t);
-static constexpr uint64_t BITE_AES_KEY_LEN = libBLS::AES_256_KEY_SIZE_BYTES;
-static constexpr uint64_t BITE_ENCRYPTED_AES_KEY_LEN = libBLS::CipheredKey::CIPHERED_KEY_SIZE_BYTES;
-static constexpr uint64_t BITE_TE_PUBLIC_KEY_LEN = libBLS::G2_SIZE_BYTES;
-static constexpr uint64_t BITE_TE_RANDOM_LEN = libBLS::RANDOM_SECRET_SIZE_BYTES;
-static constexpr uint64_t BITE_CIPHERTEXT_MIN_LEN = BITE_ENCRYPTED_AES_KEY_LEN + BITE_TE_RANDOM_LEN + ADDRESS_SIZE;
-
 
 using u256 = boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<256,
         256, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void> >;
@@ -232,30 +202,6 @@ public:
 
 };
 
-// ====== Common Types ======
-
-using TxId = uint64_t;
-using Address = std::array<uint8_t, 20>;
-using Bytes = std::vector<uint8_t>;
-
-// Contains the needed decrypted fields of a regular transaction.
-// - data: original plaintext calldata
-// - to:   original plaintext 'to' address (20 bytes)
-struct DecryptedRegularTxFields {
-    Bytes data;
-    Address to;
-};
-
-// Contains all decrypted arguments of a CAT transaction.
-// Will only be filled if decryption was successful.
-// Else, the map will contain std::nullopt for that transaction.
-struct DecryptedCATArgs {
-    std::vector<Bytes> args;
-};
-
-// TODO - std::optional would encode better the txs that did not succesfully decrypt
-using DecryptedRegularTxsMap = std::map< TxId, DecryptedRegularTxFields >;
-using DecryptedCATxsMap = std::map< TxId, DecryptedCATArgs >;
 
 /**
  * Through this interface Consensus interacts with the rest of the system
@@ -263,18 +209,47 @@ using DecryptedCATxsMap = std::map< TxId, DecryptedCATArgs >;
 class ConsensusExtFace {
 public:
 
-    typedef std::vector<Bytes > transactions_vector;
-
-#ifdef BITE2
     // BITE2 pending transactions include both regular and CAT transactions.
     // CAT should be placed before regular transactions.
     struct Transactions {
+    private:
         transactions_vector all;
         
-        std::size_t cats_size = 0;
+#ifdef BITE2
+        // number of CAT txs in 'all' vector
+        std::size_t catsSize = 0;
+#endif
 
         using iterator = typename transactions_vector::iterator;
         using const_iterator = typename transactions_vector::const_iterator;
+
+    public:
+
+#ifdef BITE2
+        std::size_t sizeCAT() const noexcept {
+            return catsSize;
+        }
+
+        bool isCat(size_t index) const {
+            return index < catsSize;
+        }
+
+        void emplaceBackCAT(Bytes&& b) {
+            CHECK_STATE(catsSize == all.size()); // ensure all cats are contiguous at the start
+            all.emplace_back(std::move(b));
+            catsSize++;
+        }
+
+        void pushBackCAT(const Bytes &b) {
+            CHECK_STATE(catsSize == all.size());
+            all.push_back(b);
+            catsSize++;
+        }
+#endif
+
+        Bytes at(size_t index) const {
+            return all.at(index);
+        }
 
         bool empty() const noexcept {
             return all.empty();
@@ -300,32 +275,23 @@ public:
             return all.end();
         }
 
-        void push_back(const Bytes &b) {
+        void emplaceBackRegular(Bytes&& b) {
+            all.emplace_back(std::move(b));
+        }
+
+        void pushBackRegular(const Bytes &b) {
             all.push_back(b);
         }
-
-        bool isCat(const_iterator it) const {
-            return std::distance(all.begin(), it) < static_cast<std::ptrdiff_t>(cats_size);
-        }
-
     };
-#else
-    using Transactions = std::vector<Bytes >;
-#endif
 
 
     // Returns hashes and bytes of new transactions as well as state root to put into block proposal
     virtual Transactions pendingTransactions(size_t _limit, u256 &_stateRoot) = 0;
 
-
-
     // Creates new block with specified transactions AND removes them from the queue
     virtual void createBlock(const Transactions &_approvedTransactions,
 #ifdef BITE
-        std::shared_ptr< DecryptedRegularTxsMap > _decryptedRegularTransactions,
-#endif
-#ifdef BITE2
-        std::shared_ptr< DecryptedCATxsMap > _decryptedCATTransactions,
+        DecryptedTransactions _decryptedTransactions,
 #endif
         uint64_t _timeStamp, uint32_t _timeStampMillis, uint64_t _blockID, u256 _gasPrice, u256 _stateRoot,
                              uint64_t _winningNodeIndex) = 0;

--- a/node/ConsensusInterface.h
+++ b/node/ConsensusInterface.h
@@ -57,6 +57,12 @@ constexpr uint8_t BITE_ADDRESS_AS_BYTE_ARRAY[ADDRESS_SIZE] = {0x42, 0x49, 0x54, 
     0x49, 0x27, 0x4D, 0x20, 0x45, 0x4E, 0x43, 0x52,
     0x59, 0x50, 0x54, 0x44};
 
+#ifdef BITE2
+constexpr uint64_t FUNCTION_SELECTOR_SIZE_BYTES = 4;
+// TODO - update to the actual function selector once decided
+constexpr uint8_t BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY[FUNCTION_SELECTOR_SIZE_BYTES] = {0x42, 0x49, 0x54, 0x45};
+#endif
+
 static constexpr uint64_t BITE_EPOCH_ID_LEN = sizeof(uint64_t);
 static constexpr uint64_t BITE_AES_KEY_LEN = libBLS::AES_256_KEY_SIZE_BYTES;
 static constexpr uint64_t BITE_ENCRYPTED_AES_KEY_LEN = libBLS::CipheredKey::CIPHERED_KEY_SIZE_BYTES;
@@ -226,45 +232,105 @@ public:
 
 };
 
-
-/**
- * Contains the needed decrypted fields of a transaction
- * Data - contains only the original plaintext 'data'
- * To - contains the original plaintext 'to' address
- */
-struct DecryptedTransactionFields {
-    std::shared_ptr< std::vector< uint8_t > > data;
-    // TODO better to make it std::array of size 20
-    std::shared_ptr< std::vector< uint8_t > > to;
-};
+// ====== Common Types ======
 
 using TxId = uint64_t;
+using Address = std::array<uint8_t, 20>;
+using Bytes = std::vector<uint8_t>;
 
-using DecryptedTransactionFieldsMap = std::map< TxId, DecryptedTransactionFields >;
+// Contains the needed decrypted fields of a regular transaction.
+// - data: original plaintext calldata
+// - to:   original plaintext 'to' address (20 bytes)
+struct DecryptedRegularTxFields {
+    Bytes data;
+    Address to;
+};
 
+// Contains all decrypted arguments of a CAT transaction.
+// Will only be filled if decryption was successful.
+// Else, the map will contain std::nullopt for that transaction.
+struct DecryptedCATArgs {
+    std::vector<Bytes> args;
+};
+
+// TODO - std::optional would encode better the txs that did not succesfully decrypt
+using DecryptedRegularTxsMap = std::map< TxId, DecryptedRegularTxFields >;
+using DecryptedCATxsMap = std::map< TxId, DecryptedCATArgs >;
 
 /**
  * Through this interface Consensus interacts with the rest of the system
  */
 class ConsensusExtFace {
 public:
-    typedef std::vector<std::vector<uint8_t> > transactions_vector;
+
+    typedef std::vector<Bytes > transactions_vector;
+
+#ifdef BITE2
+    // BITE2 pending transactions include both regular and CAT transactions.
+    // CAT should be placed before regular transactions.
+    struct Transactions {
+        transactions_vector all;
+        
+        std::size_t cats_size = 0;
+
+        using iterator = typename transactions_vector::iterator;
+        using const_iterator = typename transactions_vector::const_iterator;
+
+        bool empty() const noexcept {
+            return all.empty();
+        }
+
+        std::size_t size() const noexcept {
+            return all.size();
+        }
+
+        iterator begin() {
+            return all.begin();
+        }
+
+        iterator end() {
+            return all.end();
+        }
+
+        const_iterator begin() const {
+            return all.begin();
+        }
+
+        const_iterator end() const {
+            return all.end();
+        }
+
+        void push_back(const Bytes &b) {
+            all.push_back(b);
+        }
+
+        bool isCat(const_iterator it) const {
+            return std::distance(all.begin(), it) < static_cast<std::ptrdiff_t>(cats_size);
+        }
+
+    };
+#else
+    using Transactions = std::vector<Bytes >;
+#endif
+
 
     // Returns hashes and bytes of new transactions as well as state root to put into block proposal
-    virtual transactions_vector pendingTransactions(size_t _limit, u256 &_stateRoot) = 0;
+    virtual Transactions pendingTransactions(size_t _limit, u256 &_stateRoot) = 0;
+
+
 
     // Creates new block with specified transactions AND removes them from the queue
-    virtual void createBlock(const transactions_vector &_approvedTransactions,
+    virtual void createBlock(const Transactions &_approvedTransactions,
 #ifdef BITE
-        // map of transaction index in the block starting from 0 to transaction
-        // empty mapped is passed for now
-        // Note: if BITE transaction did not decrypt well due to invalid AES ciphertext
-        // , _decryptedTransactionDataFields will include
-        // null for this transaction
-        std::shared_ptr< DecryptedTransactionFieldsMap > _decryptedTransactionDataFields,
+        std::shared_ptr< DecryptedRegularTxsMap > _decryptedRegularTransactions,
+#endif
+#ifdef BITE2
+        std::shared_ptr< DecryptedCATxsMap > _decryptedCATTransactions,
 #endif
         uint64_t _timeStamp, uint32_t _timeStampMillis, uint64_t _blockID, u256 _gasPrice, u256 _stateRoot,
                              uint64_t _winningNodeIndex) = 0;
+
+
 
     virtual ~ConsensusExtFace() = default;
 

--- a/node/ConsensusTypes.h
+++ b/node/ConsensusTypes.h
@@ -19,15 +19,13 @@ struct DecryptedRegularTxFields {
     Address to;
 };
 
-// Contains all decrypted arguments of a CAT transaction.
-// Will only be filled if decryption was successful.
-// Else, the map will contain std::nullopt for that transaction.
 struct DecryptedCATArgs {
     std::vector<Bytes> args;
 };
 
-using DecryptedRegularTxsMap = std::map< TxId, DecryptedRegularTxFields >;
-using DecryptedCATxsMap = std::map< TxId, DecryptedCATArgs >;
+// For both maps, an entry will be marked as std::nullopt if decryption failed for that tx.
+using DecryptedRegularTxsMap = std::map< TxId, std::optional<DecryptedRegularTxFields> >;
+using DecryptedCATxsMap = std::map< TxId, std::optional<DecryptedCATArgs> >;
 
 // Used to return both regular txs and CAT txs decryption results
 struct DecryptedTransactions {

--- a/node/ConsensusTypes.h
+++ b/node/ConsensusTypes.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <array>
+#include <map>
+#include <vector>
+#include <memory>
+#include "SkaleCommon.h"
+
+// ====== Common Types ======
+
+using TxId = uint64_t;
+using Address = std::array<uint8_t, 20>;
+using Bytes = std::vector<uint8_t>;
+
+// Contains the needed decrypted fields of a regular transaction.
+// - data: original plaintext calldata
+// - to:   original plaintext 'to' address (20 bytes)
+struct DecryptedRegularTxFields {
+    Bytes data;
+    Address to;
+};
+
+// Contains all decrypted arguments of a CAT transaction.
+// Will only be filled if decryption was successful.
+// Else, the map will contain std::nullopt for that transaction.
+struct DecryptedCATArgs {
+    std::vector<Bytes> args;
+};
+
+using DecryptedRegularTxsMap = std::map< TxId, DecryptedRegularTxFields >;
+using DecryptedCATxsMap = std::map< TxId, DecryptedCATArgs >;
+
+// Used to return both regular txs and CAT txs decryption results
+struct DecryptedTransactions {
+#ifdef BITE2
+    std::shared_ptr<DecryptedCATxsMap> catTxsMap;
+#endif
+    std::shared_ptr<DecryptedRegularTxsMap> regularTxsMap;
+
+    DecryptedTransactions(
+#ifdef BITE2
+        std::shared_ptr<DecryptedCATxsMap> _catTxsMap,
+#endif
+        std::shared_ptr<DecryptedRegularTxsMap> _regularTxsMap) {
+#ifdef BITE2
+        CHECK_STATE(_catTxsMap);
+        catTxsMap = _catTxsMap;
+#endif
+        CHECK_STATE(_regularTxsMap);
+        regularTxsMap = _regularTxsMap;
+    }
+
+    DecryptedTransactions() = default;
+};
+
+
+typedef std::vector<Bytes > transactions_vector;

--- a/node/ConsensusTypes.h
+++ b/node/ConsensusTypes.h
@@ -8,7 +8,7 @@
 // ====== Common Types ======
 
 using TxId = uint64_t;
-using Address = std::array<uint8_t, 20>;
+using AddressBytes = std::array<uint8_t, 20>;
 using Bytes = std::vector<uint8_t>;
 
 // Contains the needed decrypted fields of a regular transaction.
@@ -16,7 +16,7 @@ using Bytes = std::vector<uint8_t>;
 // - to:   original plaintext 'to' address (20 bytes)
 struct DecryptedRegularTxFields {
     Bytes data;
-    Address to;
+    AddressBytes to;
 };
 
 struct DecryptedCATArgs {

--- a/pendingqueue/PendingTransactionsAgent.cpp
+++ b/pendingqueue/PendingTransactionsAgent.cpp
@@ -105,9 +105,7 @@ pair<ptr<vector<ptr<Transaction> > >, u256>
 PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterCatchup) {
     MONITOR2(__CLASS_NAME__, __FUNCTION__, getSchain()->getMaxExternalBlockProcessingTime())
 
-
     size_t needMax;
-
 
     auto env = getenv("TEST_TRANSACTIONS_PER_BLOCK");
 
@@ -127,7 +125,6 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
     static u256 stateRootSample = 1;
 
     uint64_t waitTimeMs = 10;
-
 
     while (transactions.empty()) {
         getSchain()->getNode()->exitCheck();

--- a/pendingqueue/PendingTransactionsAgent.cpp
+++ b/pendingqueue/PendingTransactionsAgent.cpp
@@ -119,7 +119,7 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
         needMax = getNode()->getMaxTransactionsPerBlock();
     }
 
-    ConsensusExtFace::transactions_vector txVector;
+    ConsensusExtFace::Transactions transactions;
 
     auto startTimeMs = Time::getCurrentTimeMs();
 
@@ -129,12 +129,12 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
     uint64_t waitTimeMs = 10;
 
 
-    while (txVector.empty()) {
+    while (transactions.empty()) {
         getSchain()->getNode()->exitCheck();
 
         if (sChain->getExtFace()) {
             getSchain()->getNode()->checkForExitOnBlockBoundaryAndExitIfNeeded();
-            txVector = sChain->getExtFace()->pendingTransactions(needMax, stateRoot);
+            transactions = sChain->getExtFace()->pendingTransactions(needMax, stateRoot);
             // block boundary is the safest place for exit
             // exit immediately if exit has been requested
             // this will initiate immediate exit and throw ExitRequestedException
@@ -143,9 +143,9 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
             stateRootSample++;
             stateRoot = 7;
 #ifdef BITE
-            txVector = sChain->getTestMessageGeneratorAgent()->pendingTransactionsBITE(needMax);
+            transactions = sChain->getTestMessageGeneratorAgent()->pendingTransactionsBITE(needMax);
 #else
-            txVector = sChain->getTestMessageGeneratorAgent()->pendingTransactions(needMax);
+            transactions = sChain->getTestMessageGeneratorAgent()->pendingTransactions(needMax);
 #endif
         }
 
@@ -180,14 +180,25 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
 
     auto result = make_shared<vector<ptr<Transaction> > >();
 
-    for (const auto &e: txVector) {
+    for (const auto &e: transactions) {
         ptr<Transaction> pt = Transaction::deserialize(
             make_shared<std::vector<uint8_t> >(e), 0, e.size(), false);
 
 #ifdef BITE
+        auto biteManager = sChain->getBiteManager();
+        auto currentEpoch = sChain->getNode()->getCurrentEpochId();
         try {
-            pt->parseAndValidate();
-            pt->tryGetBiteData(sChain->getNode()->getCurrentEpochId());
+#ifdef BITE2
+            if (transactions.isCat(e)) {
+                pt->tryGetCATEncryptedArgs(pt, currentEpoch);
+            }
+            else
+#else
+            // only used for validation purposes
+            // If BITE2, only do this validation for non-CATs
+            biteManager->tryGetEncryptedRegularTxFields(pt, currentEpoch);
+            
+#endif
             result->push_back(pt);
             pushKnownTransaction(pt);
         } catch (std::exception &e) {

--- a/pendingqueue/PendingTransactionsAgent.cpp
+++ b/pendingqueue/PendingTransactionsAgent.cpp
@@ -177,25 +177,27 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
 
     auto result = make_shared<vector<ptr<Transaction> > >();
 
-    for (const auto &e: transactions) {
+    for (size_t i = 0; i < transactions.size(); i++) {
+        auto tx = transactions.at(i);
         ptr<Transaction> pt = Transaction::deserialize(
-            make_shared<std::vector<uint8_t> >(e), 0, e.size(), false);
+            make_shared<std::vector<uint8_t> >(tx), 0, tx.size(), false);
 
 #ifdef BITE
         auto biteManager = sChain->getBiteManager();
         auto currentEpoch = sChain->getNode()->getCurrentEpochId();
         try {
 #ifdef BITE2
-            if (transactions.isCat(e)) {
-                pt->tryGetCATEncryptedArgs(pt, currentEpoch);
+            if (transactions.isCat(i)) {
+                biteManager->tryGetEncryptedCATArgs(pt, currentEpoch);
             }
             else
-#else
-            // only used for validation purposes
-            // If BITE2, only do this validation for non-CATs
-            biteManager->tryGetEncryptedRegularTxFields(pt, currentEpoch);
-            
 #endif
+            {
+                // only used for validation purposes
+                // If BITE2, only do this validation for non-CATs
+                biteManager->tryGetEncryptedRegularTxFields(pt, currentEpoch);
+            }
+
             result->push_back(pt);
             pushKnownTransaction(pt);
         } catch (std::exception &e) {

--- a/pendingqueue/TestMessageGeneratorAgent.cpp
+++ b/pendingqueue/TestMessageGeneratorAgent.cpp
@@ -59,11 +59,11 @@ TestMessageGeneratorAgent::TestMessageGeneratorAgent( Schain& _sChain_ )
 }
 
 
-ConsensusExtFace::transactions_vector TestMessageGeneratorAgent::pendingTransactions(
+ConsensusExtFace::Transactions TestMessageGeneratorAgent::pendingTransactions(
     size_t _limit ) {
     // test oracle for the first block
 
-    ConsensusExtFace::transactions_vector result;
+    ConsensusExtFace::Transactions result;
 
     auto test = sChain->getBlockProposerTest();
 
@@ -75,7 +75,7 @@ ConsensusExtFace::transactions_vector TestMessageGeneratorAgent::pendingTransact
     for ( uint64_t i = 0; i < _limit; i++ ) {
         vector< uint8_t > transaction( TEST_MESSAGE_SIZE );
         std::copy_n(randomBytes.begin() + position, TEST_MESSAGE_SIZE, transaction.begin());
-        result.push_back( transaction );
+        result.pushBackRegular( transaction );
         counter++;
         position = (position + randomBytes.at(position)) % (RANDOM_TEST_ARRAY_LEN - TEST_MESSAGE_SIZE - 1);
     }
@@ -162,44 +162,83 @@ void TestMessageGeneratorAgent::sendTestRequestEthCall() {
 
 #ifdef BITE
 
-ConsensusExtFace::transactions_vector TestMessageGeneratorAgent::pendingTransactionsBITE(
+ConsensusExtFace::Transactions TestMessageGeneratorAgent::pendingTransactionsBITE(
     size_t _limit ) {
-    static size_t txIdxInPrecomputedBatch = 0;
-    static ConsensusExtFace::transactions_vector result;
+    static size_t txIdxInPrecomputedBatchRegular = 0;
+    static size_t txIdxInPrecomputedBatchCAT = 0;
+    // contains 3/4 BITE encrypted & 1/4 unencrypted regular transactions
+    static ConsensusExtFace::Transactions onlyRegularTxs;
+    // contains only BITE2 CAT transactions (with encrypted args)
+    static ConsensusExtFace::Transactions onlyCATs;
     static std::once_flag initFlag;
+    static size_t numTotalRegularTxs = 1000;
+    static size_t numTotalCATTxs = 200;
+    static double CATsProportion = 0;
 
     // build test transactions only once at start (includes encrypting them)
     std::call_once(initFlag, [&] () {
-        ConsensusExtFace::transactions_vector tmpRes;
+#ifdef BITE2
+        CATsProportion = (double) numTotalCATTxs / (numTotalRegularTxs + numTotalCATTxs);
+        ConsensusExtFace::Transactions tmpOnlyCATs;
+#endif
 
-        for ( uint64_t i = 0; i < 1000; i++ ) {
-            // 1/4 chance of being bite encoded
-            // make half of them bite encoded
+        ConsensusExtFace::Transactions tmpOnlyRegularTxs;
+
+        // setup only regular txs
+        for ( uint64_t i = 0; i < numTotalRegularTxs; i++ ) {
+            auto tx = EthTransactionEncoder::generateSampleTx();
+            // 3/4 chance of being bite encoded
             // make one quarter unencrypted
-            auto tx = EthTransactionEncoder::generateSampleTx( i % 4 != 0, sChain->getBiteManager()  );
-            tmpRes.emplace_back( *tx );
+            if ( i % 4 != 0 ) {
+                EthTransactionEncoder::encryptRegularTransaction( tx, sChain->getBiteManager() );
+            }
+            auto signedTx = EthTransactionEncoder::signAndEncodeTx( tx );
+            tmpOnlyRegularTxs.emplaceBackRegular( std::move(*signedTx) );
         }
+        onlyRegularTxs = std::move(tmpOnlyRegularTxs);
 
-        result = std::move(tmpRes);
+#ifdef BITE2
+        // setup cat txs
+        for ( uint64_t i = 0; i < numTotalCATTxs; i++ ) {
+            auto tx = EthTransactionEncoder::generateSampleTx();
+            
+            auto catData = sChain->getBiteManager()->generateEncryptedCATData();
+            tx->data = *catData;
+            auto signedTx = EthTransactionEncoder::signAndEncodeTx( tx );
+            tmpOnlyCATs.emplaceBackCAT( std::move(*signedTx) );
+        }
+        onlyCATs = std::move(tmpOnlyCATs);
+#endif
     });
 
-
-    ConsensusExtFace::transactions_vector selectedTxs;
+    ConsensusExtFace::Transactions selectedTxs;
 
     auto test = sChain->getBlockProposerTest();
 
     CHECK_STATE( !test.empty() );
 
     if ( test == SchainTest::NONE )
-        return result;
+        return selectedTxs;
 
-    size_t idx = txIdxInPrecomputedBatch;
-    for ( uint64_t i = 0; i < _limit; i++ ) {
-        idx = (idx + 1) % result.size();
-        selectedTxs.emplace_back( result.at(idx) );
+    // compute how many CATs / non-CATs to include
+    const size_t numCATs = (CATsProportion * _limit);
+    const size_t numRegularTxs = _limit - numCATs;
+
+    // place all CATs at the start
+    size_t catIdx = txIdxInPrecomputedBatchCAT;
+    for ( size_t i = 0; i < numCATs; i++ ) {
+        catIdx = (catIdx + 1) % numTotalCATTxs;
+        selectedTxs.emplaceBackCAT( onlyCATs.at(catIdx) );
     }
+    txIdxInPrecomputedBatchCAT = catIdx;
 
-    txIdxInPrecomputedBatch = idx;
+    size_t regularIdx = txIdxInPrecomputedBatchRegular;
+    for ( uint64_t i = 0; i < numRegularTxs; i++ ) {
+        regularIdx = (regularIdx + 1) % numTotalRegularTxs;
+        selectedTxs.emplaceBackRegular( onlyRegularTxs.at(regularIdx) );
+    }
+    txIdxInPrecomputedBatchRegular = regularIdx;
+    
     return selectedTxs;
 };
 #endif

--- a/pendingqueue/TestMessageGeneratorAgent.h
+++ b/pendingqueue/TestMessageGeneratorAgent.h
@@ -41,10 +41,10 @@ class TestMessageGeneratorAgent : Agent {
 public:
     explicit TestMessageGeneratorAgent( Schain& _sChain );
 
-    ConsensusExtFace::transactions_vector pendingTransactions( size_t _limit );
+    ConsensusExtFace::Transactions pendingTransactions( size_t _limit );
 
 #ifdef BITE
-    ConsensusExtFace::transactions_vector pendingTransactionsBITE( size_t _limit );
+    ConsensusExtFace::Transactions pendingTransactionsBITE( size_t _limit );
 #endif
 
 

--- a/pricing/ConstantPricingStrategy.cpp
+++ b/pricing/ConstantPricingStrategy.cpp
@@ -26,6 +26,6 @@
 #include "ConstantPricingStrategy.h"
 
 u256 ConstantPricingStrategy::calculatePrice(
-    u256, const ConsensusExtFace::transactions_vector&, uint64_t, uint32_t, block_id ) {
+    u256, const ConsensusExtFace::Transactions&, uint64_t, uint32_t, block_id ) {
     return price;
 }

--- a/pricing/ConstantPricingStrategy.h
+++ b/pricing/ConstantPricingStrategy.h
@@ -30,7 +30,7 @@ class ConstantPricingStrategy : public PricingStrategy {
 public:
     ConstantPricingStrategy( u256 price_ ) : price( price_ ) {};
     u256 calculatePrice( u256 previousPrice,
-        const ConsensusExtFace::transactions_vector& _approvedTransactions, uint64_t _timeStamp,
+        const ConsensusExtFace::Transactions& _approvedTransactions, uint64_t _timeStamp,
         uint32_t _timeStampMs, block_id _blockID ) override;
 private:
     u256 price;

--- a/pricing/DynamicPricingStrategy.cpp
+++ b/pricing/DynamicPricingStrategy.cpp
@@ -27,7 +27,7 @@
 
 
 u256 DynamicPricingStrategy::calculatePrice( u256 _previousPrice,
-    const ConsensusExtFace::transactions_vector& _block, uint64_t, uint32_t, block_id ) {
+    const ConsensusExtFace::Transactions& _block, uint64_t, uint32_t, block_id ) {
     auto loadPercentage = ( _block.size() * 100 ) / MAX_TRANSACTIONS_PER_BLOCK;
 
     u256 price;

--- a/pricing/DynamicPricingStrategy.h
+++ b/pricing/DynamicPricingStrategy.h
@@ -37,7 +37,7 @@ public:
         uint32_t optimalLoadPercentage, uint32_t adjustmentSpeed );
 
     u256 calculatePrice( u256 previousPrice,
-        const ConsensusExtFace::transactions_vector& _approvedTransactions, uint64_t _timeStamp,
+        const ConsensusExtFace::Transactions& _approvedTransactions, uint64_t _timeStamp,
         uint32_t _timeStampMs, block_id _blockID ) override;
 };
 

--- a/pricing/PricingAgent.cpp
+++ b/pricing/PricingAgent.cpp
@@ -79,7 +79,7 @@ PricingAgent::PricingAgent( Schain& _sChain ) : Agent( _sChain, false ) {
 }
 
 u256 PricingAgent::calculatePrice(
-    const ConsensusExtFace::transactions_vector& _approvedTransactions, uint64_t _timeStamp,
+    const ConsensusExtFace::Transactions& _approvedTransactions, uint64_t _timeStamp,
     uint32_t _timeStampMs, block_id _blockID ) {
     u256 price;
     CHECK_STATE( pricingStrategy );

--- a/pricing/PricingAgent.h
+++ b/pricing/PricingAgent.h
@@ -34,7 +34,7 @@ class PricingAgent : public Agent {
 public:
     explicit PricingAgent( Schain& _sChain );
 
-    u256 calculatePrice( const ConsensusExtFace::transactions_vector& _approvedTransactions,
+    u256 calculatePrice( const ConsensusExtFace::Transactions& _approvedTransactions,
         uint64_t _timeStamp, uint32_t _timeStampMs, block_id _blockID );
 
     u256 readPrice( block_id _blockId );

--- a/pricing/PricingStrategy.h
+++ b/pricing/PricingStrategy.h
@@ -28,7 +28,7 @@
 class PricingStrategy {
 public:
     virtual u256 calculatePrice( u256 previousPrice,
-        const ConsensusExtFace::transactions_vector& _approvedTransactions, uint64_t _timeStamp,
+        const ConsensusExtFace::Transactions& _approvedTransactions, uint64_t _timeStamp,
         uint32_t _timeStampMs, block_id _blockID ) = 0;
     virtual ~PricingStrategy() {}
 };

--- a/pricing/ZeroPricingStrategy.cpp
+++ b/pricing/ZeroPricingStrategy.cpp
@@ -26,6 +26,6 @@
 #include "ZeroPricingStrategy.h"
 
 u256 ZeroPricingStrategy::calculatePrice(
-    u256, const ConsensusExtFace::transactions_vector&, uint64_t, uint32_t, block_id ) {
+    u256, const ConsensusExtFace::Transactions&, uint64_t, uint32_t, block_id ) {
     return 0;
 }

--- a/pricing/ZeroPricingStrategy.h
+++ b/pricing/ZeroPricingStrategy.h
@@ -29,7 +29,7 @@
 class ZeroPricingStrategy : public PricingStrategy {
 public:
     u256 calculatePrice( u256 previousPrice,
-        const ConsensusExtFace::transactions_vector& _approvedTransactions, uint64_t _timeStamp,
+        const ConsensusExtFace::Transactions& _approvedTransactions, uint64_t _timeStamp,
         uint32_t _timeStampMs, block_id _blockID ) override;
 };
 

--- a/rlp/EthTransaction.cpp
+++ b/rlp/EthTransaction.cpp
@@ -8,7 +8,7 @@
 #include <SkaleCommon.h>
 #include "Log.h"
 #include "node/ConsensusInterface.h"
-#include "bite/BiteDataField.h"
+#include "bite/BiteCiphertext.h"
 #include "bite/BiteManager.h"
 #include "libBLS/threshold_encryption/ThresholdEncryption.h"
 #include "crypto/EncryptedAESKey.h"

--- a/rlp/EthTransaction.cpp
+++ b/rlp/EthTransaction.cpp
@@ -8,7 +8,7 @@
 #include <SkaleCommon.h>
 #include "Log.h"
 #include "node/ConsensusInterface.h"
-#include "bite/BiteDataFiled.h"
+#include "bite/BiteDataField.h"
 #include "bite/BiteManager.h"
 #include "libBLS/threshold_encryption/ThresholdEncryption.h"
 #include "crypto/EncryptedAESKey.h"

--- a/rlp/EthTransactionEncoder.cpp
+++ b/rlp/EthTransactionEncoder.cpp
@@ -11,7 +11,7 @@
 #include "SkaleCommon.h"
 #include "Log.h"
 #include "node/ConsensusInterface.h"
-#include "bite/BiteDataField.h"
+#include "bite/BiteCiphertext.h"
 #include "bite/BiteManager.h"
 #include "libBLS/threshold_encryption/ThresholdEncryption.h"
 #include "crypto/EncryptedAESKey.h"
@@ -121,7 +121,7 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
 
     if ( _isByte ) {
         auto encryptedKeyPlusData = _biteManager->teEncryptDataAndToAddress(txRef.data, txRef.to);
-        BiteDataField biteDataField(encryptedKeyPlusData , 0);
+        BiteCiphertext biteDataField(encryptedKeyPlusData , 0);
         // set data
         txRef.data = *biteDataField.getSerializedData();
         // set to field with BITE magic number

--- a/rlp/EthTransactionEncoder.cpp
+++ b/rlp/EthTransactionEncoder.cpp
@@ -34,24 +34,17 @@ std::vector< uint8_t > EthTransactionEncoder::generateRandomPrivateKey() {
 }
 
 
-ptr< vector< uint8_t > > EthTransactionEncoder::signAndEncodeTx( const EthTransaction& tx ) {
-
-
+ptr< vector< uint8_t > > EthTransactionEncoder::signAndEncodeTx( const std::unique_ptr<EthTransaction>& tx ) {
     std::vector< uint8_t > privkey = generateRandomPrivateKey();
-    Signature signature = tx.sign(privkey);
+    Signature signature = tx->sign(privkey);
 
-    std::vector< uint8_t > encodedTx = tx.rlpEncode( std::make_optional( signature ) );
-    tx.verifySignature(signature);
+    std::vector< uint8_t > encodedTx = tx->rlpEncode( std::make_optional( signature ) );
+    tx->verifySignature(signature);
     return make_shared< vector< uint8_t > >( std::move( encodedTx ) );
 }
 
-/// @brief Generates a sample transaction of one of the three types (Legacy, Type1, Type2).
-/// The transaction is signed and encoded. Each time it is called, it rotates through the three types.
-/// @param _isByte Specifies if the transaction data should be BITE encrypted.
-/// @param _biteManager 
-/// @return pointer to RLP-encoded transaction
-ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, ptr<BiteManager> _biteManager ) {
-    CHECK_STATE(_biteManager)
+
+std::unique_ptr<EthTransaction> EthTransactionEncoder::generateSampleTx() {
     static atomic< uint64_t > counter = 0;
     static atomic< uint64_t > nonce = 0;
 
@@ -115,28 +108,23 @@ ptr< vector< uint8_t > > EthTransactionEncoder::generateSampleTx( bool _isByte, 
         default:
             throw std::invalid_argument( "Unknown transaction type" );
     }
-
-    EthTransaction& txRef = *tx;
-    txRef.nonce = RLPStream::u256toBytes( static_cast<u256>( currentNonce ) );
-
-    if ( _isByte ) {
-        auto encryptedKeyPlusData = _biteManager->teEncryptDataAndToAddress(txRef.data, txRef.to);
-        BiteCiphertext biteDataField(encryptedKeyPlusData , 0);
-        // set data
-        txRef.data = *biteDataField.getSerializedData();
-        // set to field with BITE magic number
-        txRef.to = { 0x42, 0x49, 0x54, 0x45, 0x20, 0x4D, 0x45, 0x20,
-                     0x49, 0x27, 0x4D, 0x20, 0x45, 0x4E, 0x43, 0x52,
-                     0x59, 0x50, 0x54, 0x44 };
-    }
-
-    auto encodedTx = signAndEncodeTx( txRef );
-    CHECK_STATE( encodedTx );
-
-    return encodedTx;
+    tx->nonce = RLPStream::u256toBytes( static_cast<u256>( currentNonce ) );
+    return tx;
 }
 
-ptr< vector< uint8_t > >  EthTransactionEncoder::rlpEncodeWithoutSig(
+
+void EthTransactionEncoder::encryptRegularTransaction(std::unique_ptr<EthTransaction>& tx, std::shared_ptr<BiteManager> _biteManager) {
+    auto encryptedKeyPlusData = _biteManager->encryptRegularTx(tx->data, tx->to);
+    BiteCiphertext biteDataField(encryptedKeyPlusData , 0);
+    // set data
+    tx->data = *biteDataField.getSerializedData();
+    // set to field with BITE magic number
+    tx->to = { 0x42, 0x49, 0x54, 0x45, 0x20, 0x4D, 0x45, 0x20,
+                0x49, 0x27, 0x4D, 0x20, 0x45, 0x4E, 0x43, 0x52,
+                0x59, 0x50, 0x54, 0x44 };
+}
+
+std::shared_ptr< std::vector< uint8_t > >  EthTransactionEncoder::rlpEncodeWithoutSig(
     ParsedEthTransaction& _ethTransaction ) {
     auto fields = _ethTransaction.getFields();
 

--- a/rlp/EthTransactionEncoder.cpp
+++ b/rlp/EthTransactionEncoder.cpp
@@ -11,7 +11,7 @@
 #include "SkaleCommon.h"
 #include "Log.h"
 #include "node/ConsensusInterface.h"
-#include "bite/BiteDataFiled.h"
+#include "bite/BiteDataField.h"
 #include "bite/BiteManager.h"
 #include "libBLS/threshold_encryption/ThresholdEncryption.h"
 #include "crypto/EncryptedAESKey.h"

--- a/rlp/EthTransactionEncoder.h
+++ b/rlp/EthTransactionEncoder.h
@@ -11,13 +11,27 @@ class BiteManager;
 class EthTransactionEncoder {
 
 public:
-    static std::shared_ptr<std::vector<uint8_t>> generateSampleTx(bool _isByte, ptr<BiteManager> _biteManager);
-
     static std::shared_ptr< std::vector< uint8_t > >  rlpEncodeWithoutSig(ParsedEthTransaction& _transaction);
 
     inline static std::vector< uint8_t > generateRandomPrivateKey();
 
-    static std::shared_ptr<std::vector<uint8_t>> signAndEncodeTx(const EthTransaction& tx);
+
+    /**
+     * @brief Generates a sample transaction of one of the three types (Legacy, Type1, Type2).
+     * Loops through the three types on each call following the order: Legacy -> Type1 -> Type2.
+     * The transaction returned is unsigned.
+     */
+    static std::unique_ptr<EthTransaction> generateSampleTx();
+
+    /**
+     * @brief Encrypts the transaction using BITE1 encryption. Meaning it will encrypt both
+     * the 'to' and 'data' fields of the transaction.
+     * Substitutes the 'to' field with the BITE magic number, and the 'data' field with the encrypted data,
+     * all in-place.
+     */
+    static void encryptRegularTransaction(std::unique_ptr<EthTransaction>& tx, std::shared_ptr<BiteManager> _biteManager);
+
+    static std::shared_ptr<std::vector<uint8_t>> signAndEncodeTx(const std::unique_ptr<EthTransaction>& tx);
 
 
 };

--- a/rlp/RLPStream.h
+++ b/rlp/RLPStream.h
@@ -55,8 +55,4 @@ public:
         data.push_back(other.encode());
         return *this;
     }
-
-
-
-
 };

--- a/sgxclient/DecryptAESKeyShareBatchRspMessage.h
+++ b/sgxclient/DecryptAESKeyShareBatchRspMessage.h
@@ -7,7 +7,7 @@ public:
 
     DecryptAESKeyShareBatchRspMessage( shared_ptr< rapidjson::Document >& _d ) : SgxZmqMessage( _d ){};
 
-    ptr<vector<ptr<string>>> getAEKeyDecryptShares() {
+    ptr<vector<string>> getAEKeyDecryptShares() {
         return getStringArrayRapid( "decryptionShares" );
     }
 };

--- a/sgxclient/SgxZmqClient.cpp
+++ b/sgxclient/SgxZmqClient.cpp
@@ -367,7 +367,7 @@ string SgxZmqClient::blsSignMessageHash( const std::string& keyShareName,
 
 #ifdef BITE
 ptr<vector<string>> SgxZmqClient::decryptAESKeySharesBatch( const std::string& keyShareName,
-     std::vector<std::string > & _aesKeySharesBatch, int t, int n, bool _throwExceptionOnTimeout ) {
+     const std::vector<std::string > & _aesKeySharesBatch, int t, int n, bool _throwExceptionOnTimeout ) {
     Json::Value p;
     p["type"] = SgxZmqMessage::DECRYPT_SHARE_REQ;
     p["blsKeyName"] = keyShareName;

--- a/sgxclient/SgxZmqClient.cpp
+++ b/sgxclient/SgxZmqClient.cpp
@@ -362,8 +362,8 @@ string SgxZmqClient::blsSignMessageHash( const std::string& keyShareName,
 
 
 #ifdef BITE
-ptr<vector<ptr<string>>> SgxZmqClient::decryptAESKeySharesBatch( const std::string& keyShareName,
-     std::vector<std::shared_ptr<std::string> > & _aesKeySharesBatch, int t, int n, bool _throwExceptionOnTimeout ) {
+ptr<vector<string>> SgxZmqClient::decryptAESKeySharesBatch( const std::string& keyShareName,
+     std::vector<std::string > & _aesKeySharesBatch, int t, int n, bool _throwExceptionOnTimeout ) {
     Json::Value p;
     p["type"] = SgxZmqMessage::DECRYPT_SHARE_REQ;
     p["blsKeyName"] = keyShareName;
@@ -371,8 +371,7 @@ ptr<vector<ptr<string>>> SgxZmqClient::decryptAESKeySharesBatch( const std::stri
     // Correctly create an array of strings
     Json::Value _aesKeySharesBatchAsJson(Json::arrayValue);
     for (const auto& share  : _aesKeySharesBatch) {
-        CHECK_STATE(share);
-        _aesKeySharesBatchAsJson.append(*share);
+        _aesKeySharesBatchAsJson.append(share);
     }
 
     p["publicDecryptionValues"] = _aesKeySharesBatchAsJson;

--- a/sgxclient/SgxZmqClient.h
+++ b/sgxclient/SgxZmqClient.h
@@ -131,7 +131,7 @@ public:
 
 #ifdef BITE
     ptr<vector<string>>decryptAESKeySharesBatch( const string& _keyShareName,
-    std::vector<std::string> & _aesKeySharesBatch, int _t, int _n,
+    const std::vector<std::string> & _aesKeySharesBatch, int _t, int _n,
     bool _throwExceptionOnTimeout );
 #endif
 

--- a/sgxclient/SgxZmqClient.h
+++ b/sgxclient/SgxZmqClient.h
@@ -130,8 +130,8 @@ public:
         int _n, bool _throwExceptionOnTimeout );
 
 #ifdef BITE
-    ptr<vector<ptr<string>>>decryptAESKeySharesBatch( const string& _keyShareName,
-    std::vector<std::shared_ptr<std::string> > & _aesKeySharesBatch, int _t, int _n,
+    ptr<vector<string>>decryptAESKeySharesBatch( const string& _keyShareName,
+    std::vector<std::string> & _aesKeySharesBatch, int _t, int _n,
     bool _throwExceptionOnTimeout );
 #endif
 

--- a/sgxclient/SgxZmqMessage.cpp
+++ b/sgxclient/SgxZmqMessage.cpp
@@ -63,16 +63,16 @@ string SgxZmqMessage::getStringRapid( const char* _name ) {
 };
 
 
-ptr<vector<ptr<string>>> SgxZmqMessage::getStringArrayRapid( const char* _name ) {
+ptr<vector<string>> SgxZmqMessage::getStringArrayRapid( const char* _name ) {
     CHECK_STATE( _name );
     CHECK_STATE( d->HasMember( _name ) );
     CHECK_STATE( (*d)[_name].IsArray() );
 
-    auto result = make_shared<vector<ptr<string>>>();
+    auto result = make_shared<vector<string>>();
     const auto& strArray = (*d)[_name];
     for (rapidjson::SizeType i = 0; i < strArray.Size(); ++i) {
         CHECK_STATE(strArray[i].IsString());
-        result->push_back(make_shared<string>(strArray[i].GetString()));
+        result->push_back(strArray[i].GetString());
     }
     return result;
 }

--- a/sgxclient/SgxZmqMessage.h
+++ b/sgxclient/SgxZmqMessage.h
@@ -61,7 +61,7 @@ public:
     explicit SgxZmqMessage( shared_ptr< rapidjson::Document >& _d );
     string getStringRapid( const char* _name );
 
-    ptr<vector<ptr<string>>> getStringArrayRapid( const char* _name );
+    ptr<vector<string>> getStringArrayRapid( const char* _name );
 
     uint64_t getUint64Rapid( const char* _name );
 


### PR DESCRIPTION
## Description

- Introduced Conditional Transactions (CTXs) that must be placed before any regular transaction in the transaction vector passed from the layer above consensus.
- CTXs follow a very specific format:
```cpp
{ 
     functionSelector,  // (4 bytes)
     RLP(
         RLP( // can be of size 0 up to N
             cipher1,
             cipher2,
             ...
             cipherN
         ),
         RLP( // can be of size 0 up to N
             plaintextArg1,
             plaintextArg2,
             ...,
             plaintextArgN
         )
     )
}

```
- Updated/Refactored the distinction between data and logic - moved most of BITE related logic inside BiteManager, leaving the Transaction datastructure holding only data (currently still serving as a cache - should be refactored later - BITE-related caches should be responsibility of BiteManager)
- Serialization into flatbuffers was kept the same. Each aesKey is serialized as a pair `(txId, key)`. This was done to keep backward compatibility with BITE1. The only difference for BITE2 is that now there could be several entries under the same `txId`, each corresponding to a different ciphertext (different ciphered arguments). This also means that the order in which these serialized AESkeys appear **must** be the exact same as the order of the ciphered args in the original transaction.
     - This serialization can be refactored in the future by introducing a table that avoids repeating the txId field, and allows dynamic amount of aesKeys. This should save space.
     
- refactored types and BITE macros out of consensus interface header file. only API calls should be exposed there.
- Refactored BITE1 code to clearly separate calls related to BITE1 vs. BITE2. This was done by assigning the following naming:
    - **regularTxs** for BITE1-related encryption/decryption, since these work for any regular transaction where we want entire `data` field to be encrypted, and the `to` field to include BITE1 signature address
    - **CTXs** / **CTXArgs** for BITE2-related transactions, since these have the `data` field encoded in a way to include all encrypted & non-encrypted arguments for the function call. These are _non-regular_ simply because they are inserted by protocol, and **require** a contiguous placement at the start of the transactions list.
- Renamed `BiteDataField` to `BiteCiphertext` - more generic. can be used for both CTX and regularTxs.
- Base implementation was refactored to use the generic logic that assumes any transaction may hold several Ciphertexts. This makes it much easier for readability instead of having custom logic pieces everywhere enclosed by `#ifdef BITE2` macros. These were only placed on input places, where the generic transactions vector is parsed to check for CTXs. Everywhere else, both BITE1 and BITE2 follow the exact same logic. Meaning BITE1 transactions are just transactions with a single ciphertext (simplest case).

## Performance

- Consensus should now also be subject to possible 'slowdown' since each CTX can have up to N ciphertexts. Which is the same as having additional N BITE1 txs inserted into the BITE decryption phase. Of course this highly depends on how many CTXs, and how many ciphered args in each CTX.
- Practical measurements: (TBD)

PS: **CTX** transactions are currently named CAT in code. This will be updated in a future PR as well as some refactoring

