### PR TITLE
Improve log setting for agents & thread teardown for unit tests

### DIFF
--- a/Consensust.cpp
+++ b/Consensust.cpp
@@ -59,6 +59,22 @@
 
 ConsensusEngine* engine;  // definition
 
+namespace {
+    
+// Ensure that ConsensusEngine logging is initialized before any tests are run
+class ConsensusLogFixture : public Catch::TestEventListenerBase {
+public:
+    using Catch::TestEventListenerBase::TestEventListenerBase;
+
+    void testCaseStarting( const Catch::TestCaseInfo& ) override {
+        ConsensusEngine::ensureConfigLogger();
+    }
+};
+
+CATCH_REGISTER_LISTENER( ConsensusLogFixture )
+
+}  // namespace
+
 uint64_t Consensust::getRunningTimeS() {
     if ( runningTimeS == 0 ) {
         auto env = getenv( "TEST_TIME_S" );

--- a/abstracttcpclient/AbstractClientAgent.cpp
+++ b/abstracttcpclient/AbstractClientAgent.cpp
@@ -53,9 +53,6 @@ AbstractClientAgent::AbstractClientAgent( Schain& _sChain, port_type _portType )
     : Agent( _sChain, false ) {
     portType = _portType;
 
-
-    logThreadLocal_ = _sChain.getNode()->getLog();
-
     for ( uint64_t i = 1; i <= _sChain.getNodeCount(); i++ ) {
         ( itemQueue ).emplace( schain_index( i ), make_shared< queue< ptr< SendableItem > > >() );
         ( queueCond ).emplace( schain_index( i ), make_shared< condition_variable >() );
@@ -148,6 +145,7 @@ void AbstractClientAgent::workerThreadItemSendLoop( AbstractClientAgent* agent )
     setThreadName( "BlockPopClnt", agent->getSchain()->getNode()->getConsensusEngine() );
 
     agent->waitOnGlobalStartBarrier();
+    logThreadLocal_ = agent->getSchain()->getNode()->getLog();
 
     auto destinationSchainIndex = schain_index( agent->incrementAndReturnThreadCounter() + 1 );
 

--- a/abstracttcpserver/AbstractServerAgent.cpp
+++ b/abstracttcpserver/AbstractServerAgent.cpp
@@ -83,6 +83,8 @@ void AbstractServerAgent::workerThreadConnectionProcessingLoop( void* _params ) 
 
     server->waitOnGlobalStartBarrier();
 
+    logThreadLocal_ = server->getSchain()->getNode()->getLog();
+
     CONS_LOG( trace, "Started server loop" );
 
     while ( !server->getNode()->isExitRequested() ) {
@@ -115,7 +117,6 @@ void AbstractServerAgent::send(
 AbstractServerAgent::AbstractServerAgent(
     const string& _name, Schain& _schain, const ptr< TCPServerSocket >& _socket )
     : Agent( _schain, true ), name( _name ), socket( _socket ), networkReadThread( nullptr ) {
-    logThreadLocal_ = _schain.getNode()->getLog();
 }
 
 AbstractServerAgent::~AbstractServerAgent() {
@@ -126,6 +127,9 @@ void AbstractServerAgent::acceptTCPConnectionsLoop() {
     setThreadName( name, getSchain()->getNode()->getConsensusEngine() );
 
     waitOnGlobalStartBarrier();
+
+    logThreadLocal_ = getSchain()->getNode()->getLog();
+    logThreadLocal_ = getSchain()->getNode()->getLog();
 
     struct sockaddr_in clientAddress;
     socklen_t sizeOfClientAddress = sizeof( clientAddress );

--- a/abstracttcpserver/AbstractServerAgent.cpp
+++ b/abstracttcpserver/AbstractServerAgent.cpp
@@ -127,8 +127,6 @@ void AbstractServerAgent::acceptTCPConnectionsLoop() {
     setThreadName( name, getSchain()->getNode()->getConsensusEngine() );
 
     waitOnGlobalStartBarrier();
-
-    logThreadLocal_ = getSchain()->getNode()->getLog();
     logThreadLocal_ = getSchain()->getNode()->getLog();
 
     struct sockaddr_in clientAddress;

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -83,8 +83,6 @@ BlockFinalizeDownloader::BlockFinalizeDownloader(
     CHECK_STATE(_sChain->getNodeCount() > 1)
 
     try {
-        logThreadLocal_ = _sChain->getNode()->getLog();
-
         CHECK_STATE(sChain)
     } catch (ExitRequestedException &) {
         throw;
@@ -462,6 +460,8 @@ void BlockFinalizeDownloader::workerThreadFragmentDownloadLoop(
     setThreadName("BlckFinLoop", node->getConsensusEngine());
 
     node->waitOnGlobalClientStartBarrier();
+
+    logThreadLocal_ = node->getLog();
 
     auto fragmentToDownload = computeFirstFragmentToDowload(_dstIndex, mySchainIndex);
 

--- a/catchup/client/CatchupClientAgent.cpp
+++ b/catchup/client/CatchupClientAgent.cpp
@@ -49,7 +49,6 @@
 
 CatchupClientAgent::CatchupClientAgent( Schain& _sChain ) : Agent( _sChain, false ) {
     try {
-        logThreadLocal_ = _sChain.getNode()->getLog();
         this->sChain = &_sChain;
 
         if ( _sChain.getNodeCount() > 1 ||
@@ -301,6 +300,7 @@ void CatchupClientAgent::workerThreadItemSendLoop( CatchupClientAgent* _agent ) 
     CHECK_ARGUMENT( _agent )
 
     _agent->waitOnGlobalStartBarrier();
+    logThreadLocal_ = _agent->getNode()->getLog();
 
     // wait until the schain state is fully initialized
     // otherwise the chain can not accept catchup blocks

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -315,6 +315,36 @@ Schain::Schain(weak_ptr<Node> _node, schain_index _schainIndex, const schain_id 
     }
 }
 
+Schain::~Schain() {
+
+    auto n = node.lock();
+    if ( n ) {
+        // Signal all agent threads to exit their loops
+        n->exitRequested = true;
+
+        // Release barriers so threads blocked on waitOnGlobalStartBarrier() can wake up.
+        // This is a no-op if barriers were already released by startServers().
+        n->releaseGlobalServerBarrier();
+        n->releaseGlobalClientBarrier();
+    }
+
+    // MonitoringAgent requires explicit stop() because it uses a condition_variable
+    // for sleeping, not the global start barrier. The stop() signals the condition
+    // variable to wake up immediately rather than waiting for the sleep interval.
+    if ( monitoringAgent ) {
+        monitoringAgent->stop();
+        monitoringAgent->join();
+    }
+
+    // TimeoutAgent and StuckDetectionAgent will exit their loops once they detect
+    // exitRequested is true (checked after barrier wait and in their main loops).
+    if ( timeoutAgent ) {
+        timeoutAgent->join();
+    }
+    if ( stuckDetectionAgent ) {
+        stuckDetectionAgent->join();
+    }
+}
 
 // called from constructor so no locks needed
 void Schain::constructChildAgents() {

--- a/chains/Schain.h
+++ b/chains/Schain.h
@@ -306,6 +306,8 @@ public:
     Schain( weak_ptr< Node > _node, schain_index _schainIndex, const schain_id& _schainID,
         ConsensusExtFace* _extFace, string& _schainName );
 
+    ~Schain();
+    
     Schain();  // empty constructor is used for tests
 
     void startThreads();

--- a/chains/SchainGettersSetters.cpp
+++ b/chains/SchainGettersSetters.cpp
@@ -254,6 +254,8 @@ uint64_t Schain::getMaxExternalBlockProcessingTime() const {
 
 void Schain::joinMonitorAndTimeoutThreads() {
     CHECK_STATE( monitoringAgent );
+    // monitoring agent relies on condVar - needs to be stopped first
+    monitoringAgent->stop();
     monitoringAgent->join();
 
     if ( getNode()->isSyncOnlyNode() )

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -68,6 +68,13 @@ TEDecryptionDB::TEDecryptionDB(
     threadPoolExecutor = std::make_shared<folly::CPUThreadPoolExecutor>(NUM_BITE_VALIDATION_THREADS);
 }
 
+TEDecryptionDB::~TEDecryptionDB() {
+    if ( threadPoolExecutor ) {
+        threadPoolExecutor->stop();
+        threadPoolExecutor->join();
+    }
+}
+
 const string& TEDecryptionDB::getFormatVersion() {
     static const string version = "1.0";
     return version;

--- a/db/TEDecryptionDB.h
+++ b/db/TEDecryptionDB.h
@@ -34,6 +34,7 @@ class TEDecryptionDB : public CacheLevelDB {
 public:
     explicit TEDecryptionDB(
         Schain* _sChain, string& _dirName, string& _prefix, node_id _nodeId, uint64_t _maxDBSize );
+    ~TEDecryptionDB();
 
     void addDecryptionShares(const ptr<AESKeyDecryptionShareList> &_decryptionShareList);
 

--- a/monitoring/MonitoringAgent.cpp
+++ b/monitoring/MonitoringAgent.cpp
@@ -39,7 +39,6 @@
 
 MonitoringAgent::MonitoringAgent( Schain& _sChain ) : Agent( _sChain, false, true ) {
     try {
-        logThreadLocal_ = _sChain.getNode()->getLog();
         this->sChain = &_sChain;
 
         this->monitoringThreadPool = make_shared< MonitoringThreadPool >( 1, this );
@@ -91,14 +90,33 @@ void MonitoringAgent::monitor() {
 void MonitoringAgent::monitoringLoop( MonitoringAgent* _agent ) {
     CHECK_ARGUMENT( _agent );
 
+    logThreadLocal_ = _agent->getSchain()->getNode()->getLog();
     setThreadName( "MonitoringLoop", _agent->getSchain()->getNode()->getConsensusEngine() );
 
 
     CONS_LOG( info, "Monitoring agent started monitoring" );
 
     try {
-        while ( !_agent->getSchain()->getNode()->isExitRequested() ) {
-            usleep( _agent->getSchain()->getNode()->getMonitoringIntervalMs() * 1000 );
+        auto intervalMs = _agent->getSchain()->getNode()->getMonitoringIntervalMs();
+
+        while ( true ) {
+            {
+                std::unique_lock< std::mutex > lock( _agent->stopMutex );
+                _agent->stopCond.wait_for( lock, std::chrono::milliseconds( intervalMs ),
+                    [_agent] { return _agent->stopRequested.load(); } );
+
+                // In test, we set the condition variable to exit,
+                // thus we exit the loop from this condition
+                if ( _agent->stopRequested.load() ) {
+                    return;
+                }
+            }
+
+            // In production, we do not set the condition variable to exit.
+            // So it will wake up after the interval, and will just check if the node is exiting.
+            if ( _agent->getSchain()->getNode()->isExitRequested() ) {
+                return;
+            }
 
             try {
                 _agent->monitor();
@@ -108,7 +126,7 @@ void MonitoringAgent::monitoringLoop( MonitoringAgent* _agent ) {
             } catch ( exception& e ) {
                 SkaleException::logNested( e );
             }
-        };
+        }
     } catch ( FatalError& e ) {
         SkaleException::logNested( e );
         _agent->getSchain()->getNode()->initiateApplicationExitOnFatalConsensusError( e.what() );
@@ -126,6 +144,13 @@ void MonitoringAgent::unregisterMonitor( uint64_t _id ) {
     activeMonitors.erase( _id );
 }
 
+void MonitoringAgent::stop() {
+    {
+        std::lock_guard< std::mutex > lock( stopMutex );
+        stopRequested = true;
+    }
+    stopCond.notify_all();
+}
 
 void MonitoringAgent::join() {
     CHECK_STATE( monitoringThreadPool );

--- a/monitoring/MonitoringAgent.h
+++ b/monitoring/MonitoringAgent.h
@@ -33,12 +33,20 @@ class MonitoringAgent : public Agent {
 
     ptr< MonitoringThreadPool > monitoringThreadPool = nullptr;
 
+    // Thread lifecycle control
+    std::atomic< bool > stopRequested{ false };
+    std::mutex stopMutex;
+    std::condition_variable stopCond;
+
 public:
     explicit MonitoringAgent( Schain& _sChain );
 
     static void monitoringLoop( MonitoringAgent* agent );
 
     void monitor();
+
+    // Signals the monitoring thread to stop immediately
+    void stop();
 
     void join();
 

--- a/monitoring/StuckDetectionAgent.cpp
+++ b/monitoring/StuckDetectionAgent.cpp
@@ -51,7 +51,6 @@
 
 StuckDetectionAgent::StuckDetectionAgent( Schain& _sChain ) : Agent( _sChain, false, true ) {
     try {
-        logThreadLocal_ = _sChain.getNode()->getLog();
         this->sChain = &_sChain;
         // we only need one agent
         this->stuckDetectionThreadPool = make_shared< StuckDetectionThreadPool >( 1, this );
@@ -66,6 +65,7 @@ void StuckDetectionAgent::StuckDetectionLoop( StuckDetectionAgent* _agent ) {
     CHECK_ARGUMENT( _agent );
     setThreadName( "StuckDetectionLoop", _agent->getSchain()->getNode()->getConsensusEngine() );
     _agent->getSchain()->getSchain()->waitOnGlobalStartBarrier();
+    logThreadLocal_ = _agent->getSchain()->getNode()->getLog();
 
     CONS_LOG( info, "StuckDetection agent: started monitoring." );
 

--- a/monitoring/TimeoutAgent.cpp
+++ b/monitoring/TimeoutAgent.cpp
@@ -39,7 +39,6 @@
 
 TimeoutAgent::TimeoutAgent( Schain& _sChain ) : Agent( _sChain, false, true ) {
     try {
-        logThreadLocal_ = _sChain.getNode()->getLog();
         this->sChain = &_sChain;
         this->timeoutThreadPool = make_shared< TimeoutThreadPool >( 1, this );
         timeoutThreadPool->startService();
@@ -56,6 +55,9 @@ void TimeoutAgent::timeoutLoop( TimeoutAgent* _agent ) {
     setThreadName( "TimeoutLoop", _agent->getSchain()->getNode()->getConsensusEngine() );
 
     _agent->getSchain()->getSchain()->waitOnGlobalStartBarrier();
+    
+    logThreadLocal_ = _agent->getSchain()->getNode()->getLog();
+
     if ( _agent->getSchain()->getNode()->isExitRequested() )
         return;
 

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -216,6 +216,23 @@ void ConsensusEngine::setConfigLogLevel( string& _s ) {
     configLogger->set_level( configLogLevel );
 }
 
+void ConsensusEngine::ensureConfigLogger() {
+    LOCK( logMutex )
+
+    if ( configLogger ) {
+        return;
+    }
+
+    auto logger = spdlog::get( "config" );
+    if ( !logger ) {
+        logger = spdlog::stdout_color_mt( "config", spdlog::color_mode::never );
+        logger->flush_on( debug );
+    }
+
+    logger->set_pattern( "%+", spdlog::pattern_time_type::utc );
+    configLogger = logger;
+}
+
 void ConsensusEngine::logConfig(
     level_enum _severity, const string& _message, const string& _className ) {
     CHECK_STATE( configLogger != nullptr );

--- a/node/ConsensusEngine.h
+++ b/node/ConsensusEngine.h
@@ -151,6 +151,8 @@ public:
 
     static void log( level_enum _severity, const string& _message, const string& _className );
 
+    static void ensureConfigLogger();
+
     static void logConfig( level_enum _severity, const string& _message, const string& _className );
 
     ptr< spdlog::logger > createLogger( const string& loggerName );

--- a/node/Node.h
+++ b/node/Node.h
@@ -74,6 +74,8 @@ enum PricingStrategyEnum { ZERO, DOS_PROTECT };
 
 
 class Node {
+    friend class Schain;  // Allow Schain to access private barrier methods for teardown
+    
     ConsensusEngine* consensusEngine;
 
     vector< Agent* > agents;

--- a/oracle/OracleResultAssemblyAgent.cpp
+++ b/oracle/OracleResultAssemblyAgent.cpp
@@ -13,7 +13,6 @@
 OracleResultAssemblyAgent::OracleResultAssemblyAgent( Schain& _sChain )
     : Agent( _sChain, true ), oracleMessageThreadPool( new OracleMessageThreadPool( this ) ) {
     try {
-        logThreadLocal_ = _sChain.getNode()->getLog();
         oracleMessageThreadPool->startService();
     } catch ( ... ) {
         throw_with_nested( InvalidStateException( __FUNCTION__, __CLASS_NAME__ ) );

--- a/threads/GlobalThreadRegistry.cpp
+++ b/threads/GlobalThreadRegistry.cpp
@@ -36,7 +36,9 @@ void GlobalThreadRegistry::joinAll() {
         return;
 
     for ( auto&& thread : GlobalThreadRegistry::allThreads ) {
-        thread->join();
+        if ( thread->joinable() ) {
+            thread->join();
+        }
     }
 
     joined = true;


### PR DESCRIPTION
# Description
Currently, consensus has a few issues that make it impossible to build tests spinning up a new consensus engine for each test:

1. Dangling logger pointers: Agent constructors set logThreadLocal_ on the main test thread (`logThreadLocal` variable is thread local - i.e, local to whatever thread is calling the constructor), creating a shared pointer to SkaleLog that internally holds a raw ConsensusEngine*. When the test completes and ConsensusEngine is destroyed, logThreadLocal_ still exists with a dangling pointer. The next test calling CONS_LOG accesses logThreadLocal_->getEngine() → SIGSEGV (https://github.com/skalenetwork/skale-consensus/issues/967)

2. Monitoring agents are not built to work with fast unit tests. All agents get 'stuck' for 3 seconds before checking that exit was requested. If we have hundreds of tests spinning up and destroying consensus instances, testing time scales quickly.

3. Missing test logging infrastructure: For unit tests of consensus components without spinning up a consensus instance, CONS_LOG attempts to use a null `logThreadLocal_` → falls back to `configLogger`, which is also null, and fails the `CHECK_STATE`.

# Solution
1. Logger Lifecycle Fix
- Remove `logThreadLocal_` assignment from all agent constructors
- Add `logThreadLocal_ = node->getLog()` inside worker thread loop functions (after barrier waits)
- Worker threads now set their own thread-local logger, which is cleaned up when threads exit before engine destruction

2. Faster agent wake up
- Updated `MonitoringAgent` to use `cond_var` instead of `usleep`. Once `Schain` is destroyed, it will instantly wake up `MonitoringAgent` & will exit. No more 3 second wait for each test.

3. Added default config log before each test.
- We now call `ensureConfigLog` before tests. this way we guarantee there is always some logger set to ensure `CONS_LOG` calls won't fail.

4. Further Thread Teardown Improvements
- Schain::~Schain():
    - Call `monitoringAgent->stop()` to signal condition variable for immediate wake-up
    - Join all monitoring, timeout, and stuck detection threads
- `GloablThreadRegistry` - only join threads if joinable
- Added `TEDecryptionDB` destructor to release threadpool 


From the tests, only `MonitoringAgent` seems to delay unit tests. Thus `cond_var` logic was only applied to this agent. 
In the future, we may consider switching all agents to this logic for instant exit, instead of waiting for the 3 second sleep.