### PR TITLE
Fix liveness issues for BITE txs

### DIFF
--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -370,7 +370,7 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
     CHECK_STATE(_proposal);
 
     ptr<TransactionCiphertextsMap> txsCiphertexts = _proposal->getTransactionCiphertexts();
-    auto failedTransactionRef = _proposal->getFailedTransactionsRef();
+    auto& failedTransactionRef = _proposal->getFailedTransactionsRef();
     auto publicDecryptionValues = make_shared<vector<string>>();
 
     std::vector< transaction_index > validGlobalIndices; // global indices of all valid txs

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -83,7 +83,7 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
     CHECK_STATE(_proposal);
 
     ptr<TransactionCiphertextsMap> txsCiphertexts = _proposal->getTransactionCiphertexts();
-    auto failedTransactionRef = _proposal->getFailedTransactionsRef();
+    auto& failedTransactionRef = _proposal->getFailedTransactionsRef();
 
     BiteEngine::CiphertextValidationResult validationResult = biteEngine.validateCiphertexts(*txsCiphertexts);
 

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -544,6 +544,7 @@ bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
 
             CHECK_STATE(proposal->getTransactionCiphertexts());
 
+            auto biteManager = getSchain()->getBiteManager();
             biteManager->computeAndValidateSGXAESKeyBatch(proposal);
 
             CHECK_STATE2(proposal->getFailedTransactionsRef().empty(),

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -524,12 +524,10 @@ bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
 #ifdef BITE
             CHECK_STATE(getNode()->getTEDecryptionDB()->isEnoughForeignShares(blockId));
 #endif
+            // Already parses all BITE txs
             proposal = BlockProposal::makeFromNetworkSerialized(
                 fragmentList.serialize(), getSchain()->getCryptoManager());
-#ifdef BITE
-            auto biteManager = getSchain()->getBiteManager();
-            biteManager->parseBITETransactions(proposal);
-#endif
+
             CHECK_STATE(proposal)
             CHECK_STATE(proposal->getProposerIndex() == ( uint64_t ) proposerIndex);
             {

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -669,7 +669,7 @@ void Schain::proposeNextBlock(bool _isCalledAfterCatchup) {
                 CONS_LOG(err, "Critical error - invalid BITE transactions");
                 CONS_LOG(err, "Rejecting proposal and triggering fallback consensus for default block");
                 try {
-                    blockProposalReceiptTimeoutArrived(_proposedBlockID);
+                    timeoutAgent->forceEarlyTimeout();
                 } catch (ExitRequestedException &) {
                     throw;
                 } catch (...) {
@@ -683,7 +683,7 @@ void Schain::proposeNextBlock(bool _isCalledAfterCatchup) {
                 CONS_LOG(err, "Critical error - could not decrypt BITE transactions");
                 CONS_LOG(err, "Rejecting proposal and triggering fallback consensus for default block");
                 try {
-                    blockProposalReceiptTimeoutArrived(_proposedBlockID);
+                    timeoutAgent->forceEarlyTimeout();
                 } catch (ExitRequestedException &) {
                     throw;
                 } catch (...) {

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -637,14 +637,28 @@ void Schain::proposeNextBlock(bool _isCalledAfterCatchup) {
 
             if (!myProposal->getFailedTransactionsRef().empty()) {
                 CONS_LOG(err, "Critical error - invalid BITE transactions");
-                CONS_LOG(err, "Proposing default block instead");
+                CONS_LOG(err, "Rejecting proposal and triggering fallback consensus for default block");
+                try {
+                    blockProposalReceiptTimeoutArrived(_proposedBlockID);
+                } catch (ExitRequestedException &) {
+                    throw;
+                } catch (...) {
+                    CONS_LOG(err, "Could not trigger fallback consensus for default block");
+                }
                 return;
             }
 
             getBiteManager()->callSGXToCreateMyDecryptionSharesForProposalTransactions(myProposal);
             if (!myProposal->getFailedTransactionsRef().empty()) {
                 CONS_LOG(err, "Critical error - could not decrypt BITE transactions");
-                CONS_LOG(err, "Proposing default block instead");
+                CONS_LOG(err, "Rejecting proposal and triggering fallback consensus for default block");
+                try {
+                    blockProposalReceiptTimeoutArrived(_proposedBlockID);
+                } catch (ExitRequestedException &) {
+                    throw;
+                } catch (...) {
+                    CONS_LOG(err, "Could not trigger fallback consensus for default block");
+                }
                 return;
             }
         }

--- a/monitoring/TimeoutAgent.cpp
+++ b/monitoring/TimeoutAgent.cpp
@@ -49,22 +49,21 @@ TimeoutAgent::TimeoutAgent( Schain& _sChain ) : Agent( _sChain, false, true ) {
 }
 
 
-void TimeoutAgent::timeoutLoop( TimeoutAgent* _agent ) {
-    CHECK_ARGUMENT( _agent );
+void TimeoutAgent::timeoutLoop() {
 
-    setThreadName( "TimeoutLoop", _agent->getSchain()->getNode()->getConsensusEngine() );
+    setThreadName( "TimeoutLoop", getSchain()->getNode()->getConsensusEngine() );
 
-    _agent->getSchain()->getSchain()->waitOnGlobalStartBarrier();
+    getSchain()->getSchain()->waitOnGlobalStartBarrier();
     
-    logThreadLocal_ = _agent->getSchain()->getNode()->getLog();
+    logThreadLocal_ = getSchain()->getNode()->getLog();
 
-    if ( _agent->getSchain()->getNode()->isExitRequested() )
+    if ( getSchain()->getNode()->isExitRequested() )
         return;
 
     CONS_LOG( info, "Timeout agent started monitoring" );
 
     uint64_t blockProcessingStart =
-        max( _agent->getSchain()->getLastCommitTimeMs(), _agent->getSchain()->getStartTimeMs() );
+        max( getSchain()->getLastCommitTimeMs(), getSchain()->getStartTimeMs() );
 
     if ( blockProcessingStart == 0 )
         blockProcessingStart = Time::getCurrentTimeMs();
@@ -74,21 +73,31 @@ void TimeoutAgent::timeoutLoop( TimeoutAgent* _agent ) {
     bool proposalReceiptTimedOut = false;
 
     try {
-        while ( !_agent->getSchain()->getNode()->isExitRequested() ) {
-            usleep( _agent->getSchain()->getNode()->getMonitoringIntervalMs() * 1000 );
+        while ( !getSchain()->getNode()->isExitRequested() ) {
+            usleep( getSchain()->getNode()->getMonitoringIntervalMs() * 1000 );
 
             try {
-                auto currentBlockId = _agent->getSchain()->getLastCommittedBlockID() + 1;
+                auto currentBlockId = getSchain()->getLastCommittedBlockID() + 1;
                 auto currentTime = Time::getCurrentTimeMs();
 
-                auto timeZero = max( _agent->getSchain()->getLastCommitTimeMs(),
-                    _agent->getSchain()->getStartTimeMs() );
-
+                auto timeZero = max( getSchain()->getLastCommitTimeMs(),
+                    getSchain()->getStartTimeMs() );
                 blockProcessingStart = timeZero;
 
                 lastRebroadCastTime = max( lastRebroadCastTime, timeZero );
 
-                if ( _agent->getSchain()->getNodeCount() > 2 ) {
+                // If early timeout is forced, trigger timeout event immediately without waiting 
+                // for the normal timeout.
+                if ( earlyTimeoutForced ) {
+                    try {
+                        getSchain()->blockProposalReceiptTimeoutArrived(
+                            currentBlockId );
+                        earlyTimeoutForced = false;
+                    } catch ( ... ) {
+                    }
+                }
+
+                if ( getSchain()->getNodeCount() > 2 ) {
                     if ( currentTime - blockProcessingStart <= BLOCK_PROPOSAL_RECEIVE_TIMEOUT_MS )
                         proposalReceiptTimedOut = false;
 
@@ -99,7 +108,7 @@ void TimeoutAgent::timeoutLoop( TimeoutAgent* _agent ) {
 #endif
                          currentTime - blockProcessingStart > BLOCK_PROPOSAL_RECEIVE_TIMEOUT_MS ) {
                         try {
-                            _agent->getSchain()->blockProposalReceiptTimeoutArrived(
+                            getSchain()->blockProposalReceiptTimeoutArrived(
                                 currentBlockId );
                             proposalReceiptTimedOut = true;
                         } catch ( ... ) {
@@ -108,7 +117,7 @@ void TimeoutAgent::timeoutLoop( TimeoutAgent* _agent ) {
 
                     if ( currentBlockId > 2 &&
                          currentTime - lastRebroadCastTime > REBROADCAST_TIMEOUT_MS ) {
-                        _agent->getSchain()->rebroadcastAllMessagesForCurrentBlock();
+                        getSchain()->rebroadcastAllMessagesForCurrentBlock();
                         lastRebroadCastTime = currentTime;
                     }
                 }
@@ -120,8 +129,12 @@ void TimeoutAgent::timeoutLoop( TimeoutAgent* _agent ) {
         };
     } catch ( FatalError& e ) {
         SkaleException::logNested( e );
-        _agent->getSchain()->getNode()->initiateApplicationExitOnFatalConsensusError( e.what() );
+        getSchain()->getNode()->initiateApplicationExitOnFatalConsensusError( e.what() );
     }
+}
+
+void TimeoutAgent::forceEarlyTimeout() {
+    earlyTimeoutForced = true;
 }
 
 void TimeoutAgent::join() {

--- a/monitoring/TimeoutAgent.cpp
+++ b/monitoring/TimeoutAgent.cpp
@@ -51,8 +51,8 @@ TimeoutAgent::TimeoutAgent( Schain& _sChain ) : Agent( _sChain, false, true ) {
 
 void TimeoutAgent::timeoutLoop() {
 
-    logThreadLocal_ = _agent->getSchain()->getNode()->getLog();
-    setThreadName( "TimeoutLoop", _agent->getSchain()->getNode()->getConsensusEngine() );
+    logThreadLocal_ = getSchain()->getNode()->getLog();
+    setThreadName( "TimeoutLoop", getSchain()->getNode()->getConsensusEngine() );
 
     getSchain()->getSchain()->waitOnGlobalStartBarrier();
 

--- a/monitoring/TimeoutAgent.h
+++ b/monitoring/TimeoutAgent.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "atomic"
+
 
 class Schain;
 
@@ -32,10 +34,20 @@ class LivelinessMonitor;
 class TimeoutAgent : public Agent {
     ptr< TimeoutThreadPool > timeoutThreadPool = nullptr;
 
+    // Indicates whether the proposal receipt has timed out
+    // If true, the agent will trigger timeout event in Schain to start the next round
+    std::atomic_bool earlyTimeoutForced = false;
+
 public:
     explicit TimeoutAgent( Schain& _sChain );
 
-    static void timeoutLoop( TimeoutAgent* agent );
+    void timeoutLoop();
+
+    /**
+     * Sets prposalReceiptTimedOut immediately to true to trigger timeout event 
+     * in Schain to start the next round.
+     */
+    void forceEarlyTimeout();
 
     void join();
 };

--- a/monitoring/TimeoutThreadPool.cpp
+++ b/monitoring/TimeoutThreadPool.cpp
@@ -35,5 +35,5 @@ TimeoutThreadPool::TimeoutThreadPool( num_threads _numThreads, Agent* _agent )
 void TimeoutThreadPool::createThread( uint64_t /*number*/ ) {
     auto a = ( TimeoutAgent* ) agent;
     LOCK( threadPoolLock );
-    this->threadpool.push_back( make_shared< thread >( TimeoutAgent::timeoutLoop, a ) );
+    this->threadpool.push_back( make_shared< thread >( [a] { a->timeoutLoop(); } ) );
 }

--- a/node/ConsensusTypes.h
+++ b/node/ConsensusTypes.h
@@ -47,9 +47,9 @@ struct DecryptedTransactions {
         regularTxsMap = _regularTxsMap;
     }
 
-    DecryptedTransactions()
+    DecryptedTransactions() :
 #ifdef BITE2
-        : catTxsMap(std::make_shared<DecryptedCATxsMap>()),
+        catTxsMap(std::make_shared<DecryptedCATxsMap>()),
 #endif
           regularTxsMap(std::make_shared<DecryptedRegularTxsMap>()) {}
 };

--- a/node/ConsensusTypes.h
+++ b/node/ConsensusTypes.h
@@ -47,7 +47,11 @@ struct DecryptedTransactions {
         regularTxsMap = _regularTxsMap;
     }
 
-    DecryptedTransactions() = default;
+    DecryptedTransactions()
+#ifdef BITE2
+        : catTxsMap(std::make_shared<DecryptedCATxsMap>()),
+#endif
+          regularTxsMap(std::make_shared<DecryptedRegularTxsMap>()) {}
 };
 
 


### PR DESCRIPTION
# Description

This PR addresses 2 main issues:

---

## Issue 1 #990 

Consensus halts when invalid BITE txs are present.

**Issues**
1. Does not update proposal's invalid tx queue (alters a copy of the map)
2. Later it tries to get decryptShares even though we haven't set them - fails `CHECK_STATE`:

```bash
2026-02-06T11:58:12.233947342Z  [2026-02-06 11:58:12.233] [config] [error] AES key encryption validation failed for ciphertext 0 of transaction 0
2026-02-06T11:58:12.233950177Z  [2026-02-06 11:58:12.233] [config] [error] AES key encryption validation failed for ciphertext 1 of transaction 0
2026-02-06T11:58:12.233952331Z  [2026-02-06 11:58:12.233] [config] [error] AES key encryption validation failed for ciphertext 2 of transaction 0
2026-02-06T11:58:12.233954455Z  [2026-02-06 11:58:12.233] [config] [error] AES key encryption validation failed for ciphertext 3 of transaction 0
2026-02-06T11:58:12.233956869Z  [2026-02-06 11:58:12.233] [config] [error] AES key encryption validation failed for ciphertext 4 of transaction 0
2026-02-06T11:58:12.233958984Z  [2026-02-06 11:58:12.233] [config] [error] !Exception: Schain:blockCommitArrived
2026-02-06T11:58:12.233960987Z  [2026-02-06 11:58:12.233] [config] [error]  !Caused by: Schain:proposeNextBlock
2026-02-06T11:58:12.233963101Z  [2026-02-06 11:58:12.233] [config] [error]   !Caused by: getDecryptionSharesFromAESKeys:State check failed::sgxAESKeyBatch /home/s5/actions-runner-1/_work/skaled/skaled/libconsensus/bite/BiteManager.cpp: 312
2026-02-06T11:58:12.233965315Z  [2026-02-06 11:58:12.233] [config] [critical] Could not finalizeDecidedAndSignedBlock. Hopefully catchup will work.
```

3. We exit consensus flow early in case of failedTxs in `proposeNextBlock`:

```cpp
if (!isProposalCameFromDb) {
    getSchain()->getBiteManager()->computeAndValidateSGXAESKeyBatch(myProposal);

    if (!myProposal->getFailedTransactionsRef().empty()) {
        CONS_LOG(err, "Critical error - invalid BITE transactions");
        CONS_LOG(err, "Proposing default block instead"); // <- no default block is produced
        return;
    }

    getBiteManager()->callSGXToCreateMyDecryptionSharesForProposalTransactions(myProposal);
    if (!myProposal->getFailedTransactionsRef().empty()) {
        CONS_LOG(err, "Critical error - could not decrypt BITE transactions");
        CONS_LOG(err, "Proposing default block instead"); // <- no default block is produced
        return;
    }
}
CHECK_STATE(myProposal->getMyDecryptionShares());   
 ```
 
 
 ## Solution
 
 1. Replace `auto` type with `auto&` to use reference of failedTxs map instead of copy. This also gets rid of issue 2.
 2. Force consensus to continue in presence of invalid txs by calling `agent->forceEarlyTimeout()`
 3. Add default constructors for `DecryptedTransactions` in case of no decryptions
 
 
 ## Tests
 
 - Tested running skaled with new consensus version, sending invalid CTX through bite-ts. consensus now keeps producing blocks after invalid CTX, but skaled fails since it expected the CTX (issue out of consensus scope):
 
 ```
 [2026-02-07 13:19:12.636] [config] [info] CWT:85:TLWT:1239:SBPT:47:BITE_DECRYPTED_TXS:0:CAT_DECRYPTED_TXS:0
2026-02-07 13:19:12.638136   createBlock ID = #572
2026-02-07 13:19:12.638195   Got block with 0 CTXs
2026-02-07 13:19:12.648028   Self-destructing#00000000…
2026-02-07 13:19:12.648840   Block sealed #572 (#caa7001d…)
2026-02-07 13:19:12.648921   Block stats:BN:571:BTS:1770470351:TXS:4:HDRS:12:LOGS:42:SENGS:1:TXRS:38:BLCKS:3:ACCS:22:BQS:1:BDS:89:TSS:0:UTX:0:VTX:0:CMM:78495:KDS:15
2026-02-07 13:19:12.649965   noteChanged: {chain}
2026-02-07 13:19:12.650113   SWT:12:BFT:1339:TQBYTES:CTQ:0:FTQ:0:TQSIZE:CTQ:0:FTQ:0
2026-02-07 13:19:12.650144   Successfully imported 1 of 1 transactions
[2026-02-07 13:19:12.791] [config] [error] AES key encryption validation failed for ciphertext 0 of transaction 0
[2026-02-07 13:19:12.791] [config] [error] AES key encryption validation failed for ciphertext 1 of transaction 0
[2026-02-07 13:19:12.791] [config] [error] AES key encryption validation failed for ciphertext 2 of transaction 0
[2026-02-07 13:19:12.791] [config] [error] AES key encryption validation failed for ciphertext 3 of transaction 0
[2026-02-07 13:19:12.791] [config] [error] AES key encryption validation failed for ciphertext 4 of transaction 0
[2026-02-07 13:19:12.791] [config] [error] Critical error - invalid BITE transactions
[2026-02-07 13:19:12.791] [config] [error] Rejecting proposal and triggering fallback consensus for default block
[2026-02-07 13:19:12.793] [config] [info] CONSENSUS_STARTED:PROPOSING: 0
[2026-02-07 13:19:12.821] [1:consensus] [info] 572:CONSENSUS_COMPLETED:STATS::19:15:6:7:3:2:0:0:1:0:0:0:0:0:0:0
[2026-02-07 13:19:12.821] [1:consensus] [info] 572:BLOCK_DECIDED:PROPOSER:0:BID:573:STATS:|DEFAULT_BLOCK| Now signing block ...
[2026-02-07 13:19:12.835] [config] [info] BLOCK_COMMITED: PRPSR:0:BID: 573:ROOT:0:HASH:aa018fb4:BLOCK_TXS:0:DMSG:0:TPRPS:6:MPRPS:1:RPRPS:1:TXS:14:TXLS:5:MGS:11:INSTS:13:BPS:0:HDRS:1:SOCK:0:FDS:417:PRT:143:BTA:1290:BSA:0:TPS:0:LWT:0:LRT:0:LWC:786:LRC:982:KNWN:14:CONS:0:DSDS:0:SET:0:SBT:0:STET:0:SEC:53:SBC:65:ZSC:1:EPT:14:STAMP:1770470352.552
[2026-02-07 13:19:12.838] [config] [info] CWT:75:TLWT:111:SBPT:34:BITE_DECRYPTED_TXS:0:CAT_DECRYPTED_TXS:0
2026-02-07 13:19:12.840080   createBlock ID = #573
2026-02-07 13:19:12.840142   Got block with 0 CTXs
2026-02-07 13:19:12.840235   Expected 1 CTX, but received 0.
 Exiting with code 200, repair will be needed.

Internal exit initiated. Signal -1. Unknown signal type.


SELF-KILL: Will sleep 270 seconds before force exit...THREADS timer started2026-02-07 13:19:12.840987   Block sealed #573 (#657b94c2…)
2026-02-07 13:19:12.841064   Block stats:BN:572:BTS:1770470352:TXS:0:HDRS:12:LOGS:42:SENGS:1:TXRS:37:BLCKS:3:ACCS:22:BQS:1:BDS:89:TSS:0:UTX:0:VTX:0:CMM:78495:KDS:15
2026-02-07 13:19:12.842095   noteChanged: {chain}
2026-02-07 13:19:12.842234   SWT:2:BFT:192:TQBYTES:CTQ:0:FTQ:0:TQSIZE:CTQ:0:FTQ:0
2026-02-07 13:19:12.842264   Successfully imported 0 of 0 transactions
0.000135497 THREADS 60: +main +dPool0 +blockVerifier0 +main +MonitoringLoop +TimeoutLoop +StuckDetectionL +orclAssemblyLoo +BlockPopClnt +main +main +Client +ZMQbg/Reaper +ZMQbg/IO/0 +ZmqBroadcaster +broadcastFunc +CtchpSrvAg0 +CtchpSrvAg1 +CtchpSrvAg2 +CtchpSrvAg3 +CtchpSrvAg4 +CtchpSrvAg5 +CtchpSrvAg6 +CtchpSrvAg7 +CatchupServer +BlkPropSrvAg0 +BlockPropSrv +NtwkRdLoop +DeferMsgLoop +main +msgThreadProcLo +HTTPSrvExec0 +HTTPSrvExec1 +HTTPSrvExec2 +HTTPSrvExec3 +HTTPSrvExec4 +HTTPSrvExec5 +HTTPSrvExec6 +HTTPSrvExec7 +IOThreadPool0 +ZMQbg/Reaper +ZMQbg/IO/0 +CPUThreadPool0 +ain/WS-listener +in/WSS-listener +-0x5baaf187eef0 +HTTPSrvExec0 +HTTPSrvExec1 +HTTPSrvExec2 +HTTPSrvExec3 +HTTPSrvExec4 +HTTPSrvExec5 +HTTPSrvExec6 +HTTPSrvExec7 +HTTPSrvExec8 +HTTPSrvExec9 +IOThreadPool0 +CPUThreadPool0 +CPUThreadPool0 +CPUThreadPool02026-02-07 13:19:12.849160   Skaled status: setExitState: StartAgain to true
2026-02-07 13:19:12.849549   Skaled status: setExitState: StartFromSnapshot to true
2026-02-07 13:19:12.849750   Skaled status: setExitState: ClearDataDir to true
0.103045 THREADS 48: --0x5baaf187eef0 -HTTPSrvExec8 -HTTPSrvExec9[2026-02-07 13:19:14.225] [config] [info] CONSENSUS_STARTED:PROPOSING: 1
[2026-02-07 13:19:14.228] [1:consensus] [info] 573:CONSENSUS_COMPLETED:STATS::20:15:6:7:3:2:0:0:1:0:0:0:0:0:0:0
[2026-02-07 13:19:14.229] [1:consensus] [info] 573:BLOCK_DECIDED:PROPOSER:1:BID:574:STATS:|1|D1R0P0L0|| Now signing block ...
[2026-02-07 13:19:14.241] [config] [info] BLOCK_COMMITED: PRPSR:1:BID: 574:ROOT:46320509353513273106582423493727320152202237096314791991810382902766530930981:HASH:5c08c9d4:BLOCK_TXS:0:DMSG:0:TPRPS:5:MPRPS:1:RPRPS:0:TXS:14:TXLS:4:MGS:11:INSTS:13:BPS:0:HDRS:1:SOCK:0:FDS:335:PRT:1383:BTA:1269:BSA:0:TPS:0:LWT:0:LRT:0:LWC:798:LRC:997:KNWN:14:CONS:0:DSDS:0:SET:0:SBT:0:STET:0:SEC:54:SBC:66:ZSC:1:EPT:4:STAMP:1770470354.179
[2026-02-07 13:19:14.244] [config] [info] CWT:65:TLWT:1336:SBPT:37:BITE_DECRYPTED_TXS:0:CAT_DECRYPTED_TXS:0
2026-02-07 13:19:14.245591   createBlock ID = #574
2026-02-07 13:19:14.245651   Got block with 0 CTXs
2026-02-07 13:19:14.246365   Block sealed #574 (#cae5731a…)
2026-02-07 13:19:14.246439   Block stats:BN:573:BTS:1770470352:TXS:0:HDRS:12:LOGS:42:SENGS:1:TXRS:37:BLCKS:3:ACCS:22:BQS:1:BDS:90:TSS:0:UTX:0:VTX:0:CMM:78495:KDS:15
2026-02-07 13:19:14.247386   noteChanged: {chain}
2026-02-07 13:19:14.247550   SWT:1:BFT:1405:TQBYTES:CTQ:0:FTQ:0:TQSIZE:CTQ:0:FTQ:0
2026-02-07 13:19:14.247581   Successfully imported 0 of 0 transactions
[2026-02-07 13:19:15.633] [config] [info] CONSENSUS_STARTED:PROPOSING: 1
[2026-02-07 13:19:15.657] [1:consensus] [info] 574:CONSENSUS_COMPLETED:STATS::20:15:6:7:4:2:0:0:1:0:0:0:0:0:0:0
[2026-02-07 13:19:15.657] [1:consensus] [info] 574:BLOCK_DECIDED:PROPOSER:1:BID:575:STATS:|1|D1R4P0L0|| Now signing block ...
[2026-02-07 13:19:15.670] [config] [info] BLOCK_COMMITED: PRPSR:1:BID: 575:ROOT:46320509353513273106582423493727320152202237096314791991810382902766530930981:HASH:d74889be:BLOCK_TXS:0:DMSG:0:TPRPS:5:MPRPS:1:RPRPS:0:TXS:14:TXLS:4:MGS:11:INSTS:13:BPS:0:HDRS:1:SOCK:0:FDS:335:PRT:1386:BTA:1271:BSA:0:TPS:0:LWT:0:LRT:0:LWC:818:LRC:1020:KNWN:14:CONS:0:DSDS:0:SET:0:SBT:0:STET:0:SEC:55:SBC:68:ZSC:1:EPT:3:STAMP:1770470355.586
[2026-02-07 13:19:15.673] [config] [info] CWT:87:TLWT:1338:SBPT:44:BITE_DECRYPTED_TXS:0:CAT_DECRYPTED_TXS:0
2026-02-07 13:19:15.674859   createBlock ID = #575
2026-02-07 13:19:15.674915   Got block with 0 CTXs
2026-02-07 13:19:15.675640   Block sealed #575 (#013efe27…)
2026-02-07 13:19:15.675714   Block stats:BN:574:BTS:1770470354:TXS:0:HDRS:12:LOGS:42:SENGS:1:TXRS:37:BLCKS:3:ACCS:22:BQS:1:BDS:91:TSS:0:UTX:0:VTX:0:CMM:83208:KDS:15
2026-02-07 13:19:15.676669   noteChanged: {chain}
2026-02-07 13:19:15.676808   SWT:1:BFT:1429:TQBYTES:CTQ:0:FTQ:0:TQSIZE:CTQ:0:FTQ:0
2026-02-07 13:19:15.676838   Successfully imported 0 of 0 transactions
[2026-02-07 13:19:17.064] [config] [info] CONSENSUS_STARTED:PROPOSING: 1
[2026-02-07 13:19:17.067] [1:consensus] [info] 575:CONSENSUS_COMPLETED:STATS::21:15:6:7:4:2:0:0:1:0:0:0:0:0:0:0
[2026-02-07 13:19:17.067] [1:consensus] [info] 575:BLOCK_DECIDED:PROPOSER:1:BID:576:STATS:|1|D1R0P0L0|| Now signing block ...
[2026-02-07 13:19:17.080] [config] [info] BLOCK_COMMITED: PRPSR:1:BID: 576:ROOT:46320509353513273106582423493727320152202237096314791991810382902766530930981:HASH:e7bea5b5:BLOCK_TXS:0:DMSG:0:TPRPS:5:MPRPS:1:RPRPS:0:TXS:14:TXLS:4:MGS:11:INSTS:13:BPS:0:HDRS:1:SOCK:0:FDS:335:PRT:1388:BTA:1274:BSA:0:TPS:0:LWT:0:LRT:0:LWC:830:LRC:1035:KNWN:14:CONS:0:DSDS:0:SET:0:SBT:0:STET:0:SEC:56:SBC:69:ZSC:1:EPT:3:STAMP:1770470357.15
[2026-02-07 13:19:17.083] [config] [info] CWT:68:TLWT:1337:SBPT:39:BITE_DECRYPTED_TXS:0:CAT_DECRYPTED_TXS:0
2026-02-07 13:19:17.084765   createBlock ID = #576
2026-02-07 13:19:17.084826   Got block with 0 CTXs
2026-02-07 13:19:17.085559   Block sealed #576 (#f95deaec…)
2026-02-07 13:19:17.085643   Block stats:BN:575:BTS:1770470355:TXS:0:HDRS:12:LOGS:42:SENGS:1:TXRS:37:BLCKS:3:ACCS:22:BQS:1:BDS:92:TSS:0:UTX:0:VTX:0:CMM:83208:KDS:15
2026-02-07 13:19:17.086665   noteChanged: {chain}
2026-02-07 13:19:17.086811   SWT:2:BFT:1410:TQBYTES:CTQ:0:FTQ:0:TQSIZE:CTQ:0:FTQ:0
2026-02-07 13:19:17.086840   Successfully imported 0 of 0 transactions
[2026-02-07 13:19:18.469] [config] [info] CONSENSUS_STARTED:PROPOSING: 1
[2026-02-07 13:19:18.473] [1:consensus] [info] 576:CONSENSUS_COMPLETED:STATS::22:15:6:7:4:2:0:0:1:0:0:0:0:0:0:0
[2026-02-07 13:19:18.473] [1:consensus] [info] 576:BLOCK_DECIDED:PROPOSER:1:BID:577:STATS:|1|D1R0P0L0|| Now signing block ...
[2026-02-07 13:19:18.490] [config] [info] BLOCK_COMMITED: PRPSR:1:BID: 577:ROOT:46320509353513273106582423493727320152202237096314791991810382902766530930981:HASH:8410abe6:BLOCK_TXS:0:DMSG:0:TPRPS:5:MPRPS:1:RPRPS:0:TXS:14:TXLS:4:MGS:11:INSTS:13:BPS:0:HDRS:1:SOCK:0:FDS:335:PRT:1383:BTA:1277:BSA:0:TPS:0:LWT:0:LRT:0:LWC:842:LRC:1050:KNWN:14:CONS:0:DSDS:0:SET:0:SBT:0:STET:0:SEC:57:SBC:70:ZSC:1:EPT:3:STAMP:1770470358.423
[2026-02-07 13:19:18.492] [config] [info] CWT:69:TLWT:1335:SBPT:39:BITE_DECRYPTED_TXS:0:CAT_DECRYPTED_TXS:0
 
 ```
 
 
 ---
 
 ## Issue 2 #992
 
 - consensus tries to set ciphertexts in block proposal twice when downloading block, but we have explicit `CHECK` that disallows double setting (currently failing):
 
 ```
 [2026-02-09 13:21:16.806] [2:main] [error] 26878:!Exception: setTransactionCiphertexts:State check failed::std::atomic_exchange(&transactionCiphertexts, _EncryptedAESKeyMap) == nullptr /home/s5/actions-runner-2/_work/skaled/skaled/libconsensus/datastructures/BlockProposal.h: 251
[2026-02-09 13:21:16.806] [2:main] [error] 26878:!Exception: BlockFinalizeDownloader:bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions()
[2026-02-09 13:21:16.806] [2:main] [error] 26878: !Caused by: setTransactionCiphertexts:State check failed::std::atomic_exchange(&transactionCiphertexts, _EncryptedAESKeyMap) == nullptr /home/s5/actions-runner-2/_work/skaled/skaled/libconsensus/datastructures/BlockProposal.h: 251
[2026-02-09 13:21:16.806] [2:main] [critical] 26878:Could not finalizeDecidedAndSignedBlock. Hopefully catchup will work.
```
 
 Code:
 ```cpp
         if (!proposal && fragmentList.isComplete()) {
#ifdef BITE
            CHECK_STATE(getNode()->getTEDecryptionDB()->isEnoughForeignShares(blockId));
#endif
            proposal = BlockProposal::makeFromNetworkSerialized(
                fragmentList.serialize(), getSchain()->getCryptoManager()); // 1st parsing & setting done by this call
#ifdef BITE
            auto biteManager = getSchain()->getBiteManager();
            biteManager->parseBITETransactions(proposal); // second done here, removed
#endif
            CHECK_STATE(proposal)
            CHECK_STATE(proposal->getProposerIndex() == ( uint64_t ) proposerIndex);
            {
            
```

## Solution

- Removal of `#ifdef` macro section.
 
 
 
 
 