### PR TITLE
Rename CAT variables & methods to CTX

### DIFF
--- a/bite/BiteCodec.cpp
+++ b/bite/BiteCodec.cpp
@@ -21,7 +21,7 @@ ptr<BiteCiphertext> BiteCodec::tryParseEncryptedRegularTxFields(
 }
 
 #ifdef BITE2
-std::shared_ptr<std::vector<std::shared_ptr<BiteCiphertext>>> BiteCodec::tryParseEncryptedCATArgs(
+std::shared_ptr<std::vector<std::shared_ptr<BiteCiphertext>>> BiteCodec::tryParseEncryptedCTXArgs(
         const std::vector<uint8_t>& _dataField, epoch_id _currentEpochId) {
     // compare first 4 bytes to BITE2 expected function selector
     if (_dataField.size() < BITE2_FUNCTION_SELECTOR_SIZE_BYTES ||
@@ -45,14 +45,14 @@ std::shared_ptr<std::vector<std::shared_ptr<BiteCiphertext>>> BiteCodec::tryPars
     RLPItem encryptedArgsRLP = rlpItem[0];
     CHECK_STATE(encryptedArgsRLP.isList());
 
-    auto encryptedCATArgs = std::make_shared<std::vector<std::shared_ptr<BiteCiphertext>>>();
+    auto encryptedCTXArgs = std::make_shared<std::vector<std::shared_ptr<BiteCiphertext>>>();
 
-    encryptedCATArgs->reserve(encryptedArgsRLP.size());
+    encryptedCTXArgs->reserve(encryptedArgsRLP.size());
     for (size_t i = 0; i < encryptedArgsRLP.size(); i++) {
         auto argData = std::make_shared<std::vector<uint8_t>>(encryptedArgsRLP[i].asBytes());
-        encryptedCATArgs->emplace_back( std::make_shared<BiteCiphertext>(argData, _currentEpochId) );
+        encryptedCTXArgs->emplace_back( std::make_shared<BiteCiphertext>(argData, _currentEpochId) );
     }
-    return encryptedCATArgs;
+    return encryptedCTXArgs;
 }
 #endif
 
@@ -63,9 +63,9 @@ std::shared_ptr<std::vector<std::shared_ptr<BiteCiphertext>>> BiteCodec::tryPars
 // ==================== BiteCiphertext building for Transaction fields ==================== //
 
 
-// Encode CAT arguments given serialized encrypted args + plaintext args
+// Encode CTX arguments given serialized encrypted args + plaintext args
 #ifdef BITE2
-std::vector<uint8_t> BiteCodec::encodeCATData(
+std::vector<uint8_t> BiteCodec::encodeCTXData(
     const std::vector<std::vector<uint8_t>>& encryptedSerializedArgs,
     const std::vector<std::vector<uint8_t>>& plainArgs
 ) {

--- a/bite/BiteCodec.h
+++ b/bite/BiteCodec.h
@@ -20,7 +20,7 @@ struct BiteCodec {
         std::vector<uint8_t>& _to, ptr<std::vector<uint8_t>> _data, epoch_id _currentEpochId);
 
 #ifdef BITE2
-    static std::shared_ptr<std::vector<std::shared_ptr<BiteCiphertext>>> tryParseEncryptedCATArgs(
+    static std::shared_ptr<std::vector<std::shared_ptr<BiteCiphertext>>> tryParseEncryptedCTXArgs(
         const std::vector<uint8_t>& _dataField, epoch_id _currentEpochId);
 #endif
 
@@ -36,7 +36,7 @@ struct BiteCodec {
     // ==================== BiteCiphertext building for Transaction fields ==================== //
     
 #ifdef BITE2
-    static std::vector<uint8_t> encodeCATData(
+    static std::vector<uint8_t> encodeCTXData(
         const std::vector<std::vector<uint8_t>>& encryptedSerializedArgs,
         const std::vector<std::vector<uint8_t>>& plainArgs);
 #endif

--- a/bite/BiteEngine.cpp
+++ b/bite/BiteEngine.cpp
@@ -47,15 +47,15 @@ ptr<BiteCiphertext> BiteEngine::tryGetEncryptedRegularTxFields(
 }
 
 #ifdef BITE2
-ptr<std::vector<ptr<BiteCiphertext>>> BiteEngine::tryGetEncryptedCATArgs(
+ptr<std::vector<ptr<BiteCiphertext>>> BiteEngine::tryGetEncryptedCTXArgs(
             const ptr<Transaction>& _transaction, epoch_id _currentEpochId ) {
     CHECK_STATE(_transaction);
 
-    auto encryptedCATArgs = _transaction->getCATEncryptedArgs();
+    auto encryptedCTXArgs = _transaction->getCTXEncryptedArgs();
     auto scAddressAadTE = _transaction->getScAddressAadTE();
 
     // if not cached - try to parse it
-    if (!encryptedCATArgs || !scAddressAadTE) {
+    if (!encryptedCTXArgs || !scAddressAadTE) {
 
         // if not set bite data already - try parse it
         auto ethTx = _transaction->getAsEthereumTransaction();
@@ -63,64 +63,64 @@ ptr<std::vector<ptr<BiteCiphertext>>> BiteEngine::tryGetEncryptedCATArgs(
         auto dataField = ethTx->getTransactionDataField();
         CHECK_STATE(dataField);
 
-        encryptedCATArgs = BiteCodec::tryParseEncryptedCATArgs(*dataField, _currentEpochId);
+        encryptedCTXArgs = BiteCodec::tryParseEncryptedCTXArgs(*dataField, _currentEpochId);
         
-        if (encryptedCATArgs) {
+        if (encryptedCTXArgs) {
             // fetch & cache 'to' field - scAddress used as AAD for TE validation phases
             auto toField = ethTx->getToField();
             CHECK_STATE(toField);
             CHECK_STATE2(toField->size() == sizeof(AddressBytes), 
-                "CAT transaction 'to' field must be exactly 20 bytes");
+                "CTX transaction 'to' field must be exactly 20 bytes");
             
             AddressBytes toFieldBytes;
             std::copy(toField->begin(), toField->end(), toFieldBytes.begin());
 
             // only cache after both are successfully parsed
             _transaction->setScAddressAadTE(toFieldBytes);
-            _transaction->setCATEncryptedArgs(encryptedCATArgs);
+            _transaction->setCTXEncryptedArgs(encryptedCTXArgs);
             
             // Fetch the cached values to return
-            encryptedCATArgs = _transaction->getCATEncryptedArgs();
+            encryptedCTXArgs = _transaction->getCTXEncryptedArgs();
             scAddressAadTE = _transaction->getScAddressAadTE();
         }
     }
-    return encryptedCATArgs;
+    return encryptedCTXArgs;
 }
 #endif
 
 BiteEngine::ParseResult BiteEngine::parseAndCacheBITETransactions(
     const TransactionList& txList,
-    BiteRuntimeContext& runtimeCtx
+    BiteRuntimeContext& runtimeContext
 ) {
     ParseResult result;
 
     ptr<vector<ptr<Transaction> > > transactions = txList.getItems();
-    // Assume no regular txs by default; only process regular txs if a non-CAT is found
+    // Assume no regular txs by default; only process regular txs if a non-CTX is found
     size_t regularTxsStartIdx = transactions->size();
 
     std::set<size_t> failedTxIndices;
 
 #ifdef BITE2
-    // Try parsing CAT transactions first
+    // Try parsing CTX transactions first
     for (size_t i = 0 ; i < transactions->size(); i++) {
         try {
             auto tx = transactions->at(i);
-            auto catArgs = BiteEngine::tryGetEncryptedCATArgs(tx, runtimeCtx.currentEpoch);
+            auto ctxArgs = BiteEngine::tryGetEncryptedCTXArgs(tx, runtimeContext.currentEpoch);
 
-            if (catArgs) {
+            if (ctxArgs) {
                 // Fetch the cached SC address for AAD
                 auto scAddressAadTE = tx->getScAddressAadTE();
                 std::optional<AddressBytes> scAddrOpt = scAddressAadTE ? std::make_optional(*scAddressAadTE) : std::nullopt;
                 
-                auto txCiphertexts = make_shared<TransactionCiphertexts>(*catArgs, scAddrOpt);
+                auto txCiphertexts = make_shared<TransactionCiphertexts>(*ctxArgs, scAddrOpt);
                 result.txsCiphertexts.emplace(i, txCiphertexts);
             } else {
-                // the first non-CAT transaction indicates the start of regular transactions
+                // the first non-CTX transaction indicates the start of regular transactions
                 regularTxsStartIdx = i;
                 break;
             }
         } catch (exception &e) {
-            CONS_LOG(err, fmt::format("Could not try to parse as CAT transaction: {}: ", i) + e.what());
+            CONS_LOG(err, fmt::format("Could not try to parse as CTX transaction: {}: ", i) + e.what());
             failedTxIndices.insert(i);
         }
     }
@@ -133,12 +133,12 @@ BiteEngine::ParseResult BiteEngine::parseAndCacheBITETransactions(
     for (size_t i = regularTxsStartIdx; i < transactions->size(); i++) {
         try {
             if (failedTxIndices.find(i) != failedTxIndices.end()) {
-                // already reported failure for this tx (e.g., CAT parsing failed)
+                // already reported failure for this tx (e.g., CTX parsing failed)
                 // no need to try parsing again
                 continue;
             }
             auto tx = transactions->at(i);
-            auto ciphertext = BiteEngine::tryGetEncryptedRegularTxFields(tx, runtimeCtx.currentEpoch);
+            auto ciphertext = BiteEngine::tryGetEncryptedRegularTxFields(tx, runtimeContext.currentEpoch);
             if (ciphertext) {
                 auto txCiphertexts = make_shared<TransactionCiphertexts>(ciphertext);
                 result.txsCiphertexts.emplace(i, txCiphertexts);
@@ -162,7 +162,7 @@ BiteEngine::ParseResult BiteEngine::parseAndCacheBITETransactions(
  * @brief Helper function - appends ciphertexts from TransactionCiphertexts to vector of CipheredKey
  */
 void appendCiphertextsToVector(ptr<TransactionCiphertexts> _ciphertexts, std::vector< libBLS::CipheredKey >& _vec, size_t& _ciphertextIdx) {
-    // Allow transactions with no ciphertexts (e.g., CAT txs with empty ciphertext)
+    // Allow transactions with no ciphertexts (e.g., CTX txs with empty ciphertext)
     if (_ciphertexts->count() == 0) {
         return;
     }
@@ -208,8 +208,8 @@ BiteEngine::CiphertextValidationResult BiteEngine::validateCiphertexts(const Tra
             parsedTxs.emplace_back(idx, ciphertexts->count());
             expectedValidationResults += ciphertexts->count();
 
-            // Build AAD only for CAT transactions - regular txs don't need AAD entries
-            if (ciphertexts->isCAT()) {
+            // Build AAD only for CTX transactions - regular txs don't need AAD entries
+            if (ciphertexts->isCTX()) {
                 const auto& scAddr = ciphertexts->getScAddressAadTE();
                 CHECK_STATE(scAddr.has_value());
                 std::vector<uint8_t> aadBytes(scAddr->begin(), scAddr->end());
@@ -228,7 +228,7 @@ BiteEngine::CiphertextValidationResult BiteEngine::validateCiphertexts(const Tra
     }
 
     // From the successfully built CipheredKey vector, validate ciphertexts
-    // Pass AAD only if we have at least one CAT transaction
+    // Pass AAD only if we have at least one CTX transaction
     BiteCore::CiphertextValidationResult coreResult = core.validateCiphertexts(
         cipheredKeys, hasAnyAAD ? &aadTE : nullptr);
     CHECK_STATE(coreResult.validationResults.size() == expectedValidationResults);
@@ -265,7 +265,7 @@ std::shared_ptr<DecryptedAESKeyList> BiteEngine::mergeAESKeys(
     TransactionCiphertextsMap& _txCiphertexts,
     const std::map<schain_index, std::shared_ptr<AESKeyDecryptionShareList>>& _decryptionShareMap,
     const std::vector<libBLS::TEPublicKeyShare>& _tePublicKeyShares,
-    const BiteRuntimeContext& _runtimeCtx
+    const BiteRuntimeContext& _runtimeContext
 ) const {
 
     CHECK_STATE(!_decryptionShareMap.empty());
@@ -357,12 +357,12 @@ std::shared_ptr<DecryptedAESKeyList> BiteEngine::mergeAESKeys(
                 std::vector<bool> allSharesFromNodeAreValid;
                 allSharesFromNodeAreValid.resize(config.totalSigners, true);
 
-                // Prepare AAD for CAT transactions
+                // Prepare AAD for CTX transactions
                 const auto& txCiphertexts = _txCiphertexts.at(txId);
                 const std::vector<std::vector<uint8_t>>* aadPtr = nullptr;
                 std::vector<std::vector<uint8_t>> aadVec;
                 
-                if (txCiphertexts->isCAT()) {
+                if (txCiphertexts->isCTX()) {
                     const auto& scAddr = txCiphertexts->getScAddressAadTE();
                     CHECK_STATE(scAddr.has_value());
                     // Single element - same AAD for the one ciphertext validated per call
@@ -414,11 +414,11 @@ std::shared_ptr<DecryptedAESKeyList> BiteEngine::mergeAESKeys(
     };
 
     try {
-        if (_runtimeCtx.threadPoolExecutor) {
+        if (_runtimeContext.threadPoolExecutor) {
             for ( auto&& [txId, decryptionSet]: decryptionShareSets ) {
                 auto txIdLocal = txId;
                 auto decryptionSetLocal = decryptionSet;
-                futures.emplace_back(folly::via(_runtimeCtx.threadPoolExecutor.get(), [processTx, txIdLocal, decryptionSetLocal]() {
+                futures.emplace_back(folly::via(_runtimeContext.threadPoolExecutor.get(), [processTx, txIdLocal, decryptionSetLocal]() {
                     return processTx(txIdLocal, decryptionSetLocal);
                 }));
             }
@@ -444,15 +444,15 @@ std::shared_ptr<DecryptedAESKeyList> BiteEngine::mergeAESKeys(
 DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
         const TransactionList &_transactionList,
         const DecryptedAESKeyList &_aesKeys,
-        BiteRuntimeContext& runtimeCtx
+        BiteRuntimeContext& runtimeContext
 ) const {
  
     auto decryptedFieldsMap = std::make_shared<DecryptedRegularTxsMap>();
     auto regularTxMapMutex = std::make_shared<std::mutex>();
     
 #ifdef BITE2
-    auto catTxsMap          = std::make_shared<DecryptedCATxsMap>();
-    auto catTxsMapMutex     = std::make_shared<std::mutex>();
+    auto ctxTxsMap          = std::make_shared<DecryptedCTXTxsMap>();
+    auto ctxTxsMapMutex     = std::make_shared<std::mutex>();
 #endif
 
     auto txs = _transactionList.getItems();
@@ -466,7 +466,7 @@ DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
     // Helper to avoid repeating folly::via boilerplate
     auto schedule = [&](auto &&fn) {
         futures.emplace_back(
-            folly::via(runtimeCtx.threadPoolExecutor.get(), std::forward<decltype(fn)>(fn))
+            folly::via(runtimeContext.threadPoolExecutor.get(), std::forward<decltype(fn)>(fn))
         );
     };
 
@@ -474,26 +474,26 @@ DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
         const std::size_t txCount = _transactionList.size();
 
 #ifdef BITE2
-        bool allCATsParsed = false;
+        bool allCTXsParsed = false;
 #endif
 
         for (std::size_t txIdx = 0; txIdx < txCount; ++txIdx) {
             auto tx = txs->at(txIdx);
 
 #ifdef BITE2
-            // ---------- Try CAT path first ----------
-            if (!allCATsParsed) {
+            // ---------- Try CTX path first ----------
+            if (!allCTXsParsed) {
                 ptr< std::vector<ptr<BiteCiphertext> > > encryptedArgs;
                 try { 
-                    encryptedArgs = tryGetEncryptedCATArgs(tx, runtimeCtx.currentEpoch);
+                    encryptedArgs = tryGetEncryptedCTXArgs(tx, runtimeContext.currentEpoch);
                 } catch (const std::exception& e) {
-                    CONS_LOG(warn, fmt::format("Could not try to parse as CAT encrypted transaction during decryption: {}: {}", txIdx, e.what()));
+                    CONS_LOG(warn, fmt::format("Could not try to parse as CTX encrypted transaction during decryption: {}: {}", txIdx, e.what()));
                 }
                 if (encryptedArgs) {
-                    // CAT tx with no encrypted arguments — nothing to decrypt
+                    // CTX tx with no encrypted arguments — nothing to decrypt
                     if (encryptedArgs->empty()) {
-                        std::lock_guard<std::mutex> lock(*catTxsMapMutex);
-                        catTxsMap->emplace(txIdx, DecryptedCATArgs{});
+                        std::lock_guard<std::mutex> lock(*ctxTxsMapMutex);
+                        ctxTxsMap->emplace(txIdx, DecryptedCTXArgs{});
                         continue;
                     }
                     auto decryptedAESKey = _aesKeys.getKeys(txIdx);
@@ -501,9 +501,9 @@ DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
                     CHECK_STATE(encryptedArgs->size() == decryptedAESKey->size());
 
                     try {
-                        schedule([corePtr = &this->core, encryptedArgs, decryptedAESKey, catTxsMap, txIdx, catTxsMapMutex]() 
+                        schedule([corePtr = &this->core, encryptedArgs, decryptedAESKey, ctxTxsMap, txIdx, ctxTxsMapMutex]() 
                         -> folly::Unit {
-                            DecryptedCATArgs decryptedData;
+                            DecryptedCTXArgs decryptedData;
                             decryptedData.args.reserve(encryptedArgs->size());
 
                             for (std::size_t argIdx = 0; argIdx < encryptedArgs->size(); ++argIdx) {
@@ -517,23 +517,23 @@ DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
                                 );
                             }
 
-                            std::lock_guard<std::mutex> lock(*catTxsMapMutex);
-                            catTxsMap->emplace(txIdx, std::move(decryptedData));
+                            std::lock_guard<std::mutex> lock(*ctxTxsMapMutex);
+                            ctxTxsMap->emplace(txIdx, std::move(decryptedData));
 
                             return folly::unit;
                         });
                     } catch (const std::exception &e) {
-                        CONS_LOG(err, fmt::format("Corrupt CAT tx:{} that doesn't decrypt: {}", txIdx, e.what()));
-                        std::lock_guard<std::mutex> lock(*catTxsMapMutex);
-                        catTxsMap->emplace(txIdx, std::nullopt);
+                        CONS_LOG(err, fmt::format("Corrupt CTX tx:{} that doesn't decrypt: {}", txIdx, e.what()));
+                        std::lock_guard<std::mutex> lock(*ctxTxsMapMutex);
+                        ctxTxsMap->emplace(txIdx, std::nullopt);
                     }
 
-                    // This tx is CAT, do not treat it as regular
+                    // This tx is CTX, do not treat it as regular
                     continue;
                 }
                 else {
-                    // No more CAT transactions expected after the first non-CAT one
-                    allCATsParsed = true;
+                    // No more CTX transactions expected after the first non-CTX one
+                    allCTXsParsed = true;
                 }
             }
 
@@ -542,7 +542,7 @@ DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
             // ---------- Regular BITE1-style encryption ----------
             ptr<BiteCiphertext> bite;
             try {
-                bite = tryGetEncryptedRegularTxFields(tx, runtimeCtx.currentEpoch);
+                bite = tryGetEncryptedRegularTxFields(tx, runtimeContext.currentEpoch);
             } catch (const std::exception& e) {
                 CONS_LOG(warn, fmt::format("Could not try to parse as regular encrypted transaction during decryption: {}: {}", txIdx, e.what()));
             }
@@ -578,7 +578,7 @@ DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
             }
 
             // ---------- No BITE data at all ----------
-            // If it's neither CAT nor regular encrypted, we must not have AES keys
+            // If it's neither CTX nor regular encrypted, we must not have AES keys
             CHECK_STATE(!_aesKeys.getKeys(txIdx));
         }
     } catch ( ... ) {
@@ -593,7 +593,7 @@ DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
 
     return DecryptedTransactions(
 #ifdef BITE2 
-        catTxsMap,
+        ctxTxsMap,
 #endif 
         decryptedFieldsMap 
     );
@@ -614,7 +614,7 @@ std::vector<uint8_t> BiteEngine::buildRegularTxData(
 
 #ifdef BITE2
 
-std::vector<uint8_t> BiteEngine::buildCATData(
+std::vector<uint8_t> BiteEngine::buildCTXData(
     const libBLS::TEPublicKey& key,
     size_t numberOfCiphertexts,
     uint64_t epochId,
@@ -646,7 +646,7 @@ std::vector<uint8_t> BiteEngine::buildCATData(
         plainArgs.emplace_back(numberOfCiphertexts * 5);
     }
 
-    return BiteCodec::encodeCATData(encryptedSerializedArgs, plainArgs);
+    return BiteCodec::encodeCTXData(encryptedSerializedArgs, plainArgs);
 }
 
 #endif

--- a/bite/BiteEngine.h
+++ b/bite/BiteEngine.h
@@ -57,11 +57,11 @@ public:
      * @brief Stage 1: Parse BITE transactions from the transaction list.
      * Attempts to parse all BITE transactions in the given TransactionList.
      * Caches parsed BiteCiphertext objects in the Transaction objects.
-     * Assumes CATs are at the start of the list, followed by regular transactions.
+     * Assumes CTXs are at the start of the list, followed by regular transactions.
      */
     static ParseResult parseAndCacheBITETransactions(
         const TransactionList& txList,
-        BiteRuntimeContext& runtimeCtx
+        BiteRuntimeContext& runtimeContext
     );
 
     //=================== Stage 2: Ciphertext Validation  =================== //
@@ -84,7 +84,7 @@ public:
     /**
      * @brief Validates the ciphertexts extracted from BITE transactions.
      * Failures can either be from parsing from bytes or semantic validation.
-     * Each transaction can have multiple ciphertexts (e.g., CAT transactions).
+     * Each transaction can have multiple ciphertexts (e.g., CTX transactions).
      * Thus, if a single ciphertext in a transaction is invalid, the whole transaction is marked invalid.
      * Only if all ciphertexts are valid, public decryption values are returned.
      */
@@ -99,7 +99,7 @@ public:
         TransactionCiphertextsMap& _txCiphertexts,
         const std::map<schain_index, std::shared_ptr<AESKeyDecryptionShareList>>& _decryptionShareMap,
         const std::vector<libBLS::TEPublicKeyShare>& _tePublicKeyShares,
-        const BiteRuntimeContext& _runtimeCtx
+        const BiteRuntimeContext& _runtimeContext
     ) const;
 
     //=================== Stage 4: Decrypt transactions from decrypted keys  =================== //
@@ -107,7 +107,7 @@ public:
     DecryptedTransactions decryptTransactionsListInParallel(
             const TransactionList &_transactionList,
             const DecryptedAESKeyList &_aesKeys,
-            BiteRuntimeContext& runtimeCtx
+            BiteRuntimeContext& runtimeContext
     ) const;
 
     //=================== Helpers =================== //
@@ -128,10 +128,10 @@ public:
 
 
 #ifdef BITE2
-    static ptr<std::vector<ptr<BiteCiphertext>>> tryGetEncryptedCATArgs(
+    static ptr<std::vector<ptr<BiteCiphertext>>> tryGetEncryptedCTXArgs(
             const ptr<Transaction>& _transaction, epoch_id _currentEpochId );
 
-    std::vector<uint8_t> buildCATData(
+    std::vector<uint8_t> buildCTXData(
         const libBLS::TEPublicKey& key,
         size_t numberOfCiphertexts,
         uint64_t epochId,

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -283,7 +283,7 @@ ptr<vector<uint8_t> > BiteManager::encryptRegularTx(const vector<uint8_t> &_data
 }
 
 #ifdef BITE2
-ptr<vector<uint8_t>> BiteManager::generateEncryptedCATData(uint64_t epochId, const std::optional<AddressBytes>& scAddressAadTE) {
+ptr<vector<uint8_t>> BiteManager::generateEncryptedCTXData(uint64_t epochId, const std::optional<AddressBytes>& scAddressAadTE) {
     constexpr size_t numberOfCiphertexts = 2;
 
     if (biteEngine.usingRealCrypto()) {
@@ -291,7 +291,7 @@ ptr<vector<uint8_t>> BiteManager::generateEncryptedCATData(uint64_t epochId, con
         CHECK_STATE(primaryKey);
         auto blsKey = primaryKey->getPublicKey();
         libBLS::TEPublicKey teKey(blsKey);
-        return std::make_shared<vector<uint8_t>>(biteEngine.buildCATData(teKey, numberOfCiphertexts, epochId, scAddressAadTE));
+        return std::make_shared<vector<uint8_t>>(biteEngine.buildCTXData(teKey, numberOfCiphertexts, epochId, scAddressAadTE));
     }
 
     // mock path: build ciphertexts using mockup encryption + epoch wrapping
@@ -311,21 +311,21 @@ ptr<vector<uint8_t>> BiteManager::generateEncryptedCATData(uint64_t epochId, con
         plainArgs.emplace_back(numberOfCiphertexts * 5);
     }
 
-    return std::make_shared<vector<uint8_t>>(BiteCodec::encodeCATData(encryptedSerializedArgs, plainArgs));
+    return std::make_shared<vector<uint8_t>>(BiteCodec::encodeCTXData(encryptedSerializedArgs, plainArgs));
 }
 
-ptr<vector<uint8_t> > BiteManager::generateEmptyCATData(uint64_t epochId) {
+ptr<vector<uint8_t> > BiteManager::generateEmptyCTXData(uint64_t epochId) {
     (void)epochId;  // epochId not needed since there are no ciphertexts
     
     // No encrypted arguments (empty ciphertexts)
     std::vector<std::vector<uint8_t>> encryptedSerializedArgs;
     
-    // Some plain arguments to include in the CAT
+    // Some plain arguments to include in the CTX
     std::vector<std::vector<uint8_t>> plainArgs;
     plainArgs.emplace_back(std::vector<uint8_t>{0x01, 0x02, 0x03});
     plainArgs.emplace_back(std::vector<uint8_t>{0x04, 0x05});
     
-    return std::make_shared<vector<uint8_t>>(BiteCodec::encodeCATData(encryptedSerializedArgs, plainArgs));
+    return std::make_shared<vector<uint8_t>>(BiteCodec::encodeCTXData(encryptedSerializedArgs, plainArgs));
 }
 #endif
 

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -130,7 +130,7 @@ public:
 
 #ifdef BITE2
     /**
-     * @brief Encrypts CAT function arguments using BITE2 scheme.
+     * @brief Encrypts CTX function arguments using BITE2 scheme.
      * @param _scAddressAadTE - Smart contract address used as AAD for TE validation (real crypto only)
      * @param _data - Returned data follows the format:
      * [
@@ -141,13 +141,13 @@ public:
      *      ),
      * ]
      */
-    [[nodiscard]] ptr<vector<uint8_t> > generateEncryptedCATData(uint64_t epochId, const std::optional<AddressBytes>& scAddressAadTE = std::nullopt);
+    [[nodiscard]] ptr<vector<uint8_t> > generateEncryptedCTXData(uint64_t epochId, const std::optional<AddressBytes>& scAddressAadTE = std::nullopt);
 
     /**
-     * @brief Generates a CAT transaction with no encrypted arguments (empty ciphertexts).
+     * @brief Generates a CTX transaction with no encrypted arguments (empty ciphertexts).
      * Only plain arguments are included.
      */
-    [[nodiscard]] ptr<vector<uint8_t> > generateEmptyCATData(uint64_t epochId);
+    [[nodiscard]] ptr<vector<uint8_t> > generateEmptyCTXData(uint64_t epochId);
 #endif
 
 private:

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -870,7 +870,7 @@ void Schain::processCommittedBlock(const ptr<CommittedBlock> &_block) {
             auto decryptedTxs = _block->getDecryptedTransactions();
             CHECK_STATE(decryptedTxs.regularTxsMap)
 #ifdef BITE2
-            CHECK_STATE(decryptedTxs.catTxsMap)
+            CHECK_STATE(decryptedTxs.ctxTxsMap)
 #endif
 #endif
 
@@ -882,7 +882,7 @@ void Schain::processCommittedBlock(const ptr<CommittedBlock> &_block) {
 #ifdef BITE
                     + ":BITE_DECRYPTED_TXS:" + to_string(decryptedTxs.regularTxsMap->size())
 #ifdef BITE2
-                    + ":CAT_DECRYPTED_TXS:" + to_string(decryptedTxs.catTxsMap->size())
+                    + ":CAT_DECRYPTED_TXS:" + to_string(decryptedTxs.ctxTxsMap->size())
 #endif
 #endif
 

--- a/crypto/TransactionCiphertexts.h
+++ b/crypto/TransactionCiphertexts.h
@@ -63,5 +63,5 @@ public:
     [[nodiscard]] const std::optional<AddressBytes>& getScAddressAadTE() const { return scAddressAadTE; }
     
     // Returns true if this is a CAT transaction (has SC address AAD)
-    [[nodiscard]] bool isCAT() const { return scAddressAadTE.has_value(); }
+    [[nodiscard]] bool isCTX() const { return scAddressAadTE.has_value(); }
 };

--- a/datastructures/CommittedBlock.cpp
+++ b/datastructures/CommittedBlock.cpp
@@ -404,8 +404,8 @@ ptr< DecryptedRegularTxsMap > CommittedBlock::getDecryptedRegularTxFields() cons
 }
 
 #ifdef BITE2
-ptr< DecryptedCATxsMap > CommittedBlock::getDecryptedCATArgs() const {
-    return decryptedTransactions.catTxsMap;
+ptr< DecryptedCTXTxsMap > CommittedBlock::getDecryptedCATArgs() const {
+    return decryptedTransactions.ctxTxsMap;
 }
 #endif
 #endif

--- a/datastructures/CommittedBlock.h
+++ b/datastructures/CommittedBlock.h
@@ -56,7 +56,7 @@ public:
     [[nodiscard]] ptr< DecryptedRegularTxsMap > getDecryptedRegularTxFields() const;
 
 #ifdef BITE2
-    [[nodiscard]] ptr< DecryptedCATxsMap > getDecryptedCATArgs() const;
+    [[nodiscard]] ptr< DecryptedCTXTxsMap > getDecryptedCATArgs() const;
 #endif
 
 #endif

--- a/datastructures/Transaction.cpp
+++ b/datastructures/Transaction.cpp
@@ -207,11 +207,11 @@ void Transaction::setRegularTxEncryptedData( ptr<BiteCiphertext> _biteDataField 
 }
 
 #ifdef BITE2
-ptr<std::vector<ptr<BiteCiphertext>>> Transaction::getCATEncryptedArgs() {
+ptr<std::vector<ptr<BiteCiphertext>>> Transaction::getCTXEncryptedArgs() {
     // thread safe
     return std::atomic_load(&parsedEncryptedCATArgs );
 }
-void Transaction::setCATEncryptedArgs( ptr<std::vector<ptr<BiteCiphertext>>> _biteDataField ) {
+void Transaction::setCTXEncryptedArgs( ptr<std::vector<ptr<BiteCiphertext>>> _biteDataField ) {
     // thread safe
     std::atomic_store(&parsedEncryptedCATArgs, _biteDataField);
 }

--- a/datastructures/Transaction.h
+++ b/datastructures/Transaction.h
@@ -114,8 +114,8 @@ public:
 
 #ifdef BITE2
     // Allows caching parsed encrypted CAT transaction arguments
-    ptr<std::vector<ptr<BiteCiphertext>>> getCATEncryptedArgs();
-    void setCATEncryptedArgs( ptr<std::vector<ptr<BiteCiphertext>>> _biteDataField );
+    ptr<std::vector<ptr<BiteCiphertext>>> getCTXEncryptedArgs();
+    void setCTXEncryptedArgs( ptr<std::vector<ptr<BiteCiphertext>>> _biteDataField );
 
     void setScAddressAadTE( const AddressBytes& _scAddressAadTE );
     ptr<AddressBytes> getScAddressAadTE();

--- a/datastructures/TransactionList.cpp
+++ b/datastructures/TransactionList.cpp
@@ -167,8 +167,8 @@ ptr< ConsensusExtFace::Transactions > TransactionList::createTransactionVector(
         auto epochId = biteManager->getSchain()->getNode()->getCurrentEpochId();
         for (size_t i = 0; i < transactions->size(); i++) {
             auto tx = transactions->at(i);
-            if (BiteEngine::tryGetEncryptedCATArgs(tx, epochId)) {
-                tv->pushBackCAT(*(tx->getData()));
+            if (BiteEngine::tryGetEncryptedCTXArgs(tx, epochId)) {
+                tv->pushBackCTX(*(tx->getData()));
             }
             else {
                 // first regular tx found

--- a/node/ConsensusInterface.h
+++ b/node/ConsensusInterface.h
@@ -217,7 +217,7 @@ public:
         
 #ifdef BITE2
         // number of CAT txs in 'all' vector
-        std::size_t catsSize = 0;
+        std::size_t ctxsSize = 0;
 #endif
 
         using iterator = typename transactions_vector::iterator;
@@ -226,24 +226,24 @@ public:
     public:
 
 #ifdef BITE2
-        std::size_t sizeCAT() const noexcept {
-            return catsSize;
+        std::size_t sizeCTX() const noexcept {
+            return ctxsSize;
         }
 
-        bool isCat(size_t index) const {
-            return index < catsSize;
+        bool isCTX(size_t index) const {
+            return index < ctxsSize;
         }
 
-        void emplaceBackCAT(Bytes&& b) {
-            CHECK_STATE(catsSize == all.size()); // ensure all cats are contiguous at the start
+        void emplaceBackCTX(Bytes&& b) {
+            CHECK_STATE(ctxsSize == all.size()); // ensure all cats are contiguous at the start
             all.emplace_back(std::move(b));
-            catsSize++;
+            ctxsSize++;
         }
 
-        void pushBackCAT(const Bytes &b) {
-            CHECK_STATE(catsSize == all.size());
+        void pushBackCTX(const Bytes &b) {
+            CHECK_STATE(ctxsSize == all.size());
             all.push_back(b);
-            catsSize++;
+            ctxsSize++;
         }
 #endif
 

--- a/node/ConsensusTypes.h
+++ b/node/ConsensusTypes.h
@@ -20,29 +20,29 @@ struct DecryptedRegularTxFields {
     AddressBytes to;
 };
 
-struct DecryptedCATArgs {
+struct DecryptedCTXArgs {
     std::vector<Bytes> args;
 };
 
 // For both maps, an entry will be marked as std::nullopt if decryption failed for that tx.
 using DecryptedRegularTxsMap = std::map< TxId, std::optional<DecryptedRegularTxFields> >;
-using DecryptedCATxsMap = std::map< TxId, std::optional<DecryptedCATArgs> >;
+using DecryptedCTXTxsMap = std::map< TxId, std::optional<DecryptedCTXArgs> >;
 
 // Used to return both regular txs and CAT txs decryption results
 struct DecryptedTransactions {
 #ifdef BITE2
-    std::shared_ptr<DecryptedCATxsMap> catTxsMap;
+    std::shared_ptr<DecryptedCTXTxsMap> ctxTxsMap;
 #endif
     std::shared_ptr<DecryptedRegularTxsMap> regularTxsMap;
 
     DecryptedTransactions(
 #ifdef BITE2
-        std::shared_ptr<DecryptedCATxsMap> _catTxsMap,
+        std::shared_ptr<DecryptedCTXTxsMap> _ctxTxsMap,
 #endif
         std::shared_ptr<DecryptedRegularTxsMap> _regularTxsMap) {
 #ifdef BITE2
-        CHECK_STATE(_catTxsMap);
-        catTxsMap = _catTxsMap;
+        CHECK_STATE(_ctxTxsMap);
+        ctxTxsMap = _ctxTxsMap;
 #endif
         CHECK_STATE(_regularTxsMap);
         regularTxsMap = _regularTxsMap;
@@ -50,7 +50,7 @@ struct DecryptedTransactions {
 
     DecryptedTransactions() :
 #ifdef BITE2
-        catTxsMap(std::make_shared<DecryptedCATxsMap>()),
+        ctxTxsMap(std::make_shared<DecryptedCTXTxsMap>()),
 #endif
           regularTxsMap(std::make_shared<DecryptedRegularTxsMap>()) {}
 };

--- a/pendingqueue/PendingTransactionsAgent.cpp
+++ b/pendingqueue/PendingTransactionsAgent.cpp
@@ -187,10 +187,10 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
         auto currentEpoch = sChain->getNode()->getCurrentEpochId();
         try {
 #ifdef BITE2
-            if (transactions.isCat(i)) {
-                auto catArgs = BiteEngine::tryGetEncryptedCATArgs(pt, currentEpoch);
-                if (!catArgs) {
-                    CONS_LOG(err, "Found regular transaction marked as CAT. Skipping it from my proposal.");
+            if (transactions.isCTX(i)) {
+                auto ctxArgs = BiteEngine::tryGetEncryptedCTXArgs(pt, currentEpoch);
+                if (!ctxArgs) {
+                    CONS_LOG(err, "Found regular transaction marked as CTX. Skipping it from my proposal.");
                     continue;
                 }
             }
@@ -198,7 +198,7 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
 #endif
             {
                 // only used for validation purposes
-                // If BITE2, only do this validation for non-CATs
+                // If BITE2, only do this validation for non-CTXs
                 BiteEngine::tryGetEncryptedRegularTxFields(pt, currentEpoch);
             }
 

--- a/pendingqueue/TestMessageGeneratorAgent.cpp
+++ b/pendingqueue/TestMessageGeneratorAgent.cpp
@@ -165,21 +165,21 @@ void TestMessageGeneratorAgent::sendTestRequestEthCall() {
 ConsensusExtFace::Transactions TestMessageGeneratorAgent::pendingTransactionsBITE(
     size_t _limit ) {
     static size_t txIdxInPrecomputedBatchRegular = 0;
-    static size_t txIdxInPrecomputedBatchCAT = 0;
+    static size_t txIdxInPrecomputedBatchCTX = 0;
     // contains 3/4 BITE encrypted & 1/4 unencrypted regular transactions
     static ConsensusExtFace::Transactions onlyRegularTxs;
-    // contains only BITE2 CAT transactions (with encrypted args)
-    static ConsensusExtFace::Transactions onlyCATs;
+    // contains only BITE2 CTX transactions (with encrypted args)
+    static ConsensusExtFace::Transactions onlyCTXs;
     static std::once_flag initFlag;
     static size_t numTotalRegularTxs = 1000;
-    static size_t numTotalCATTxs = 200;
-    static double CATsProportion = 0;
+    static size_t numTotalCTXTxs = 200;
+    static double CTXsProportion = 0;
 
     // build test transactions only once at start (includes encrypting them)
     std::call_once(initFlag, [&] () {
 #ifdef BITE2
-        CATsProportion = (double) numTotalCATTxs / (numTotalRegularTxs + numTotalCATTxs);
-        ConsensusExtFace::Transactions tmpOnlyCATs;
+        CTXsProportion = (double) numTotalCTXTxs / (numTotalRegularTxs + numTotalCTXTxs);
+        ConsensusExtFace::Transactions tmponlyCTXs;
 #endif
 
         ConsensusExtFace::Transactions tmpOnlyRegularTxs;
@@ -198,30 +198,30 @@ ConsensusExtFace::Transactions TestMessageGeneratorAgent::pendingTransactionsBIT
         onlyRegularTxs = std::move(tmpOnlyRegularTxs);
 
 #ifdef BITE2
-        // setup cat txs - include some empty CATs for coverage
-        // Empty CATs will be at positions: 0 (start), numTotalCATTxs/2 (middle), numTotalCATTxs-1 (end)
-        // and every 10th transaction to ensure ~10% are empty CATs
-        for ( uint64_t i = 0; i < numTotalCATTxs; i++ ) {
+        // setup ctx txs - include some empty CTXs for coverage
+        // Empty CTXs will be at positions: 0 (start), numTotalCTXTxs/2 (middle), numTotalCTXTxs-1 (end)
+        // and every 10th transaction to ensure ~10% are empty CTXs
+        for ( uint64_t i = 0; i < numTotalCTXTxs; i++ ) {
             auto tx = EthTransactionEncoder::generateSampleTx();
             
-            // Make empty CAT at start, middle, end, and every 10th transaction
-            bool isEmptyCAT = (i == 0) || 
-                              (i == numTotalCATTxs / 2) || 
-                              (i == numTotalCATTxs - 1) ||
+            // Make empty CTX at start, middle, end, and every 10th transaction
+            bool isEmptyCTX = (i == 0) || 
+                              (i == numTotalCTXTxs / 2) || 
+                              (i == numTotalCTXTxs - 1) ||
                               (i % 10 == 0);
             
-            if (isEmptyCAT) {
-                // CAT with no encrypted arguments (empty ciphertexts)
-                EthTransactionEncoder::encryptEmptyCATTransaction( tx, sChain->getBiteManager() );
+            if (isEmptyCTX) {
+                // CTX with no encrypted arguments (empty ciphertexts)
+                EthTransactionEncoder::encryptEmptyCTXTransaction( tx, sChain->getBiteManager() );
             } else {
-                // Regular CAT with encrypted arguments
-                EthTransactionEncoder::encryptCATTransaction( tx, sChain->getBiteManager() );
+                // Regular CTX with encrypted arguments
+                EthTransactionEncoder::encryptCTXTransaction( tx, sChain->getBiteManager() );
             }
             
             auto signedTx = EthTransactionEncoder::signAndEncodeTx( tx );
-            tmpOnlyCATs.emplaceBackCAT( std::move(*signedTx) );
+            tmponlyCTXs.emplaceBackCTX( std::move(*signedTx) );
         }
-        onlyCATs = std::move(tmpOnlyCATs);
+        onlyCTXs = std::move(tmponlyCTXs);
 #endif
     });
 
@@ -234,20 +234,20 @@ ConsensusExtFace::Transactions TestMessageGeneratorAgent::pendingTransactionsBIT
     if ( test == SchainTest::NONE )
         return selectedTxs;
 
-    // compute how many CATs / non-CATs to include
-    const size_t numCATs = (CATsProportion * _limit);
-    const size_t numRegularTxs = _limit - numCATs;
-    size_t catIdx = txIdxInPrecomputedBatchCAT;
+    // compute how many CTXs / non-CTXs to include
+    const size_t numCTXs = (CTXsProportion * _limit);
+    const size_t numRegularTxs = _limit - numCTXs;
+    size_t ctxIdx = txIdxInPrecomputedBatchCTX;
 
 #ifdef BITE2
-    // place all CATs at the start
-    for ( size_t i = 0; i < numCATs; i++ ) {
-        catIdx = (catIdx + 1) % numTotalCATTxs;
-        selectedTxs.emplaceBackCAT( onlyCATs.at(catIdx) );
+    // place all CTXs at the start
+    for ( size_t i = 0; i < numCTXs; i++ ) {
+        ctxIdx = (ctxIdx + 1) % numTotalCTXTxs;
+        selectedTxs.emplaceBackCTX( onlyCTXs.at(ctxIdx) );
     }
 #endif
-    ( void ) numTotalCATTxs;
-    txIdxInPrecomputedBatchCAT = catIdx;
+    ( void ) numTotalCTXTxs;
+    txIdxInPrecomputedBatchCTX = ctxIdx;
 
     size_t regularIdx = txIdxInPrecomputedBatchRegular;
     for ( uint64_t i = 0; i < numRegularTxs; i++ ) {

--- a/rlp/EthTransactionEncoder.cpp
+++ b/rlp/EthTransactionEncoder.cpp
@@ -127,7 +127,7 @@ void EthTransactionEncoder::encryptRegularTransaction(std::unique_ptr<EthTransac
 
 #ifdef BITE2
 
-void EthTransactionEncoder::encryptCATTransaction(std::unique_ptr<EthTransaction>& tx, std::shared_ptr<BiteManager> _biteManager) {
+void EthTransactionEncoder::encryptCTXTransaction(std::unique_ptr<EthTransaction>& tx, std::shared_ptr<BiteManager> _biteManager) {
     uint64_t epochId = 0;
     
     std::optional<AddressBytes> scAddressAadTE = std::nullopt;
@@ -137,17 +137,17 @@ void EthTransactionEncoder::encryptCATTransaction(std::unique_ptr<EthTransaction
         scAddressAadTE = addr;
     }
 
-    auto catData = _biteManager->generateEncryptedCATData(epochId, scAddressAadTE);
+    auto catData = _biteManager->generateEncryptedCTXData(epochId, scAddressAadTE);
     tx->data = *catData;
 }
 
-void EthTransactionEncoder::encryptEmptyCATTransaction(std::unique_ptr<EthTransaction>& tx, std::shared_ptr<BiteManager> _biteManager) {
+void EthTransactionEncoder::encryptEmptyCTXTransaction(std::unique_ptr<EthTransaction>& tx, std::shared_ptr<BiteManager> _biteManager) {
     uint64_t epochId = 0;
     // Empty CAT also has SC address AAD if needed (though empty CATs usually don't have encrypted args needing AAD validation on decryption of args, 
-    // but BiteEngine::buildCATData might be used if we change logic. 
-    // Currently generateEmptyCATData doesn't call buildCATData with encryption, so maybe no change needed there?)
-    // Let's check generateEmptyCATData implementation.
-    auto catData = _biteManager->generateEmptyCATData(epochId);
+    // but BiteEngine::buildCTXData might be used if we change logic. 
+    // Currently generateEmptyCTXData doesn't call buildCTXData with encryption, so maybe no change needed there?)
+    // Let's check generateEmptyCTXData implementation.
+    auto catData = _biteManager->generateEmptyCTXData(epochId);
     tx->data = *catData;
 }
 

--- a/rlp/EthTransactionEncoder.h
+++ b/rlp/EthTransactionEncoder.h
@@ -33,9 +33,9 @@ public:
 
 #ifdef BITE2
 
-    static void encryptCATTransaction(std::unique_ptr<EthTransaction>& tx, std::shared_ptr<BiteManager> _biteManager);
+    static void encryptCTXTransaction(std::unique_ptr<EthTransaction>& tx, std::shared_ptr<BiteManager> _biteManager);
 
-    static void encryptEmptyCATTransaction(std::unique_ptr<EthTransaction>& tx, std::shared_ptr<BiteManager> _biteManager);
+    static void encryptEmptyCTXTransaction(std::unique_ptr<EthTransaction>& tx, std::shared_ptr<BiteManager> _biteManager);
 
 #endif
 

--- a/unittests/bite/BiteCodecTests.cpp
+++ b/unittests/bite/BiteCodecTests.cpp
@@ -100,8 +100,8 @@ CATCH_TEST_CASE("BiteCodec parses CAT args with selector and ignores others", "[
     std::vector<std::vector<uint8_t>> plainArgs = { {0xAA}, {0xBB} };
 
     // correct selector - should parse
-    auto encoded = BiteCodec::encodeCATData(encryptedArgs, plainArgs);
-    auto parsed = BiteCodec::tryParseEncryptedCATArgs(encoded, epoch);
+    auto encoded = BiteCodec::encodeCTXData(encryptedArgs, plainArgs);
+    auto parsed = BiteCodec::tryParseEncryptedCTXArgs(encoded, epoch);
     CATCH_REQUIRE(parsed);
     CATCH_REQUIRE(parsed->size() == encryptedArgs.size());
     for (size_t i = 0; i < parsed->size(); i++) {
@@ -112,7 +112,7 @@ CATCH_TEST_CASE("BiteCodec parses CAT args with selector and ignores others", "[
 
     // missing selector - should not parse
     std::vector<uint8_t> withoutSelector{0x00, 0x01, 0x02, 0x03};
-    CATCH_REQUIRE(BiteCodec::tryParseEncryptedCATArgs(withoutSelector, epoch) == nullptr);
+    CATCH_REQUIRE(BiteCodec::tryParseEncryptedCTXArgs(withoutSelector, epoch) == nullptr);
 }
 
 CATCH_TEST_CASE("BiteCodec enforces epoch for CAT args", "[bite][codec][cat][epoch]") {
@@ -133,16 +133,16 @@ CATCH_TEST_CASE("BiteCodec enforces epoch for CAT args", "[bite][codec][cat][epo
     };
     std::vector<std::vector<uint8_t>> plainArgs = { {0xAA}, {0xBB} };
 
-    auto encoded = BiteCodec::encodeCATData(encryptedArgs, plainArgs);
+    auto encoded = BiteCodec::encodeCTXData(encryptedArgs, plainArgs);
 
     // matching epoch works
-    auto parsed = BiteCodec::tryParseEncryptedCATArgs(encoded, epoch);
+    auto parsed = BiteCodec::tryParseEncryptedCTXArgs(encoded, epoch);
     CATCH_REQUIRE(parsed);
     CATCH_REQUIRE(parsed->size() == encryptedArgs.size());
 
     // mismatching epoch throws when constructing BiteCiphertext for args
     CATCH_REQUIRE_THROWS_AS(
-        BiteCodec::tryParseEncryptedCATArgs(encoded, epoch + 1),
+        BiteCodec::tryParseEncryptedCTXArgs(encoded, epoch + 1),
         InvalidStateException);
 }
 #endif

--- a/unittests/bite/BiteEngineTests.cpp
+++ b/unittests/bite/BiteEngineTests.cpp
@@ -131,8 +131,8 @@ DecryptedAESKeys getDecryptedAESKeysForTransaction(
 
     // mimic engine: CAT first (if enabled), otherwise regular BITE1
 #ifdef BITE2
-    if (auto catArgs = BiteEngine::tryGetEncryptedCATArgs(tx, epoch)) {
-        ciphertexts.insert(ciphertexts.end(), catArgs->begin(), catArgs->end());
+    if (auto ctxArgs = BiteEngine::tryGetEncryptedCTXArgs(tx, epoch)) {
+        ciphertexts.insert(ciphertexts.end(), ctxArgs->begin(), ctxArgs->end());
     } else
 #endif
     if (auto regular = BiteEngine::tryGetEncryptedRegularTxFields(tx, epoch)) {
@@ -665,10 +665,10 @@ CATCH_TEST_CASE("BiteEngine decrypts only CAT transactions", "[bite][engine][dec
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
-    CATCH_REQUIRE(decrypted.catTxsMap);
-    CATCH_REQUIRE(decrypted.catTxsMap->size() == 2);
-    CATCH_REQUIRE(decrypted.catTxsMap->count(0) == 1);
-    CATCH_REQUIRE(decrypted.catTxsMap->count(1) == 1);
+    CATCH_REQUIRE(decrypted.ctxTxsMap);
+    CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 2);
+    CATCH_REQUIRE(decrypted.ctxTxsMap->count(0) == 1);
+    CATCH_REQUIRE(decrypted.ctxTxsMap->count(1) == 1);
     CATCH_REQUIRE(decrypted.regularTxsMap->empty());
 }
 #endif
@@ -709,8 +709,8 @@ CATCH_TEST_CASE("BiteEngine decrypts mixed CAT and BITE transactions", "[bite][e
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     // 1 cat decrypted
-    CATCH_REQUIRE(decrypted.catTxsMap);
-    CATCH_REQUIRE(decrypted.catTxsMap->size() == 1);
+    CATCH_REQUIRE(decrypted.ctxTxsMap);
+    CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 1);
     // 1 regular decrypted
     CATCH_REQUIRE(decrypted.regularTxsMap);
     CATCH_REQUIRE(decrypted.regularTxsMap->size() == 1);
@@ -752,8 +752,8 @@ CATCH_TEST_CASE("BiteEngine decrypts treats out of place CAT as regular tx", "[b
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     // no cat decrypted
-    CATCH_REQUIRE(decrypted.catTxsMap);
-    CATCH_REQUIRE(decrypted.catTxsMap->empty());
+    CATCH_REQUIRE(decrypted.ctxTxsMap);
+    CATCH_REQUIRE(decrypted.ctxTxsMap->empty());
     // 1 regular decrypted
     CATCH_REQUIRE(decrypted.regularTxsMap);
     CATCH_REQUIRE(decrypted.regularTxsMap->size() == 1);
@@ -998,16 +998,16 @@ CATCH_TEST_CASE("BiteEngine decrypts CAT with empty ciphertexts at start of list
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
-    CATCH_REQUIRE(decrypted.catTxsMap);
-    CATCH_REQUIRE(decrypted.catTxsMap->size() == 2);
+    CATCH_REQUIRE(decrypted.ctxTxsMap);
+    CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 2);
     // tx 0 should be present with empty args
-    auto it0 = decrypted.catTxsMap->find(0);
-    CATCH_REQUIRE(it0 != decrypted.catTxsMap->end());
+    auto it0 = decrypted.ctxTxsMap->find(0);
+    CATCH_REQUIRE(it0 != decrypted.ctxTxsMap->end());
     CATCH_REQUIRE(it0->second.has_value());
     CATCH_REQUIRE(it0->second->args.empty());
     // tx 1 should have decrypted args
-    auto it1 = decrypted.catTxsMap->find(1);
-    CATCH_REQUIRE(it1 != decrypted.catTxsMap->end());
+    auto it1 = decrypted.ctxTxsMap->find(1);
+    CATCH_REQUIRE(it1 != decrypted.ctxTxsMap->end());
     CATCH_REQUIRE(it1->second.has_value());
     CATCH_REQUIRE(it1->second->args.size() == 2);
 }
@@ -1057,21 +1057,21 @@ CATCH_TEST_CASE("BiteEngine decrypts CAT with empty ciphertexts in middle of lis
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
-    CATCH_REQUIRE(decrypted.catTxsMap);
-    CATCH_REQUIRE(decrypted.catTxsMap->size() == 3);
+    CATCH_REQUIRE(decrypted.ctxTxsMap);
+    CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 3);
     // tx 0 should have 1 decrypted arg
-    auto it0 = decrypted.catTxsMap->find(0);
-    CATCH_REQUIRE(it0 != decrypted.catTxsMap->end());
+    auto it0 = decrypted.ctxTxsMap->find(0);
+    CATCH_REQUIRE(it0 != decrypted.ctxTxsMap->end());
     CATCH_REQUIRE(it0->second.has_value());
     CATCH_REQUIRE(it0->second->args.size() == 1);
     // tx 1 should be present with empty args
-    auto it1 = decrypted.catTxsMap->find(1);
-    CATCH_REQUIRE(it1 != decrypted.catTxsMap->end());
+    auto it1 = decrypted.ctxTxsMap->find(1);
+    CATCH_REQUIRE(it1 != decrypted.ctxTxsMap->end());
     CATCH_REQUIRE(it1->second.has_value());
     CATCH_REQUIRE(it1->second->args.empty());
     // tx 2 should have 2 decrypted args
-    auto it2 = decrypted.catTxsMap->find(2);
-    CATCH_REQUIRE(it2 != decrypted.catTxsMap->end());
+    auto it2 = decrypted.ctxTxsMap->find(2);
+    CATCH_REQUIRE(it2 != decrypted.ctxTxsMap->end());
     CATCH_REQUIRE(it2->second.has_value());
     CATCH_REQUIRE(it2->second->args.size() == 2);
 }
@@ -1121,21 +1121,21 @@ CATCH_TEST_CASE("BiteEngine decrypts CAT with empty ciphertexts at end of list",
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
-    CATCH_REQUIRE(decrypted.catTxsMap);
-    CATCH_REQUIRE(decrypted.catTxsMap->size() == 3);
+    CATCH_REQUIRE(decrypted.ctxTxsMap);
+    CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 3);
     // tx 0 should have 2 decrypted args
-    auto it0 = decrypted.catTxsMap->find(0);
-    CATCH_REQUIRE(it0 != decrypted.catTxsMap->end());
+    auto it0 = decrypted.ctxTxsMap->find(0);
+    CATCH_REQUIRE(it0 != decrypted.ctxTxsMap->end());
     CATCH_REQUIRE(it0->second.has_value());
     CATCH_REQUIRE(it0->second->args.size() == 2);
     // tx 1 should have 1 decrypted arg
-    auto it1 = decrypted.catTxsMap->find(1);
-    CATCH_REQUIRE(it1 != decrypted.catTxsMap->end());
+    auto it1 = decrypted.ctxTxsMap->find(1);
+    CATCH_REQUIRE(it1 != decrypted.ctxTxsMap->end());
     CATCH_REQUIRE(it1->second.has_value());
     CATCH_REQUIRE(it1->second->args.size() == 1);
     // tx 2 should be present with empty args
-    auto it2 = decrypted.catTxsMap->find(2);
-    CATCH_REQUIRE(it2 != decrypted.catTxsMap->end());
+    auto it2 = decrypted.ctxTxsMap->find(2);
+    CATCH_REQUIRE(it2 != decrypted.ctxTxsMap->end());
     CATCH_REQUIRE(it2->second.has_value());
     CATCH_REQUIRE(it2->second->args.empty());
 }
@@ -1164,15 +1164,15 @@ CATCH_TEST_CASE("BiteEngine decrypts only CAT with empty ciphertexts", "[bite][e
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
-    CATCH_REQUIRE(decrypted.catTxsMap);
-    CATCH_REQUIRE(decrypted.catTxsMap->size() == 1);
-    auto it = decrypted.catTxsMap->find(0);
-    CATCH_REQUIRE(it != decrypted.catTxsMap->end());
+    CATCH_REQUIRE(decrypted.ctxTxsMap);
+    CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 1);
+    auto it = decrypted.ctxTxsMap->find(0);
+    CATCH_REQUIRE(it != decrypted.ctxTxsMap->end());
     CATCH_REQUIRE(it->second.has_value());
     CATCH_REQUIRE(it->second->args.empty());
 }
 
-CATCH_TEST_CASE("BiteEngine tryGetEncryptedCATArgs caches SC address as AAD", "[bite][engine][cat][aad]") {
+CATCH_TEST_CASE("BiteEngine tryGetEncryptedCTXArgs caches SC address as AAD", "[bite][engine][cat][aad]") {
     const uint64_t epoch = 20;
     auto keys = generateKeys(1, 1);
     
@@ -1188,7 +1188,7 @@ CATCH_TEST_CASE("BiteEngine tryGetEncryptedCATArgs caches SC address as AAD", "[
     );
     
     // First call should parse and cache
-    auto args = BiteEngine::tryGetEncryptedCATArgs(catTx, epoch);
+    auto args = BiteEngine::tryGetEncryptedCTXArgs(catTx, epoch);
     CATCH_REQUIRE(args != nullptr);
     CATCH_REQUIRE(!args->empty());
     

--- a/unittests/bite/BiteTestUtils.h
+++ b/unittests/bite/BiteTestUtils.h
@@ -96,7 +96,7 @@ inline std::shared_ptr<Transaction> buildBite2Transaction(
     }
 
     // build CAT data field
-    auto dataField = BiteCodec::encodeCATData(serializedEncryptedArgs, plainArgs);
+    auto dataField = BiteCodec::encodeCTXData(serializedEncryptedArgs, plainArgs);
 
     // generate sample tx, and set BITE2 data field
     auto tx = EthTransactionEncoder::generateSampleTx();
@@ -134,7 +134,7 @@ inline std::shared_ptr<Transaction> buildBite2TransactionWithScAddress(
     }
 
     // build CAT data field
-    auto dataField = BiteCodec::encodeCATData(serializedEncryptedArgs, plainArgs);
+    auto dataField = BiteCodec::encodeCTXData(serializedEncryptedArgs, plainArgs);
 
     // generate sample tx with custom SC address
     auto tx = EthTransactionEncoder::generateSampleTx();

--- a/unittests/crypto/TransactionCiphertextsTests.cpp
+++ b/unittests/crypto/TransactionCiphertextsTests.cpp
@@ -48,7 +48,7 @@ CATCH_TEST_CASE("TransactionCiphertexts stores and returns CAT AAD", "[crypto][t
     
     TransactionCiphertexts txCiphertexts(ciphertexts, scAddress);
     
-    CATCH_REQUIRE(txCiphertexts.isCAT());
+    CATCH_REQUIRE(txCiphertexts.isCTX());
     CATCH_REQUIRE(txCiphertexts.count() == 2);
     
     auto aad = txCiphertexts.getScAddressAadTE();
@@ -65,7 +65,7 @@ CATCH_TEST_CASE("TransactionCiphertexts regular tx has no AAD", "[crypto][transa
     
     TransactionCiphertexts txCiphertexts(ciphertext);
     
-    CATCH_REQUIRE_FALSE(txCiphertexts.isCAT());
+    CATCH_REQUIRE_FALSE(txCiphertexts.isCTX());
     CATCH_REQUIRE(txCiphertexts.count() == 1);
     
     auto aad = txCiphertexts.getScAddressAadTE();
@@ -81,7 +81,7 @@ CATCH_TEST_CASE("TransactionCiphertexts CAT with empty ciphertexts still has AAD
     std::vector<ptr<BiteCiphertext>> emptyCiphertexts;
     TransactionCiphertexts txCiphertexts(emptyCiphertexts, scAddress);
     
-    CATCH_REQUIRE(txCiphertexts.isCAT());
+    CATCH_REQUIRE(txCiphertexts.isCTX());
     CATCH_REQUIRE(txCiphertexts.count() == 0);
     
     auto aad = txCiphertexts.getScAddressAadTE();


### PR DESCRIPTION
- Rename all identifiers to CTX to be consistent with skaled naming

Fixes #981 