### PR TITLE
Add SC address AAD support for CTX TE validation

### DIFF
--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -81,14 +81,15 @@ ptr<BiteCiphertext> BiteManager::tryGetEncryptedRegularTxFields(
 }
 
 #ifdef BITE2
-ptr<std::vector<ptr<BiteCiphertext>>> BiteManager::tryGetEncryptedCATArgs(
-            const ptr<Transaction>& _transaction, epoch_id _currentEpochId ) {
+std::pair<ptr<std::vector<ptr<BiteCiphertext>>>, ptr<AddressBytes>> 
+BiteManager::tryGetEncryptedCATArgs( const ptr<Transaction>& _transaction, epoch_id _currentEpochId ) {
     CHECK_STATE(_transaction);
 
     auto encryptedCATArgs = _transaction->getCATEncryptedArgs();
+    auto scAddressAadTE = _transaction->getScAddressAadTE();
 
     // if not cached - try to parse it
-    if (!encryptedCATArgs) {
+    if (!encryptedCATArgs || !scAddressAadTE) {
 
         // if not set bite data already - try parse it
         auto ethTx = _transaction->getAsEthereumTransaction();
@@ -104,7 +105,7 @@ ptr<std::vector<ptr<BiteCiphertext>>> BiteManager::tryGetEncryptedCATArgs(
                 BITE2_FUNCTION_SELECTOR_SIZE_BYTES
             ) != 0
         ) {
-            return nullptr;
+            return { nullptr, nullptr };
         }
 
         // Parse args as RLP list
@@ -125,10 +126,26 @@ ptr<std::vector<ptr<BiteCiphertext>>> BiteManager::tryGetEncryptedCATArgs(
             auto argData = make_shared<std::vector<uint8_t>>(encryptedArgsRLP[i].asBytes());
             ptr<BiteCiphertext> biteCiphertext = make_shared<BiteCiphertext>(argData, _currentEpochId);
             encryptedCATArgs->emplace_back( biteCiphertext );
-        }
-        _transaction->setCATEncryptedArgs(encryptedCATArgs); // cache it   
+        }  
+
+        // fetch & cache 'to' field - scAddress used as AAD for TE validation phases
+        auto toField = ethTx->getToField();
+        CHECK_STATE(toField);
+        CHECK_STATE2(toField->size() == sizeof(AddressBytes), 
+            "CAT transaction 'to' field must be exactly 20 bytes");
+        
+        AddressBytes toFieldBytes;
+        std::copy(toField->begin(), toField->end(), toFieldBytes.begin());
+
+        // only cache after both are successfully parsed
+        _transaction->setScAddressAadTE(toFieldBytes);
+        _transaction->setCATEncryptedArgs(encryptedCATArgs);
+        
+        // Fetch the cached values to return
+        encryptedCATArgs = _transaction->getCATEncryptedArgs();
+        scAddressAadTE = _transaction->getScAddressAadTE();
     }
-    return encryptedCATArgs;
+    return { encryptedCATArgs, scAddressAadTE };
 }
 #endif
 
@@ -149,9 +166,11 @@ void BiteManager::parseBITETransactions(
         try {
             auto tx = transactions->at(i);
             auto catArgs = tryGetEncryptedCATArgs(tx, _proposal->getEpochID());
+            auto ciphertexts = catArgs.first;
+            auto scAddressAadTE = catArgs.second;
 
-            if (catArgs) {
-                auto txCiphertexts = make_shared<TransactionCiphertexts>(*catArgs);
+            if (ciphertexts && scAddressAadTE) {
+                auto txCiphertexts = make_shared<TransactionCiphertexts>(*ciphertexts, *scAddressAadTE);
                 encryptedAESKeyMap->emplace(i, txCiphertexts);
             } else {
                 // the first non-CAT transaction indicates the start of regular transactions
@@ -360,16 +379,35 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
     publicDecryptionValues->reserve(txsCiphertexts->totalCiphertextCount());
     cipheredKeys.reserve(txsCiphertexts->totalCiphertextCount());
 
+    // Separate CAT and regular tx ciphertexts for split validation
+    std::vector< libBLS::CipheredKey > catCipheredKeys;
+    std::vector< std::vector< uint8_t > > catAadTE;  // SC addresses for CAT txs
+    
+    std::vector< libBLS::CipheredKey > regularCipheredKeys;
+
     for ( auto && it: *txsCiphertexts) {
         size_t failingIdx = 0; // ciphertext idx for each tx starts at 0
         try {
             ptr<TransactionCiphertexts> ciphertexts = it.second;
             CHECK_STATE(ciphertexts)
             
-            appendCiphertextsToVector(ciphertexts, cipheredKeys, failingIdx);
-
+            if (ciphertexts->isCAT()) {
+                // CAT transaction - collect ciphertexts with AAD
+                const auto& scAddr = ciphertexts->getScAddressAadTE();
+                CHECK_STATE(scAddr.has_value());
+                std::vector<uint8_t> aadBytes(scAddr->begin(), scAddr->end());
+                
+                appendCiphertextsToVector(ciphertexts, catCipheredKeys, failingIdx);
+                for (size_t i = 0; i < ciphertexts->count(); ++i) {
+                    catAadTE.push_back(aadBytes);  // same AAD for all ciphertexts in this tx
+                }
+            } else {
+                // Regular transaction - no AAD
+                appendCiphertextsToVector(ciphertexts, regularCipheredKeys, failingIdx);
+            }
+            
             for (size_t i = 0; i < ciphertexts->count(); ++i) {
-                validGlobalIndices.push_back(it.first); // repeat global index for each ciphertext
+                validGlobalIndices.push_back(it.first);
             }
         }
         catch (exception &_e) {
@@ -379,8 +417,41 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
         }
     }
 
-    // validate all in parallel
-    std::vector< bool > validationResult = libBLS::ThresholdEncryption::validateEncryptionBatchParallel( cipheredKeys );
+    // Validate CAT ciphertexts with AAD
+    std::vector< bool > catValidationResult;
+    if (!catCipheredKeys.empty()) {
+        catValidationResult = libBLS::ThresholdEncryption::validateEncryptionBatchParallel(
+            catCipheredKeys, &catAadTE); // pass AAD for CAT txs
+    }
+    
+    // Validate regular ciphertexts without AAD
+    std::vector< bool > regularValidationResult;
+    if (!regularCipheredKeys.empty()) {
+        regularValidationResult = libBLS::ThresholdEncryption::validateEncryptionBatchParallel(
+            regularCipheredKeys, nullptr); // no AAD for these
+    }
+
+    // Combine validation results and cipheredKeys in original order
+    std::vector< bool > validationResult;
+    validationResult.reserve(catCipheredKeys.size() + regularCipheredKeys.size());
+    cipheredKeys.reserve(catCipheredKeys.size() + regularCipheredKeys.size());
+    
+    size_t catIdx = 0, regularIdx = 0;
+    for (auto&& [idx, ciphertexts] : *txsCiphertexts) {
+        if (ciphertexts->isCAT()) {
+            for (size_t i = 0; i < ciphertexts->count(); ++i) {
+                validationResult.push_back(catValidationResult[catIdx]);
+                cipheredKeys.push_back(catCipheredKeys[catIdx]);
+                catIdx++;
+            }
+        } else {
+            for (size_t i = 0; i < ciphertexts->count(); ++i) {
+                validationResult.push_back(regularValidationResult[regularIdx]);
+                cipheredKeys.push_back(regularCipheredKeys[regularIdx]);
+                regularIdx++;
+            }
+        }
+    }
 
     // If at least 1 is not valid - mark as failed, log and return
     bool allValid = std::all_of(validationResult.begin(), validationResult.end(),
@@ -456,7 +527,9 @@ DecryptedTransactions BiteManager::verifyAndDecryptTransactionList(
 #ifdef BITE2
             // ---------- Try CAT path first ----------
             if (!allCATsParsed) {
-                auto encryptedArgs = tryGetEncryptedCATArgs(tx, currentEpoch);
+                auto catParseResult = tryGetEncryptedCATArgs(tx, currentEpoch);
+                auto encryptedArgs = catParseResult.first;
+                // scAddressAadTE not needed here, already cached in Transaction
                 if (encryptedArgs) {
                     // CAT tx with no encrypted arguments — nothing to decrypt
                     if (encryptedArgs->empty()) {
@@ -611,13 +684,18 @@ void BiteManager::corruptFromTimeToTime(shared_ptr<vector<unsigned char> >) {
     }
 }
 
-ptr<vector<uint8_t>> BiteManager::encryptData(const vector<uint8_t>& data) {
+ptr<vector<uint8_t>> BiteManager::encryptData(const vector<uint8_t>& data,
+    const std::optional<std::vector<uint8_t>>& _aadTE) {
     auto [primaryKey, secondaryKey] = schain.getCryptoManager()->getSgxBlsPublicKey();
     CHECK_STATE(primaryKey);
     auto blsKey = primaryKey->getPublicKey();
     libBLS::TEPublicKey teKey(blsKey);
 
-    auto cipherText = libBLS::ThresholdEncryption::encrypt(data, teKey);
+    // Create EncryptMetaData with optional AAD for real crypto
+    libBLS::EncryptMetaData metaData;
+    metaData.associatedDataTE = _aadTE;
+
+    auto cipherText = libBLS::ThresholdEncryption::encrypt(data, teKey, metaData);
     return std::make_shared<vector<uint8_t>>(cipherText.toBytes());
 }
 
@@ -637,14 +715,11 @@ ptr<vector<uint8_t> > BiteManager::encryptRegularTx(const vector<uint8_t> &_data
 }
 
 #ifdef BITE2
-ptr<vector<uint8_t> > BiteManager::generateEncryptedCATData() {
-    static size_t numberOfCiphertexts = 2;
+ptr<vector<uint8_t> > BiteManager::generateEncryptedCATData(const AddressBytes& _scAddressAadTE) {
+    constexpr size_t numberOfCiphertexts = 2;  // Fixed count for deterministic behavior across nodes
 
-    // Keep ciphertext count between 2 and 5 (inclusive)
-    numberOfCiphertexts++;
-    if (numberOfCiphertexts % 6 == 0) {
-        numberOfCiphertexts = 2;
-    }
+    // Convert SC address to vector for AAD (used only in real crypto)
+    std::vector<uint8_t> aadBytes(_scAddressAadTE.begin(), _scAddressAadTE.end());
 
     RLPStream allArgs;
     
@@ -654,9 +729,11 @@ ptr<vector<uint8_t> > BiteManager::generateEncryptedCATData() {
         std::vector<uint8_t> encryptedData;
         rndData.resize(numberOfCiphertexts * 10);
         if (this->doRealCrypto) {
-            encryptedData = *encryptData(rndData);
+            // Real crypto: use SC address as AAD
+            encryptedData = *encryptData(rndData, aadBytes);
         }
         else {
+            // Mockup: ignore AAD, just encrypt
             encryptedData = libBLS::ThresholdEncryption::mockupEncrypt(rndData);
         }
         BiteCiphertext biteCiphertext(

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -64,7 +64,7 @@ public:
      * If parsing is successful - returns vector of BiteCiphertext objects, else returns 'nullopt'
      * @throws if it matches the function selector but fails to parse the rest of the data
      */
-    static ptr<std::vector<ptr<BiteCiphertext>>> tryGetEncryptedCATArgs(
+    static std::pair< ptr<std::vector<ptr<BiteCiphertext>>>, ptr<AddressBytes> > tryGetEncryptedCATArgs(
             const ptr<Transaction> &_transaction, epoch_id _currentEpochId);
 #endif
 
@@ -132,6 +132,7 @@ public:
 #ifdef BITE2
     /**
      * @brief Encrypts CAT function arguments using BITE2 scheme.
+     * @param _scAddressAadTE - Smart contract address used as AAD for TE validation (real crypto only)
      * @param _data - Returned data follows the format:
      * [
      *      funcSelector,  // 4 bytes
@@ -141,7 +142,7 @@ public:
      *      ),
      * ]
      */
-    [[nodiscard]] ptr<vector<uint8_t> > generateEncryptedCATData();
+    [[nodiscard]] ptr<vector<uint8_t> > generateEncryptedCATData(const AddressBytes& _scAddressAadTE);
     
     /**
      * @brief Generates a CAT transaction with no encrypted arguments (empty ciphertexts).
@@ -160,7 +161,8 @@ private:
     // Parses decrypted data as a set of CAT function arguments
     DecryptedCATArgs parseDecryptedDataAsCATArgs(const vector<uint8_t> &_data) const;
 
-    ptr<vector<uint8_t>> encryptData(const vector<uint8_t>& data);
+    ptr<vector<uint8_t>> encryptData(const vector<uint8_t>& data,
+        const std::optional<std::vector<uint8_t>>& _aadTE = std::nullopt);
 
     void stopAndDestroyThreadPoolExecutor();
 

--- a/crypto/TransactionCiphertexts.cpp
+++ b/crypto/TransactionCiphertexts.cpp
@@ -1,11 +1,15 @@
 #include "TransactionCiphertexts.h"
 #include "libBLS/threshold_encryption/threshold_encryption.h"
 
-TransactionCiphertexts::TransactionCiphertexts(ptr<BiteCiphertext> ciphertext) {
+TransactionCiphertexts::TransactionCiphertexts(ptr<BiteCiphertext> ciphertext, 
+    std::optional<AddressBytes> _scAddressAadTE) 
+    : scAddressAadTE(std::move(_scAddressAadTE)) {
     ciphertexts.push_back(ciphertext->getEncryptedAESKey());
 }
 
-TransactionCiphertexts::TransactionCiphertexts(std::vector<ptr<BiteCiphertext>>& ciphertextsVec) {
+TransactionCiphertexts::TransactionCiphertexts(std::vector<ptr<BiteCiphertext>>& ciphertextsVec,
+    std::optional<AddressBytes> _scAddressAadTE)
+    : scAddressAadTE(std::move(_scAddressAadTE)) {
     for (const auto& ciphertext : ciphertextsVec) {
         ciphertexts.push_back(ciphertext->getEncryptedAESKey());
     }

--- a/crypto/TransactionCiphertexts.h
+++ b/crypto/TransactionCiphertexts.h
@@ -15,19 +15,28 @@ namespace libBLS {
 
 /**
  * @brief Holds ciphertexts (EncryptedAESKeys) for a transaction. Transactions may have
- * 1 or multiple ciphertexts, depending on whether they are:
+ * 0 or multiple ciphertexts, depending on whether they are:
  * 
- * 1) A regular transaction - with a single EncryptedAESKey (single ciphertext)
+ * 1) A regular transaction - Requires a single EncryptedAESKey (single ciphertext)
  * 
- * 2) A CAT transaction - with multiple EncryptedAESKeys (multiple ciphertexts)
+ * 2) A CAT transaction - May have 0 or multiple EncryptedAESKeys (multiple ciphertexts)
  */
 class TransactionCiphertexts {
-    
+
+    // Ciphertexts for the transaction
     small_vector<EncryptedAESKey> ciphertexts;
 
+    // Optional smart contract address used as AAD in threshold encryption
+    // For CAT transactions, this is the address of the SC that issued
+    // the CAT. 
+    std::optional<AddressBytes> scAddressAadTE;
+
 public:
-    TransactionCiphertexts( ptr<BiteCiphertext> ciphertext);
-    TransactionCiphertexts(std::vector<ptr<BiteCiphertext>>& ciphertextsVec);
+    TransactionCiphertexts( ptr<BiteCiphertext> ciphertext, 
+        std::optional<AddressBytes> scAddressAadTE = std::nullopt);
+
+    TransactionCiphertexts(std::vector<ptr<BiteCiphertext>>& ciphertextsVec, 
+        std::optional<AddressBytes> scAddressAadTE = std::nullopt);
 
     auto begin() const { return ciphertexts.begin(); }
     auto end()   const { return ciphertexts.end();   }
@@ -48,4 +57,10 @@ public:
     }
 
     [[nodiscard]] std::shared_ptr<std::string> toHex() const;
+
+    // Returns the SC address AAD for TE validation (only set for CAT txs)
+    [[nodiscard]] const std::optional<AddressBytes>& getScAddressAadTE() const { return scAddressAadTE; }
+    
+    // Returns true if this is a CAT transaction (has SC address AAD)
+    [[nodiscard]] bool isCAT() const { return scAddressAadTE.has_value(); }
 };

--- a/datastructures/Transaction.cpp
+++ b/datastructures/Transaction.cpp
@@ -215,6 +215,16 @@ void Transaction::setCATEncryptedArgs( ptr<std::vector<ptr<BiteCiphertext>>> _bi
     // thread safe
     std::atomic_store(&parsedEncryptedCATArgs, _biteDataField);
 }
+
+void Transaction::setScAddressAadTE( const AddressBytes& _scAddressAadTE ) {
+    auto address = make_shared<AddressBytes>(_scAddressAadTE);
+    std::atomic_store(&scAddressAadTE, address);
+}
+
+ptr<AddressBytes> Transaction::getScAddressAadTE() {
+    return std::atomic_load(&scAddressAadTE);
+}
+
 #endif
 
 #endif

--- a/datastructures/Transaction.h
+++ b/datastructures/Transaction.h
@@ -67,6 +67,10 @@ class Transaction : public DataStructure {
 #ifdef BITE2
     // Stores a list of encrypted arguments from CAT transaction
     ptr<std::vector<ptr<BiteCiphertext>>> parsedEncryptedCATArgs = nullptr;
+
+    // stores the 'to' field of the CTX transaction as AAD for TE
+    // using ptr to allow atomic store/load
+    ptr<AddressBytes> scAddressAadTE;
 #endif
 
 #endif
@@ -112,6 +116,9 @@ public:
     // Allows caching parsed encrypted CAT transaction arguments
     ptr<std::vector<ptr<BiteCiphertext>>> getCATEncryptedArgs();
     void setCATEncryptedArgs( ptr<std::vector<ptr<BiteCiphertext>>> _biteDataField );
+
+    void setScAddressAadTE( const AddressBytes& _scAddressAadTE );
+    ptr<AddressBytes> getScAddressAadTE();
 #endif
 
     ptr<vector<uint8_t>> emplaceAndReencodeTransaction(vector<uint8_t>& _originalDataField );

--- a/datastructures/TransactionList.cpp
+++ b/datastructures/TransactionList.cpp
@@ -165,7 +165,8 @@ ptr< ConsensusExtFace::Transactions > TransactionList::createTransactionVector(
         auto epochId = biteManager->getSchain()->getNode()->getCurrentEpochId();
         for (size_t i = 0; i < transactions->size(); i++) {
             auto tx = transactions->at(i);
-            if (biteManager->tryGetEncryptedCATArgs(tx, epochId)) {
+            auto catArgs = biteManager->tryGetEncryptedCATArgs(tx, epochId).first;
+            if (catArgs) {
                 tv->pushBackCAT(*(tx->getData()));
             }
             else {

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -160,7 +160,7 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
 
     WRITE_LOCK(decryptionSetsMutex);
 
-    // nodeId -> decryption shares (each may hold decryption shares for multiple ciphertexts)
+    // nodeId -> decryption shares
     map< schain_index, ptr< AESKeyDecryptionShareList > >& decryptionShareMap =
         decryptionsStore[_blockId];
 
@@ -171,6 +171,7 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
     CHECK_STATE( firstDecryptionShareList );
     auto size = firstDecryptionShareList->totalCiphertextSharesCount();
 
+    // must have received same amount of shares from each decryptor
     for (auto&& [_, list] : decryptionShareMap) {
         CHECK_STATE(list->totalCiphertextSharesCount() == size);
     }
@@ -179,23 +180,27 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
     map<transaction_index, ptr<AESKeyDecryptionShareSet>> decryptionShareSets;
     map<transaction_index, std::vector<libBLS::CipheredKey>> encryptions;
 
+    // initialization using decryptions shares from 1st decryptor
     bool toValidate = false;
-    for ( auto&& [idx, aesDecryptionShare] : firstDecryptionShareList->getDecryptionShares() ) {
-        decryptionShareSets[idx] =
+
+    for ( auto&& [transactionIdx, aesDecryptionShares] : firstDecryptionShareList->getDecryptionShares() ) {
+        // allocate resources for each tx
+        decryptionShareSets[transactionIdx] =
             sChain->getBiteManager()->createAESDecryptionShareSet(
-                _blockId, idx, aesDecryptionShare->size() );
+                _blockId, transactionIdx, aesDecryptionShares->size() );
         if (sChain->getNode()->isSgxEnabled()) {
             // fill the map to use in multiple threads later if real signatures are enabled
             // dont validate inputs - were already validated before
-            auto& ciphertextsForCurrTx = *_transactionCiphertextsMap->at(idx);
+            auto& ciphertextsForCurrTx = *_transactionCiphertextsMap->at(transactionIdx);
             for (auto& ciphertext : ciphertextsForCurrTx) {
-                encryptions[idx].push_back(
+                // populate ciphertexts using tx index from the decryption share list
+                encryptions[transactionIdx].push_back(
                     libBLS::CipheredKey::fromBytes(ciphertext.data(), toValidate));
             }
         }
     }
 
-    // 1 key for each signer (index = signerId)
+    // Keep all signers' public keys
     vector<libBLS::TEPublicKeyShare> tePublicKeys;
     if (sChain->getNode()->isSgxEnabled()) {
         ptr<vector<ptr<libBLS::BLSPublicKeyShare>>> keyShares =
@@ -282,11 +287,25 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
                     std::vector<bool> allSharesFromNodeAreValid;
                     allSharesFromNodeAreValid.resize(totalSigners, true);
 
+                    // Prepare AAD for CAT transactions
+                    const auto& txCiphertexts = _transactionCiphertextsMap->at(txId);
+                    const std::vector<std::vector<uint8_t>>* aadPtr = nullptr;
+                    std::vector<std::vector<uint8_t>> aadVec;
+                    
+                    if (txCiphertexts->isCAT()) {
+                        const auto& scAddr = txCiphertexts->getScAddressAadTE();
+                        CHECK_STATE(scAddr.has_value());
+                        // Single element - same AAD for the one ciphertext validated per call
+                        aadVec.push_back(std::vector<uint8_t>(scAddr->begin(), scAddr->end()));
+                        aadPtr = &aadVec;
+                    }
+
                     for (size_t ciphertextId = 0; ciphertextId < numberOfCiphertexts; ++ciphertextId) {
                         std::vector<libBLS::CipheredKey> cipheredKeys{ encryptions.at(txId).at(ciphertextId) };
 
                         auto result = libBLS::ThresholdEncryption::validateDecryptionSharesBatch(
-                                cipheredKeys, teShares.at(ciphertextId), publicKeys.at(ciphertextId));
+                                cipheredKeys, teShares.at(ciphertextId), publicKeys.at(ciphertextId),
+                                aadPtr);  // Pass AAD for CAT txs, nullptr for regular
 
                         for (size_t shareId = 0; shareId < result.size(); ++shareId) {
                             if (!result[shareId]) {

--- a/pendingqueue/PendingTransactionsAgent.cpp
+++ b/pendingqueue/PendingTransactionsAgent.cpp
@@ -188,7 +188,7 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
         try {
 #ifdef BITE2
             if (transactions.isCat(i)) {
-                auto catArgs = biteManager->tryGetEncryptedCATArgs(pt, currentEpoch);
+                auto catArgs = biteManager->tryGetEncryptedCATArgs(pt, currentEpoch).first;
                 if (!catArgs) {
                     CONS_LOG(err, "Found regular transaction marked as CAT. Skipping it from my proposal.");
                     continue;

--- a/pendingqueue/TestMessageGeneratorAgent.cpp
+++ b/pendingqueue/TestMessageGeneratorAgent.cpp
@@ -216,7 +216,11 @@ ConsensusExtFace::Transactions TestMessageGeneratorAgent::pendingTransactionsBIT
                 catData = sChain->getBiteManager()->generateEmptyCATData();
             } else {
                 // Regular CAT with encrypted arguments
-                catData = sChain->getBiteManager()->generateEncryptedCATData();
+                // Use tx->to as SC address for AAD (only used in real crypto)
+                AddressBytes scAddress;
+                CHECK_STATE(tx->to.size() == 20);
+                std::copy_n(tx->to.begin(), 20, scAddress.begin());
+                catData = sChain->getBiteManager()->generateEncryptedCATData(scAddress);
             }
             tx->data = *catData;
             


### PR DESCRIPTION
# Description
- Parse & cache CTX `to` field
- Use this as AAD during validation phases:
   - `validateEncryption`
   - `validateDecryptionShare`
   
# Tests
- Passed `fournode` and `sixteennode` tests locally (running real crypto with SGX)

Fixes #979 