### PR TITLE
Bug/958 fix finalization

### DIFF
--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -595,7 +595,7 @@ ptr<ThresholdSignature> BlockFinalizeDownloader::getDaSig(uint64_t _timeStampS) 
             getBlockId(), getSchain()->getTotalSigners(), getSchain()->getRequiredSigners());
 }
 
-bool BlockFinalizeDownloader::isFragmentDownloadComplete() {
+bool BlockFinalizeDownloader::isFragmentDownloadComplete() const {
 #ifdef BITE
     if (!needFragmentData) {
         return true;

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -595,7 +595,7 @@ ptr<ThresholdSignature> BlockFinalizeDownloader::getDaSig(uint64_t _timeStampS) 
             getBlockId(), getSchain()->getTotalSigners(), getSchain()->getRequiredSigners());
 }
 
-bool BlockFinalizeDownloader::isFragmentDownloadComplete() const {
+bool BlockFinalizeDownloader::isFragmentDownloadComplete() {
 #ifdef BITE
     if (!needFragmentData) {
         return true;

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -611,7 +611,7 @@ bool BlockFinalizeDownloader::completeAndNeedToExitAllThreads() {
     }
 
     // check if we downloaded everything needed
-    if (fragmentList.isComplete() && daSig
+    if (fragmentList.isComplete() && !needDAProof()
 #ifdef BITE
         && getNode()->getTEDecryptionDB()->isEnoughForeignShares(blockId)
 #endif

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -595,6 +595,14 @@ ptr<ThresholdSignature> BlockFinalizeDownloader::getDaSig(uint64_t _timeStampS) 
             getBlockId(), getSchain()->getTotalSigners(), getSchain()->getRequiredSigners());
 }
 
+bool BlockFinalizeDownloader::isFragmentDownloadComplete() {
+#ifdef BITE
+    if (!needFragmentData) {
+        return true;
+    }
+#endif
+    return fragmentList.isComplete();
+}
 
 bool BlockFinalizeDownloader::completeAndNeedToExitAllThreads() {
     if (getSchain()->getNode()->isExitRequested()) {
@@ -611,7 +619,7 @@ bool BlockFinalizeDownloader::completeAndNeedToExitAllThreads() {
     }
 
     // check if we downloaded everything needed
-    if (fragmentList.isComplete() && !needDAProof()
+    if (isFragmentDownloadComplete() && !needDAProof()
 #ifdef BITE
         && getNode()->getTEDecryptionDB()->isEnoughForeignShares(blockId)
 #endif

--- a/blockfinalize/client/BlockFinalizeDownloader.h
+++ b/blockfinalize/client/BlockFinalizeDownloader.h
@@ -64,6 +64,8 @@ private:
     bool needFragmentData;
 #endif
 
+    bool isFragmentDownloadComplete();
+
 public:
 
     // this is used to signal to the outside world that

--- a/blockfinalize/client/BlockFinalizeDownloader.h
+++ b/blockfinalize/client/BlockFinalizeDownloader.h
@@ -64,7 +64,7 @@ private:
     bool needFragmentData;
 #endif
 
-    bool isFragmentDownloadComplete() const;
+    bool isFragmentDownloadComplete();
 
 public:
 

--- a/blockfinalize/client/BlockFinalizeDownloader.h
+++ b/blockfinalize/client/BlockFinalizeDownloader.h
@@ -64,7 +64,7 @@ private:
     bool needFragmentData;
 #endif
 
-    bool isFragmentDownloadComplete();
+    bool isFragmentDownloadComplete() const;
 
 public:
 


### PR DESCRIPTION
fixes #958

fixes block download finalization:
- use `needDAProof()` instead of `daSig` for completion check to cover cases when `daProof` wasn't intended to be downloaded
- use `isFragmentDownloadComplete()` instead of `fragment.isComplete()` for completion check to cover cases when `fragmentData` wasn't intended to be downloaded

The bugs occured when for a given block we only had to download `decryptionShares` and `daProof` or `decryptionShares` only:
-  If for a given block we only had to download `decryptionShares` and `daProof`, then we should prefer `isFragmentDownloadComplete()` against `fragment.isComplete()`. if catchup didn't happen before we download everything by ourselves, `daProof` (unlike `decryptionShares`) is not pushed in db right after it is downloaded and processed. this means that in `completeAndNeedToExitAllThreads` function `sChain->haveAllElementsToFinalizeBlock()` check returns `false` and final `fragmentList.isComplete() && daSig` check also returns `false`. however, all work is already completed and `BlockFinalization` thread is stuck forever. 
- If for a given block we don't need to download `daProof`, we should use `needDAProof()` instead of `daSig` for completion check, because `daSig` is never initialized even if daProof for given block exists in local db. 

verified on testnet. usually the bug appears in 24 hours after container restart - testnet works fine after 72 hours