### PR TITLE
#967 fix logThreadLocal initialization

### DIFF
--- a/abstracttcpclient/AbstractClientAgent.cpp
+++ b/abstracttcpclient/AbstractClientAgent.cpp
@@ -54,8 +54,6 @@ AbstractClientAgent::AbstractClientAgent( Schain& _sChain, port_type _portType )
     portType = _portType;
 
 
-    logThreadLocal_ = _sChain.getNode()->getLog();
-
     for ( uint64_t i = 1; i <= _sChain.getNodeCount(); i++ ) {
         ( itemQueue ).emplace( schain_index( i ), make_shared< queue< ptr< SendableItem > > >() );
         ( queueCond ).emplace( schain_index( i ), make_shared< condition_variable >() );

--- a/abstracttcpserver/AbstractServerAgent.cpp
+++ b/abstracttcpserver/AbstractServerAgent.cpp
@@ -115,7 +115,6 @@ void AbstractServerAgent::send(
 AbstractServerAgent::AbstractServerAgent(
     const string& _name, Schain& _schain, const ptr< TCPServerSocket >& _socket )
     : Agent( _schain, true ), name( _name ), socket( _socket ), networkReadThread( nullptr ) {
-    logThreadLocal_ = _schain.getNode()->getLog();
 }
 
 AbstractServerAgent::~AbstractServerAgent() {

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -83,8 +83,6 @@ BlockFinalizeDownloader::BlockFinalizeDownloader(
     CHECK_STATE(_sChain->getNodeCount() > 1)
 
     try {
-        logThreadLocal_ = _sChain->getNode()->getLog();
-
         CHECK_STATE(sChain)
     } catch (ExitRequestedException &) {
         throw;

--- a/catchup/client/CatchupClientAgent.cpp
+++ b/catchup/client/CatchupClientAgent.cpp
@@ -49,7 +49,6 @@
 
 CatchupClientAgent::CatchupClientAgent( Schain& _sChain ) : Agent( _sChain, false ) {
     try {
-        logThreadLocal_ = _sChain.getNode()->getLog();
         this->sChain = &_sChain;
 
         if ( _sChain.getNodeCount() > 1 ||

--- a/monitoring/MonitoringAgent.cpp
+++ b/monitoring/MonitoringAgent.cpp
@@ -39,7 +39,6 @@
 
 MonitoringAgent::MonitoringAgent( Schain& _sChain ) : Agent( _sChain, false, true ) {
     try {
-        logThreadLocal_ = _sChain.getNode()->getLog();
         this->sChain = &_sChain;
 
         this->monitoringThreadPool = make_shared< MonitoringThreadPool >( 1, this );
@@ -91,6 +90,7 @@ void MonitoringAgent::monitor() {
 void MonitoringAgent::monitoringLoop( MonitoringAgent* _agent ) {
     CHECK_ARGUMENT( _agent );
 
+    logThreadLocal_ = _agent->getSchain()->getNode()->getLog();
     setThreadName( "MonitoringLoop", _agent->getSchain()->getNode()->getConsensusEngine() );
 
 

--- a/monitoring/StuckDetectionAgent.cpp
+++ b/monitoring/StuckDetectionAgent.cpp
@@ -51,7 +51,6 @@
 
 StuckDetectionAgent::StuckDetectionAgent( Schain& _sChain ) : Agent( _sChain, false, true ) {
     try {
-        logThreadLocal_ = _sChain.getNode()->getLog();
         this->sChain = &_sChain;
         // we only need one agent
         this->stuckDetectionThreadPool = make_shared< StuckDetectionThreadPool >( 1, this );
@@ -64,6 +63,7 @@ StuckDetectionAgent::StuckDetectionAgent( Schain& _sChain ) : Agent( _sChain, fa
 
 void StuckDetectionAgent::StuckDetectionLoop( StuckDetectionAgent* _agent ) {
     CHECK_ARGUMENT( _agent );
+    logThreadLocal_ = _agent->getSchain()->getNode()->getLog();
     setThreadName( "StuckDetectionLoop", _agent->getSchain()->getNode()->getConsensusEngine() );
     _agent->getSchain()->getSchain()->waitOnGlobalStartBarrier();
 

--- a/monitoring/TimeoutAgent.cpp
+++ b/monitoring/TimeoutAgent.cpp
@@ -39,7 +39,6 @@
 
 TimeoutAgent::TimeoutAgent( Schain& _sChain ) : Agent( _sChain, false, true ) {
     try {
-        logThreadLocal_ = _sChain.getNode()->getLog();
         this->sChain = &_sChain;
         this->timeoutThreadPool = make_shared< TimeoutThreadPool >( 1, this );
         timeoutThreadPool->startService();
@@ -53,6 +52,7 @@ TimeoutAgent::TimeoutAgent( Schain& _sChain ) : Agent( _sChain, false, true ) {
 void TimeoutAgent::timeoutLoop( TimeoutAgent* _agent ) {
     CHECK_ARGUMENT( _agent );
 
+    logThreadLocal_ = _agent->getSchain()->getNode()->getLog();
     setThreadName( "TimeoutLoop", _agent->getSchain()->getNode()->getConsensusEngine() );
 
     _agent->getSchain()->getSchain()->waitOnGlobalStartBarrier();

--- a/oracle/OracleResultAssemblyAgent.cpp
+++ b/oracle/OracleResultAssemblyAgent.cpp
@@ -13,7 +13,6 @@
 OracleResultAssemblyAgent::OracleResultAssemblyAgent( Schain& _sChain )
     : Agent( _sChain, true ), oracleMessageThreadPool( new OracleMessageThreadPool( this ) ) {
     try {
-        logThreadLocal_ = _sChain.getNode()->getLog();
         oracleMessageThreadPool->startService();
     } catch ( ... ) {
         throw_with_nested( InvalidStateException( __FUNCTION__, __CLASS_NAME__ ) );


### PR DESCRIPTION
### Problem

Agent constructors set `logThreadLocal_` (a `thread_local` variable) on the **main thread** during Schain construction. In unit tests that create/destroy multiple ConsensusEngine instances on the same thread, this creates a dangling pointer:

1. Test creates ConsensusEngine → Schain → Agent constructors set `logThreadLocal_`
2. Test completes, ConsensusEngine is destroyed
3. `logThreadLocal_` still points to `SkaleLog` (kept alive by `shared_ptr`), but `SkaleLog.engine` (a raw pointer) is now dangling
4. Next test calls `CONS_LOG` → accesses `logThreadLocal_->getEngine()` → **SIGSEGV**

### Solution

Remove `logThreadLocal_` assignment from all agent constructors. Worker threads get `logThreadLocal_` set correctly via other mechanisms:

| Agent | How Worker Thread Gets `logThreadLocal_` |
|-------|------------------------------------------|
| MonitoringAgent |  **Added** explicit call in `monitoringLoop()` |
| TimeoutAgent |  **Added** explicit call in `timeoutLoop()` |
| StuckDetectionAgent |  **Added** explicit call in `StuckDetectionLoop()` |
| CatchupClientAgent | Already set via `waitOnGlobalStartBarrier()` in Node.cpp |
| AbstractClientAgent | Workers call `waitOnGlobalStartBarrier()` in Node.cpp |
| AbstractServerAgent | Workers call `waitOnGlobalStartBarrier()` in Node.cpp |
| OracleResultAssemblyAgent | Already set in `messageThreadProcessingLoop()` |
| BlockFinalizeDownloader | Workers call `waitOnGlobalClientStartBarrier()` in Node.cpp |

## Tests

Ran skaled `committeeRotation` test - all still works fine