### PR TITLE
Fix CacheLvlDB nullptr setting on destroy

### DIFF
--- a/db/CacheLevelDB.cpp
+++ b/db/CacheLevelDB.cpp
@@ -730,11 +730,15 @@ void CacheLevelDB::destroy() {
     checkForDeadLock( __FUNCTION__ );
     lock_guard< shared_timed_mutex > lock( m );
 
+
+    for ( auto& dbase : db) {
+        CHECK_STATE( dbase );
+        dbase = nullptr;
+    }
+
     auto [maxIndex, minIndex] = findMaxMinDBIndex();
     
     for ( uint64_t i = minIndex; i <= maxIndex; i++ ) {
-        CHECK_STATE( db.at( i ) );
-        db.at( i ) = nullptr;
         DestroyDB( index2Path( i ), leveldb::Options() );
     }
 }


### PR DESCRIPTION
## Description

The `CacheLevelDB::destroy()` method was using on-disk file indices (which grow indefinitely, e.g., 100..105) to access the db vector of active handles (which has a fixed size, e.g., 0..4). This caused an out-of-bounds exception once the file index exceeded the number of active shards.

## Fix
Decoupled the cleanup process into two distinct steps:

1. Iterate over the db to safely close and release all open database handles. 
2. Iterate over the calculated file index range to destroy the physical database files on disk.

Potentially fixes skalenetwork/internal-support#1375
Fixes #973 