### PR TITLE
Allow empty ciphertext CTX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,10 @@ jobs:
 
     - name: Cleanup
       run: |
-        sudo apt-get autoremove -y >/dev/null 2>&1
-        sudo apt-get autoclean -y >/dev/null 2>&1
-        sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
-        sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1
+        sudo apt-get autoremove -y >/dev/null 2>&1 || true
+        sudo apt-get autoclean  -y >/dev/null 2>&1 || true
+        sudo rm -rf /usr/local/lib/android >/dev/null 2>&1 || true
+        sudo docker system prune -af --volumes >/dev/null 2>&1 || true
 
     - name: Install docker compose
       run: |

--- a/.github/workflows/buildm.yml
+++ b/.github/workflows/buildm.yml
@@ -68,10 +68,10 @@ jobs:
 
     - name: Cleanup
       run: |
-        sudo apt-get autoremove -y >/dev/null 2>&1
-        sudo apt-get autoclean -y >/dev/null 2>&1
-        sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
-        sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1
+        sudo apt-get autoremove -y >/dev/null 2>&1 || true
+        sudo apt-get autoclean  -y >/dev/null 2>&1 || true
+        sudo rm -rf /usr/local/lib/android >/dev/null 2>&1 || true
+        sudo docker system prune -af --volumes >/dev/null 2>&1 || true
 
     - name: Install docker compose
       run: |

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -322,6 +322,10 @@ ptr<vector<ptr<AESKeyDecryptionShares> > > BiteManager::getDecryptionSharesFromA
  * @brief Helper function - appends ciphertexts from TransactionCiphertexts to vector of CipheredKey
  */
 void appendCiphertextsToVector(ptr<TransactionCiphertexts> _ciphertexts, std::vector< libBLS::CipheredKey >& _vec, size_t& _ciphertextIdx) {
+    // Allow transactions with no ciphertexts (e.g., CAT txs with empty ciphertext)
+    if (_ciphertexts->count() == 0) {
+        return;
+    }
     if (_ciphertexts->count() > 1) {
         std::vector< libBLS::CipheredKey > cipheredKeysLocal;
         cipheredKeysLocal.reserve(_ciphertexts->count());
@@ -454,6 +458,12 @@ DecryptedTransactions BiteManager::verifyAndDecryptTransactionList(
             if (!allCATsParsed) {
                 auto encryptedArgs = tryGetEncryptedCATArgs(tx, currentEpoch);
                 if (encryptedArgs) {
+                    // CAT tx with no encrypted arguments — nothing to decrypt
+                    if (encryptedArgs->empty()) {
+                        std::lock_guard<std::mutex> lock(catTxsMapMutex);
+                        catTxsMap->emplace(txIdx, DecryptedCATArgs{});
+                        continue;
+                    }
                     auto decryptedAESKey = _aesKeys.getKeys(txIdx);
                     CHECK_STATE(decryptedAESKey);
                     CHECK_STATE(encryptedArgs->size() == decryptedAESKey->size());
@@ -663,6 +673,35 @@ ptr<vector<uint8_t> > BiteManager::generateEncryptedCATData() {
         plainArgs << rndData;
     }
 
+    allArgs << encryptedArgs << plainArgs;
+    auto finalData = allArgs.encode();
+
+    std::vector<uint8_t> data;
+    data.reserve(BITE2_FUNCTION_SELECTOR_SIZE_BYTES + finalData.size());
+
+    // prefix with function selector 
+    data.insert(
+        data.end(),
+        BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY,
+        BITE_FUNCTION_SELECTOR_AS_BYTE_ARRAY + BITE2_FUNCTION_SELECTOR_SIZE_BYTES
+    );
+
+    // append RLP data
+    data.insert(data.end(), finalData.begin(), finalData.end());
+
+    return std::make_shared<std::vector<uint8_t>>(std::move(data));
+}
+
+ptr<vector<uint8_t> > BiteManager::generateEmptyCATData() {
+    // No encrypted arguments (empty ciphertexts)
+    RLPStream encryptedArgs;  // empty
+    
+    // Some plain arguments to include in the CAT
+    RLPStream plainArgs;
+    plainArgs << std::vector<uint8_t>{0x01, 0x02, 0x03};
+    plainArgs << std::vector<uint8_t>{0x04, 0x05};
+    
+    RLPStream allArgs;
     allArgs << encryptedArgs << plainArgs;
     auto finalData = allArgs.encode();
 

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -142,6 +142,12 @@ public:
      * ]
      */
     [[nodiscard]] ptr<vector<uint8_t> > generateEncryptedCATData();
+    
+    /**
+     * @brief Generates a CAT transaction with no encrypted arguments (empty ciphertexts).
+     * Only plain arguments are included.
+     */
+    [[nodiscard]] ptr<vector<uint8_t> > generateEmptyCATData();
 #endif
 
 private:

--- a/pendingqueue/TestMessageGeneratorAgent.cpp
+++ b/pendingqueue/TestMessageGeneratorAgent.cpp
@@ -198,12 +198,28 @@ ConsensusExtFace::Transactions TestMessageGeneratorAgent::pendingTransactionsBIT
         onlyRegularTxs = std::move(tmpOnlyRegularTxs);
 
 #ifdef BITE2
-        // setup cat txs
+        // setup cat txs - include some empty CATs for coverage
+        // Empty CATs will be at positions: 0 (start), numTotalCATTxs/2 (middle), numTotalCATTxs-1 (end)
+        // and every 10th transaction to ensure ~10% are empty CATs
         for ( uint64_t i = 0; i < numTotalCATTxs; i++ ) {
             auto tx = EthTransactionEncoder::generateSampleTx();
             
-            auto catData = sChain->getBiteManager()->generateEncryptedCATData();
+            // Make empty CAT at start, middle, end, and every 10th transaction
+            bool isEmptyCAT = (i == 0) || 
+                              (i == numTotalCATTxs / 2) || 
+                              (i == numTotalCATTxs - 1) ||
+                              (i % 10 == 0);
+            
+            ptr<vector<uint8_t>> catData;
+            if (isEmptyCAT) {
+                // CAT with no encrypted arguments (empty ciphertexts)
+                catData = sChain->getBiteManager()->generateEmptyCATData();
+            } else {
+                // Regular CAT with encrypted arguments
+                catData = sChain->getBiteManager()->generateEncryptedCATData();
+            }
             tx->data = *catData;
+            
             auto signedTx = EthTransactionEncoder::signAndEncodeTx( tx );
             tmpOnlyCATs.emplaceBackCAT( std::move(*signedTx) );
         }


### PR DESCRIPTION
## Description

- Fix bug where CTX with no ciphertexts resulted in index out of bounds
- Allow empty cipheretxt CTX

## Tested

- Added emmpty ciphertext CTX for tx builder & tested locally `fournodes` test

Fixed #977 