### PR TITLE
Feature/skaled 2414 add bite2 patch

### DIFF
--- a/bite/BiteEngine.cpp
+++ b/bite/BiteEngine.cpp
@@ -90,8 +90,7 @@ ptr<std::vector<ptr<BiteCiphertext>>> BiteEngine::tryGetEncryptedCTXArgs(
 
 BiteEngine::ParseResult BiteEngine::parseAndCacheBITETransactions(
     const TransactionList& txList,
-    BiteRuntimeContext& runtimeContext,
-    bool isBite2PatchEnabled
+    BiteRuntimeContext& runtimeContext
 ) {
     ParseResult result;
 
@@ -102,7 +101,7 @@ BiteEngine::ParseResult BiteEngine::parseAndCacheBITETransactions(
     std::set<size_t> failedTxIndices;
 
 #ifdef BITE2
-    if ( isBite2PatchEnabled ) {
+    if ( runtimeContext.isBite2PatchEnabled ) {
         // Try parsing CTX transactions first
         for (size_t i = 0 ; i < transactions->size(); i++) {
             try {
@@ -450,8 +449,7 @@ std::shared_ptr<DecryptedAESKeyList> BiteEngine::mergeAESKeys(
 DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
         const TransactionList &_transactionList,
         const DecryptedAESKeyList &_aesKeys,
-        BiteRuntimeContext& runtimeContext,
-        bool isBite2PatchEnabled
+        BiteRuntimeContext& runtimeContext
 ) const {
  
     auto decryptedFieldsMap = std::make_shared<DecryptedRegularTxsMap>();
@@ -488,7 +486,7 @@ DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
             auto tx = txs->at(txIdx);
 
 #ifdef BITE2
-            if ( isBite2PatchEnabled ) {
+            if ( runtimeContext.isBite2PatchEnabled ) {
                 // ---------- Try CTX path first ----------
                 if (!allCTXsParsed) {
                     ptr< std::vector<ptr<BiteCiphertext> > > encryptedArgs;

--- a/bite/BiteEngine.cpp
+++ b/bite/BiteEngine.cpp
@@ -90,7 +90,8 @@ ptr<std::vector<ptr<BiteCiphertext>>> BiteEngine::tryGetEncryptedCTXArgs(
 
 BiteEngine::ParseResult BiteEngine::parseAndCacheBITETransactions(
     const TransactionList& txList,
-    BiteRuntimeContext& runtimeContext
+    BiteRuntimeContext& runtimeContext,
+    bool isBite2PatchEnabled
 ) {
     ParseResult result;
 
@@ -101,28 +102,33 @@ BiteEngine::ParseResult BiteEngine::parseAndCacheBITETransactions(
     std::set<size_t> failedTxIndices;
 
 #ifdef BITE2
-    // Try parsing CTX transactions first
-    for (size_t i = 0 ; i < transactions->size(); i++) {
-        try {
-            auto tx = transactions->at(i);
-            auto ctxArgs = BiteEngine::tryGetEncryptedCTXArgs(tx, runtimeContext.currentEpoch);
+    if ( isBite2PatchEnabled ) {
+        // Try parsing CTX transactions first
+        for (size_t i = 0 ; i < transactions->size(); i++) {
+            try {
+                auto tx = transactions->at(i);
+                auto ctxArgs = BiteEngine::tryGetEncryptedCTXArgs(tx, runtimeContext.currentEpoch);
 
-            if (ctxArgs) {
-                // Fetch the cached SC address for AAD
-                auto scAddressAadTE = tx->getScAddressAadTE();
-                std::optional<AddressBytes> scAddrOpt = scAddressAadTE ? std::make_optional(*scAddressAadTE) : std::nullopt;
-                
-                auto txCiphertexts = make_shared<TransactionCiphertexts>(*ctxArgs, scAddrOpt);
-                result.txsCiphertexts.emplace(i, txCiphertexts);
-            } else {
-                // the first non-CTX transaction indicates the start of regular transactions
-                regularTxsStartIdx = i;
-                break;
+                if (ctxArgs) {
+                    // Fetch the cached SC address for AAD
+                    auto scAddressAadTE = tx->getScAddressAadTE();
+                    std::optional<AddressBytes> scAddrOpt = scAddressAadTE ? std::make_optional(*scAddressAadTE) : std::nullopt;
+
+                    auto txCiphertexts = make_shared<TransactionCiphertexts>(*ctxArgs, scAddrOpt);
+                    result.txsCiphertexts.emplace(i, txCiphertexts);
+                } else {
+                    // the first non-CTX transaction indicates the start of regular transactions
+                    regularTxsStartIdx = i;
+                    break;
+                }
+            } catch (exception &e) {
+                CONS_LOG(err, fmt::format("Could not try to parse as CTX transaction: {}: ", i) + e.what());
+                failedTxIndices.insert(i);
             }
-        } catch (exception &e) {
-            CONS_LOG(err, fmt::format("Could not try to parse as CTX transaction: {}: ", i) + e.what());
-            failedTxIndices.insert(i);
         }
+    } else {
+        // No BITE2 means all txs are regular
+        regularTxsStartIdx = 0;
     }
 #else
     // No BITE2 means all txs are regular

--- a/bite/BiteEngine.cpp
+++ b/bite/BiteEngine.cpp
@@ -450,7 +450,8 @@ std::shared_ptr<DecryptedAESKeyList> BiteEngine::mergeAESKeys(
 DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
         const TransactionList &_transactionList,
         const DecryptedAESKeyList &_aesKeys,
-        BiteRuntimeContext& runtimeContext
+        BiteRuntimeContext& runtimeContext,
+        bool isBite2PatchEnabled
 ) const {
  
     auto decryptedFieldsMap = std::make_shared<DecryptedRegularTxsMap>();
@@ -487,59 +488,61 @@ DecryptedTransactions BiteEngine::decryptTransactionsListInParallel(
             auto tx = txs->at(txIdx);
 
 #ifdef BITE2
-            // ---------- Try CTX path first ----------
-            if (!allCTXsParsed) {
-                ptr< std::vector<ptr<BiteCiphertext> > > encryptedArgs;
-                try { 
-                    encryptedArgs = tryGetEncryptedCTXArgs(tx, runtimeContext.currentEpoch);
-                } catch (const std::exception& e) {
-                    CONS_LOG(warn, fmt::format("Could not try to parse as CTX encrypted transaction during decryption: {}: {}", txIdx, e.what()));
-                }
-                if (encryptedArgs) {
-                    // CTX tx with no encrypted arguments — nothing to decrypt
-                    if (encryptedArgs->empty()) {
-                        std::lock_guard<std::mutex> lock(*ctxTxsMapMutex);
-                        ctxTxsMap->emplace(txIdx, DecryptedCTXArgs{});
+            if ( isBite2PatchEnabled ) {
+                // ---------- Try CTX path first ----------
+                if (!allCTXsParsed) {
+                    ptr< std::vector<ptr<BiteCiphertext> > > encryptedArgs;
+                    try {
+                        encryptedArgs = tryGetEncryptedCTXArgs(tx, runtimeContext.currentEpoch);
+                    } catch (const std::exception& e) {
+                        CONS_LOG(warn, fmt::format("Could not try to parse as CTX encrypted transaction during decryption: {}: {}", txIdx, e.what()));
+                    }
+                    if (encryptedArgs) {
+                        // CTX tx with no encrypted arguments — nothing to decrypt
+                        if (encryptedArgs->empty()) {
+                            std::lock_guard<std::mutex> lock(*ctxTxsMapMutex);
+                            ctxTxsMap->emplace(txIdx, DecryptedCTXArgs{});
+                            continue;
+                        }
+                        auto decryptedAESKey = _aesKeys.getKeys(txIdx);
+                        CHECK_STATE(decryptedAESKey);
+                        CHECK_STATE(encryptedArgs->size() == decryptedAESKey->size());
+
+                        try {
+                            schedule([corePtr = &this->core, encryptedArgs, decryptedAESKey, ctxTxsMap, txIdx, ctxTxsMapMutex]()
+                            -> folly::Unit {
+                                DecryptedCTXArgs decryptedData;
+                                decryptedData.args.reserve(encryptedArgs->size());
+
+                                for (std::size_t argIdx = 0; argIdx < encryptedArgs->size(); ++argIdx) {
+                                    const auto argCiphertext = encryptedArgs->at(argIdx);
+                                    CHECK_STATE(argCiphertext);
+                                    decryptedData.args.push_back(
+                                        BiteCodec::decryptCiphertext(*argCiphertext,
+                                            decryptedAESKey->at(argIdx).getAesKey(),
+                                            *corePtr
+                                        )
+                                    );
+                                }
+
+                                std::lock_guard<std::mutex> lock(*ctxTxsMapMutex);
+                                ctxTxsMap->emplace(txIdx, std::move(decryptedData));
+
+                                return folly::unit;
+                            });
+                        } catch (const std::exception &e) {
+                            CONS_LOG(err, fmt::format("Corrupt CTX tx:{} that doesn't decrypt: {}", txIdx, e.what()));
+                            std::lock_guard<std::mutex> lock(*ctxTxsMapMutex);
+                            ctxTxsMap->emplace(txIdx, std::nullopt);
+                        }
+
+                        // This tx is CTX, do not treat it as regular
                         continue;
                     }
-                    auto decryptedAESKey = _aesKeys.getKeys(txIdx);
-                    CHECK_STATE(decryptedAESKey);
-                    CHECK_STATE(encryptedArgs->size() == decryptedAESKey->size());
-
-                    try {
-                        schedule([corePtr = &this->core, encryptedArgs, decryptedAESKey, ctxTxsMap, txIdx, ctxTxsMapMutex]() 
-                        -> folly::Unit {
-                            DecryptedCTXArgs decryptedData;
-                            decryptedData.args.reserve(encryptedArgs->size());
-
-                            for (std::size_t argIdx = 0; argIdx < encryptedArgs->size(); ++argIdx) {
-                                const auto argCiphertext = encryptedArgs->at(argIdx);
-                                CHECK_STATE(argCiphertext);
-                                decryptedData.args.push_back(
-                                    BiteCodec::decryptCiphertext(*argCiphertext,
-                                        decryptedAESKey->at(argIdx).getAesKey(),
-                                        *corePtr
-                                    )
-                                );
-                            }
-
-                            std::lock_guard<std::mutex> lock(*ctxTxsMapMutex);
-                            ctxTxsMap->emplace(txIdx, std::move(decryptedData));
-
-                            return folly::unit;
-                        });
-                    } catch (const std::exception &e) {
-                        CONS_LOG(err, fmt::format("Corrupt CTX tx:{} that doesn't decrypt: {}", txIdx, e.what()));
-                        std::lock_guard<std::mutex> lock(*ctxTxsMapMutex);
-                        ctxTxsMap->emplace(txIdx, std::nullopt);
+                    else {
+                        // No more CTX transactions expected after the first non-CTX one
+                        allCTXsParsed = true;
                     }
-
-                    // This tx is CTX, do not treat it as regular
-                    continue;
-                }
-                else {
-                    // No more CTX transactions expected after the first non-CTX one
-                    allCTXsParsed = true;
                 }
             }
 

--- a/bite/BiteEngine.h
+++ b/bite/BiteEngine.h
@@ -61,7 +61,8 @@ public:
      */
     static ParseResult parseAndCacheBITETransactions(
         const TransactionList& txList,
-        BiteRuntimeContext& runtimeContext
+        BiteRuntimeContext& runtimeContext,
+        bool isBite2PatchEnabled = false
     );
 
     //=================== Stage 2: Ciphertext Validation  =================== //

--- a/bite/BiteEngine.h
+++ b/bite/BiteEngine.h
@@ -28,7 +28,9 @@ struct BiteConfig {
 struct BiteRuntimeContext {
     epoch_id currentEpoch{0};
     std::shared_ptr<folly::CPUThreadPoolExecutor> threadPoolExecutor{nullptr};
+#ifdef BITE2
     bool isBite2PatchEnabled{false};
+#endif
 };
 
 class BiteEngine {

--- a/bite/BiteEngine.h
+++ b/bite/BiteEngine.h
@@ -28,6 +28,7 @@ struct BiteConfig {
 struct BiteRuntimeContext {
     epoch_id currentEpoch{0};
     std::shared_ptr<folly::CPUThreadPoolExecutor> threadPoolExecutor{nullptr};
+    bool isBite2PatchEnabled{false};
 };
 
 class BiteEngine {
@@ -61,8 +62,7 @@ public:
      */
     static ParseResult parseAndCacheBITETransactions(
         const TransactionList& txList,
-        BiteRuntimeContext& runtimeContext,
-        bool isBite2PatchEnabled
+        BiteRuntimeContext& runtimeContext
     );
 
     //=================== Stage 2: Ciphertext Validation  =================== //
@@ -108,8 +108,7 @@ public:
     DecryptedTransactions decryptTransactionsListInParallel(
             const TransactionList &_transactionList,
             const DecryptedAESKeyList &_aesKeys,
-            BiteRuntimeContext& runtimeContext,
-            bool isBite2PatchEnabled
+            BiteRuntimeContext& runtimeContext
     ) const;
 
     //=================== Helpers =================== //

--- a/bite/BiteEngine.h
+++ b/bite/BiteEngine.h
@@ -62,7 +62,7 @@ public:
     static ParseResult parseAndCacheBITETransactions(
         const TransactionList& txList,
         BiteRuntimeContext& runtimeContext,
-        bool isBite2PatchEnabled = false
+        bool isBite2PatchEnabled
     );
 
     //=================== Stage 2: Ciphertext Validation  =================== //
@@ -108,7 +108,8 @@ public:
     DecryptedTransactions decryptTransactionsListInParallel(
             const TransactionList &_transactionList,
             const DecryptedAESKeyList &_aesKeys,
-            BiteRuntimeContext& runtimeContext
+            BiteRuntimeContext& runtimeContext,
+            bool isBite2PatchEnabled
     ) const;
 
     //=================== Helpers =================== //

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -183,7 +183,8 @@ DecryptedTransactions BiteManager::verifyAndDecryptTransactionList(
     return biteEngine.decryptTransactionsListInParallel(
             _transactionList,
             _aesKeys,
-            runtimeCtx
+            runtimeCtx,
+            schain.bite2Patch( schain.getLastCommittedBlockTimeStamp().getS() )
     );
 }
 

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -54,8 +54,11 @@ void BiteManager::parseBITETransactions(
     ptr<BlockProposal> _proposal) {
 
     BiteRuntimeContext runtimeCtx {
-        .currentEpoch = _proposal->getEpochID(),
+        .currentEpoch = _proposal->getEpochID()
+#ifdef BITE2
+        ,
         .isBite2PatchEnabled = schain.bite2Patch( schain.getLastCommittedBlockTimeStamp().getS() )
+#endif
     };
 
     auto result = BiteEngine::parseAndCacheBITETransactions(*_proposal->getTransactionList(), 
@@ -177,8 +180,11 @@ DecryptedTransactions BiteManager::verifyAndDecryptTransactionList(
 
     BiteRuntimeContext runtimeCtx {
         .currentEpoch = schain.getNode()->getCurrentEpochId(),
-        .threadPoolExecutor = threadPoolExecutor,
+        .threadPoolExecutor = threadPoolExecutor
+#ifdef BITE2
+        ,
         .isBite2PatchEnabled = schain.bite2Patch( schain.getLastCommittedBlockTimeStamp().getS() )
+#endif
     };
 
     return biteEngine.decryptTransactionsListInParallel(

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -54,12 +54,12 @@ void BiteManager::parseBITETransactions(
     ptr<BlockProposal> _proposal) {
 
     BiteRuntimeContext runtimeCtx {
-        .currentEpoch = _proposal->getEpochID()
+        .currentEpoch = _proposal->getEpochID(),
+        .isBite2PatchEnabled = schain.bite2Patch( schain.getLastCommittedBlockTimeStamp().getS() )
     };
 
-    bool isBite2PatchEnabled = schain.bite2Patch( schain.getLastCommittedBlockTimeStamp().getS() );
     auto result = BiteEngine::parseAndCacheBITETransactions(*_proposal->getTransactionList(), 
-                                                runtimeCtx, isBite2PatchEnabled);
+                                                runtimeCtx);
 
     for (auto failedTxIdx : result.failedTransactions) {
         _proposal->getFailedTransactionsRef().emplace(failedTxIdx, 
@@ -177,14 +177,14 @@ DecryptedTransactions BiteManager::verifyAndDecryptTransactionList(
 
     BiteRuntimeContext runtimeCtx {
         .currentEpoch = schain.getNode()->getCurrentEpochId(),
-        .threadPoolExecutor = threadPoolExecutor
+        .threadPoolExecutor = threadPoolExecutor,
+        .isBite2PatchEnabled = schain.bite2Patch( schain.getLastCommittedBlockTimeStamp().getS() )
     };
 
     return biteEngine.decryptTransactionsListInParallel(
             _transactionList,
             _aesKeys,
-            runtimeCtx,
-            schain.bite2Patch( schain.getLastCommittedBlockTimeStamp().getS() )
+            runtimeCtx
     );
 }
 

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -57,8 +57,9 @@ void BiteManager::parseBITETransactions(
         .currentEpoch = _proposal->getEpochID()
     };
 
+    bool isBite2PatchEnabled = schain.bite2Patch( schain.getLastCommittedBlockTimeStamp().getS() );
     auto result = BiteEngine::parseAndCacheBITETransactions(*_proposal->getTransactionList(), 
-                                                runtimeCtx);
+                                                runtimeCtx, isBite2PatchEnabled);
 
     for (auto failedTxIdx : result.failedTransactions) {
         _proposal->getFailedTransactionsRef().emplace(failedTxIdx, 

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -50,7 +50,7 @@ public:
     // Unparsable transactions will be added to failedTransactions.
     // Transactions starting from the magic number but with incorrect format will be added
     // to failedTransactions.
-    static void parseBITETransactions(ptr<BlockProposal> _proposal);
+    void parseBITETransactions(ptr<BlockProposal> _proposal);
 
     // =============== Stage 2: Ciphertext Validation =============== //
 

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -496,6 +496,10 @@ const atomic<bool> &Schain::getIsStateInitialized() const {
     return isStateInitialized;
 }
 
+uint64_t Schain::getVerifyDaSigsPatchTimeStamp() const {
+    return verifyDaSigsPatchTimestamp;
+}
+
 bool Schain::verifyDASigsPatch(uint64_t
 #ifndef BITE
         _blockTimeStampS
@@ -506,6 +510,10 @@ bool Schain::verifyDASigsPatch(uint64_t
 #else
     return verifyDaSigsPatchTimestamp != 0 && _blockTimeStampS >= verifyDaSigsPatchTimestamp;
 #endif
+}
+
+uint64_t Schain::getVerifyBlsSyncPatchTimestampS() const {
+    return verifyBlsSyncPatchTimestamp;
 }
 
 bool Schain::verifyBlsSyncPatch(uint64_t
@@ -519,6 +527,16 @@ bool Schain::verifyBlsSyncPatch(uint64_t
     return verifyBlsSyncPatchTimestamp != 0 && _blockTimeStampS >= verifyBlsSyncPatchTimestamp;
 #endif
 }
+
+#ifdef BITE2
+bool Schain::bite2Patch(uint64_t _blockTimeStampSec) {
+    return bite2PatchTimestamp != 0 && _blockTimeStampSec >= bite2PatchTimestamp;
+}
+
+uint64_t Schain::getBITE2PatchTimestampS() const {
+    return bite2PatchTimestamp;
+}
+#endif
 
 void Schain::blockCommitArrived(block_id _committedBlockID, schain_index _proposerIndex,
                                 const ptr<ThresholdSignature> &_thresholdSig, ptr<ThresholdSignature> _daSig
@@ -1748,14 +1766,6 @@ void Schain::analyzeErrors(ptr<CommittedBlock> _block) {
     }
 }
 
-uint64_t Schain::getVerifyDaSigsPatchTimeStamp() const {
-    return verifyDaSigsPatchTimestamp;
-}
-
-uint64_t Schain::getVerifyBlsSyncPatchTimestampS() const {
-    return verifyBlsSyncPatchTimestamp;
-}
-
 
 mutex Schain::vdsMutex;
 
@@ -1814,6 +1824,7 @@ void Schain::setTimeStampValuesFromConfig() {
     SET_TIMESTAMP_FROM_CONFIG(verifyDaSigsPatchTimestamp)
     SET_TIMESTAMP_FROM_CONFIG(fastConsensusPatchTimestamp)
     SET_TIMESTAMP_FROM_CONFIG(verifyBlsSyncPatchTimestamp)
+    SET_TIMESTAMP_FROM_CONFIG(bite2PatchTimestamp)
 }
 
 uint64_t Schain::getProposalStageTimeMs() {

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1824,7 +1824,9 @@ void Schain::setTimeStampValuesFromConfig() {
     SET_TIMESTAMP_FROM_CONFIG(verifyDaSigsPatchTimestamp)
     SET_TIMESTAMP_FROM_CONFIG(fastConsensusPatchTimestamp)
     SET_TIMESTAMP_FROM_CONFIG(verifyBlsSyncPatchTimestamp)
+#ifdef BITE2
     SET_TIMESTAMP_FROM_CONFIG(bite2PatchTimestamp)
+#endif
 }
 
 uint64_t Schain::getProposalStageTimeMs() {

--- a/chains/Schain.h
+++ b/chains/Schain.h
@@ -214,6 +214,9 @@ class Schain : public Agent {
     uint64_t verifyDaSigsPatchTimestamp = 0;
     uint64_t fastConsensusPatchTimestamp = 0;
     uint64_t verifyBlsSyncPatchTimestamp = 0;
+#ifdef BITE2
+    uint64_t bite2PatchTimestamp = 0;
+#endif
 
     // If a BlockError analyzer is added to the queue
     // its analyze(CommittedBlock _block) function will be run on commit
@@ -411,6 +414,8 @@ public:
 
     uint64_t getVerifyBlsSyncPatchTimestampS() const;
 
+    uint64_t getBITE2PatchTimestampS() const;
+
     bool isInCreateBlock() const;
 
 
@@ -485,6 +490,10 @@ public:
     bool verifyDASigsPatch( uint64_t _blockTimeStampSec );
 
     bool verifyBlsSyncPatch( uint64_t _blockTimeStampSec );
+
+#ifdef BITE2
+    bool bite2Patch( uint64_t _blockTimeStampSec );
+#endif
 
     void updateInternalChainInfo( block_id _lastCommittedBlockID );
 

--- a/datastructures/BlockProposal.cpp
+++ b/datastructures/BlockProposal.cpp
@@ -320,7 +320,7 @@ ptr<BlockProposal> BlockProposal::makeFromNetworkSerialized(
     // we verify sigs when receiving from network
     auto proposal = BlockProposal::deserialize(_serializedProposal, _manager, true);
 #ifdef BITE
-    BiteManager::parseBITETransactions(proposal);
+    _manager->getSchain()->getBiteManager()->parseBITETransactions(proposal);
 #endif
     return proposal;
 }
@@ -331,7 +331,7 @@ ptr<BlockProposal>  BlockProposal::makeFromDBSerialized(
     auto proposal = BlockProposal::deserialize(_serializedProposal, _manager, true);
 
 #ifdef BITE
-    BiteManager::parseBITETransactions(proposal);
+    _manager->getSchain()->getBiteManager()->parseBITETransactions(proposal);
     CHECK_STATE2(proposal->getFailedTransactionsRef().empty(), "Invalid BITE proposal received");
     CHECK_STATE2(proposal->getTransactionCiphertexts(), "Missing encrypted AES keys");
 #endif

--- a/datastructures/MyBlockProposal.cpp
+++ b/datastructures/MyBlockProposal.cpp
@@ -73,7 +73,7 @@ ptr<MyBlockProposal> MyBlockProposal::createMyProposal(
         _proposerIndex, _transactions, _stateRoot, _timeStamp, _timeStampMs, _cryptoManager));
 
 #ifdef BITE
-    BiteManager::parseBITETransactions(proposal);
+    _sChain.getBiteManager()->parseBITETransactions(proposal);
     CHECK_STATE(proposal->getFailedTransactionsRef().empty());
 #endif
     return proposal;

--- a/messages/NetworkMessage.cpp
+++ b/messages/NetworkMessage.cpp
@@ -393,8 +393,10 @@ ptr< NetworkMessage > NetworkMessage::parseMessage(
                 sigShare, srcSchainIndex, ecdsaSig, publicKey, pkSig, _sChain );
         } else if ( type == BasicHeader::BLOCK_SIG_BROADCAST ) {
 #ifdef BITE2
-            if ( d.HasMember( "ofss" ) ) {
-                offchainSigShare = getStringRapid( d, "ofss" );
+            if ( _sChain->bite2Patch( _sChain->getLastCommittedBlockTimeStamp().getS() ) ) {
+                if ( d.HasMember( "ofss" ) ) {
+                    offchainSigShare = getStringRapid( d, "ofss" );
+                }
             }
 #endif
             nwkMsg = make_shared< BlockSignBroadcastMessage >( node_id( srcNodeID ),

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -1052,6 +1052,10 @@ string ConsensusEngine::getDbDir() const {
     return dbDir;
 }
 
+void ConsensusEngine::setTestPatchTimestamps( const std::map< string, uint64_t >& _patchTimestamps ) {
+    patchTimestamps = _patchTimestamps;
+}
+
 void ConsensusEngine::setTestKeys(
     string _serverURL, string _configFile, uint64_t _totalNodes, uint64_t _requiredNodes ) {
     CHECK_STATE( !useTestSGXKeys )

--- a/node/ConsensusEngine.h
+++ b/node/ConsensusEngine.h
@@ -287,6 +287,8 @@ public:
 
     [[nodiscard]] ptr< GlobalThreadRegistry > getThreadRegistry() const;
 
+    void setTestPatchTimestamps( const std::map< string, uint64_t >& _patchTimestamps );
+
     void setTestKeys(
         string _serverURL, string _configFile, uint64_t _totalNodes, uint64_t _requiredNodes );
 

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -328,6 +328,10 @@ void Node::initParamsFromConfig() {
             getParamUint64( "verifyDaSigsPatchTimestamp", 0 );
         patchTimestamps["verifyBlsSyncPatchTimestamp"] =
                 getParamUint64( "verifyBlsSyncPatchTimestamp", 0 );
+#ifdef BITE2
+        patchTimestamps["BITE2PatchTimestamp"] =
+                getParamUint64( "BITE2PatchTimestamp", 0 );
+#endif
     }
 }
 

--- a/protocols/blockconsensus/BlockConsensusAgent.cpp
+++ b/protocols/blockconsensus/BlockConsensusAgent.cpp
@@ -227,8 +227,11 @@ void BlockConsensusAgent::decideBlock(
 
 
 #ifdef BITE2
-        auto offchainSignature = getSchain()->getNode()->getOffchainBlockSigShareDB()->checkAndSaveShareInMemory( 
-            msg->getOffchainSigShare(), getSchain()->getCryptoManager(), _sChainIndex );
+        ptr<ThresholdSignature> offchainSignature;
+        if ( getSchain()->bite2Patch( getSchain()->getLastCommittedBlockTimeStamp().getS() ) ) {
+            offchainSignature = getSchain()->getNode()->getOffchainBlockSigShareDB()->checkAndSaveShareInMemory(
+                        msg->getOffchainSigShare(), getSchain()->getCryptoManager(), _sChainIndex );
+        }
 #endif
 
         getSchain()->getNode()->getNetwork()->broadcastMessage( msg );
@@ -237,12 +240,13 @@ void BlockConsensusAgent::decideBlock(
 
         if ( signature != nullptr ) {
 #ifdef BITE2
-            CHECK_STATE2( offchainSignature, "Merged onchain sig shares, but not enough offchain shares to merge offchain sig" );
-
             // save produced random from offchain signature to DB
-            auto random = Schain::calculateRandomFromSignatureString( offchainSignature->toString() );
-            getSchain()->getNode()->getRandomDB()->writeDomainRandom(
-                blockconsensus::OFFCHAIN_REENCRYPTION_DOMAIN, msg->getBlockId(), random );
+            if ( getSchain()->bite2Patch( getSchain()->getLastCommittedBlockTimeStamp().getS() ) ) {
+                CHECK_STATE2( offchainSignature, "Merged onchain sig shares, but not enough offchain shares to merge offchain sig" );
+                auto random = Schain::calculateRandomFromSignatureString( offchainSignature->toString() );
+                getSchain()->getNode()->getRandomDB()->writeDomainRandom(
+                    blockconsensus::OFFCHAIN_REENCRYPTION_DOMAIN, msg->getBlockId(), random );
+            }
 #endif
 
             getSchain()->finalizeDecidedAndSignedBlock( _blockId, _sChainIndex, signature );
@@ -324,9 +328,12 @@ void BlockConsensusAgent::processBlockSignMessage(
             _message->getBlockProposerIndex() );
 
 #ifdef BITE2
-        auto offchainSignature = getSchain()->getNode()->getOffchainBlockSigShareDB()->checkAndSaveShareInMemory( 
-            _message->getOffchainSigShare(), getSchain()->getCryptoManager(),
-            _message->getBlockProposerIndex() );
+        ptr<ThresholdSignature> offchainSignature;
+        if ( getSchain()->bite2Patch( getSchain()->getLastCommittedBlockTimeStamp().getS() ) ) {
+            offchainSignature = getSchain()->getNode()->getOffchainBlockSigShareDB()->checkAndSaveShareInMemory(
+                _message->getOffchainSigShare(), getSchain()->getCryptoManager(),
+                _message->getBlockProposerIndex() );
+        }
 #endif
 
         if ( signature == nullptr ) {
@@ -334,12 +341,14 @@ void BlockConsensusAgent::processBlockSignMessage(
         }
 
 #ifdef BITE2
-        CHECK_STATE2( offchainSignature, "Merged onchain sig shares, but not enough offchain shares to merge offchain sig" );
+        if ( getSchain()->bite2Patch( getSchain()->getLastCommittedBlockTimeStamp().getS() ) ) {
+            CHECK_STATE2( offchainSignature, "Merged onchain sig shares, but not enough offchain shares to merge offchain sig" );
 
-        // save produced random from offchain signature to DB
-        auto random = Schain::calculateRandomFromSignatureString( offchainSignature->toString() );
-        getSchain()->getNode()->getRandomDB()->writeDomainRandom(
-            blockconsensus::OFFCHAIN_REENCRYPTION_DOMAIN, _message->getBlockId(), random );
+            // save produced random from offchain signature to DB
+            auto random = Schain::calculateRandomFromSignatureString( offchainSignature->toString() );
+            getSchain()->getNode()->getRandomDB()->writeDomainRandom(
+                blockconsensus::OFFCHAIN_REENCRYPTION_DOMAIN, _message->getBlockId(), random );
+        }
 #endif
 
 

--- a/protocols/blockconsensus/BlockSignBroadcastMessage.cpp
+++ b/protocols/blockconsensus/BlockSignBroadcastMessage.cpp
@@ -74,22 +74,24 @@ BlockSignBroadcastMessage::BlockSignBroadcastMessage( block_id _blockID,
     this->sigShareString = sigShare->toString();
 
 #ifdef BITE2
-    // compute additional offchain signature using domain separation.
-    // This signature will be used to derive a random value seen only by validators.
-    auto& signatureDomain = blockconsensus::OFFCHAIN_REENCRYPTION_DOMAIN;
+    if ( schain->bite2Patch( schain->getLastCommittedBlockTimeStamp().getS() ) ) {
+        // compute additional offchain signature using domain separation.
+        // This signature will be used to derive a random value seen only by validators.
+        auto& signatureDomain = blockconsensus::OFFCHAIN_REENCRYPTION_DOMAIN;
 
-    // Compute offchain block sig share as hash( blockHash || signatureDomain )
-    auto data = make_shared< vector< uint8_t > >();
-    const auto& baseHash = hash.getHash();
-    data->reserve( baseHash.size() + signatureDomain.size() );
-    data->insert( data->end(), baseHash.begin(), baseHash.end() );
-    data->insert( data->end(), signatureDomain.begin(), signatureDomain.end() );
-    auto offchainHash = BLAKE3Hash::calculateHash( data );
+        // Compute offchain block sig share as hash( blockHash || signatureDomain )
+        auto data = make_shared< vector< uint8_t > >();
+        const auto& baseHash = hash.getHash();
+        data->reserve( baseHash.size() + signatureDomain.size() );
+        data->insert( data->end(), baseHash.begin(), baseHash.end() );
+        data->insert( data->end(), signatureDomain.begin(), signatureDomain.end() );
+        auto offchainHash = BLAKE3Hash::calculateHash( data );
 
-    // Sign offchain digest and store in message
-    auto offchainSigShare = schain->getCryptoManager()->signBlockSigShare( offchainHash, _blockID );
-    this->offchainSigShareString = offchainSigShare->toString();
-    this->offchainSigShare = offchainSigShare;
+        // Sign offchain digest and store in message
+        auto offchainSigShare = schain->getCryptoManager()->signBlockSigShare( offchainHash, _blockID );
+        this->offchainSigShareString = offchainSigShare->toString();
+        this->offchainSigShare = offchainSigShare;
+    }
 #endif
 }
 

--- a/unittests/bite/BiteEngineTests.cpp
+++ b/unittests/bite/BiteEngineTests.cpp
@@ -325,8 +325,10 @@ CATCH_TEST_CASE("BiteEngine parses BITE txs and reports failures", "[bite][engin
 
     BiteRuntimeContext ctx{
         epoch, 
-        nullptr,
-        true
+        nullptr
+#ifdef BITE2
+        , true
+#endif
     };
 
     auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx);
@@ -350,7 +352,11 @@ CATCH_TEST_CASE("BiteEngine parse fails on epoch mismatch, when tx uses single c
     txVec->push_back(tx);
     TransactionList txList(txVec);
 
-    BiteRuntimeContext ctx{epochTx + 1, nullptr, true};
+    BiteRuntimeContext ctx{epochTx + 1, nullptr
+#ifdef BITE2
+                          , true
+#endif
+                          };
     auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx);
 
     CATCH_REQUIRE(result.txsCiphertexts.size() == 0);
@@ -372,7 +378,11 @@ CATCH_TEST_CASE("BiteEngine ignores non-BITE transactions", "[bite][engine][pars
     txVec->push_back(std::make_shared<Transaction>(encoded, false));
     TransactionList txList(txVec);
 
-    BiteRuntimeContext ctx{0, nullptr, true};
+    BiteRuntimeContext ctx{0, nullptr
+#ifdef BITE2
+                            , true
+#endif
+                          };
     auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx);
 
     CATCH_REQUIRE(result.txsCiphertexts.size() == 0);
@@ -530,7 +540,11 @@ CATCH_TEST_CASE("BiteEngine decrypts regular BITE transactions in parallel - sin
     DecryptedAESKeyList aesKeys;
     aesKeys.addKeys(0, decryptedKeys);
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)
+#ifdef BITE2
+                            , true
+#endif
+                          };
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     CATCH_REQUIRE(decrypted.regularTxsMap);
@@ -579,7 +593,11 @@ CATCH_TEST_CASE("BiteEngine decrypts regular BITE transactions in parallel - mul
     }
 
     TransactionList txList(txsVec);
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)
+#ifdef BITE2
+                            , true
+#endif
+                          };
     auto decrypted = engine.decryptTransactionsListInParallel(txList, decryptedKeysList, ctx);
 
     CATCH_REQUIRE(decrypted.regularTxsMap);
@@ -624,7 +642,11 @@ CATCH_TEST_CASE("BiteEngine decrypts mixed BITE and plaintext transactions", "[b
     DecryptedAESKeyList aesKeys;
     aesKeys.addKeys(0, getDecryptedAESKeysForTransaction(biteTx, keys, 1, 1, epoch));
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)
+#ifdef BITE2
+                            , true
+#endif
+                          };
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     CATCH_REQUIRE(decrypted.regularTxsMap);
@@ -672,7 +694,6 @@ CATCH_TEST_CASE("BiteEngine decrypts only CAT transactions", "[bite][engine][dec
     CATCH_REQUIRE(decrypted.ctxTxsMap->count(1) == 1);
     CATCH_REQUIRE(decrypted.regularTxsMap->empty());
 }
-#endif
 
 CATCH_TEST_CASE("BiteEngine decrypts mixed CAT and BITE transactions", "[bite][engine][decrypt][cat][mixed]") {
     const uint64_t epoch = 11;
@@ -706,7 +727,11 @@ CATCH_TEST_CASE("BiteEngine decrypts mixed CAT and BITE transactions", "[bite][e
     aesKeys.addKeys(0, getDecryptedAESKeysForTransaction(catTx, keys, 1, 1, epoch));
     aesKeys.addKeys(1, getDecryptedAESKeysForTransaction(biteTx, keys, 1, 1, epoch));
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)
+#ifdef BITE2
+                            , true
+#endif
+                          };
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     // 1 cat decrypted
@@ -749,7 +774,11 @@ CATCH_TEST_CASE("BiteEngine decrypts treats out of place CAT as regular tx", "[b
     DecryptedAESKeyList aesKeys;
     aesKeys.addKeys(0, getDecryptedAESKeysForTransaction(biteTx, keys, 1, 1, epoch));
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)
+#ifdef BITE2
+                            , true
+#endif
+                          };
     auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     // no cat decrypted
@@ -761,6 +790,7 @@ CATCH_TEST_CASE("BiteEngine decrypts treats out of place CAT as regular tx", "[b
     CATCH_REQUIRE(decrypted.regularTxsMap->count(0) == 1); // tx 0 decrypted
     CATCH_REQUIRE(decrypted.regularTxsMap->count(1) == 0); // tx 1 not decrypted - regular
 }
+#endif
 
 CATCH_TEST_CASE("BiteEngine decrypt regular tx missing AES keys throws", "[bite][engine][decrypt][error]") {
     const uint64_t epoch = 14;
@@ -782,7 +812,11 @@ CATCH_TEST_CASE("BiteEngine decrypt regular tx missing AES keys throws", "[bite]
 
     DecryptedAESKeyList aesKeys; // no keys
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)
+#ifdef BITE2
+                            , true
+#endif
+                          };
     CATCH_REQUIRE_THROWS(engine.decryptTransactionsListInParallel(txList, aesKeys, ctx));
 }
 

--- a/unittests/bite/BiteEngineTests.cpp
+++ b/unittests/bite/BiteEngineTests.cpp
@@ -325,10 +325,11 @@ CATCH_TEST_CASE("BiteEngine parses BITE txs and reports failures", "[bite][engin
 
     BiteRuntimeContext ctx{
         epoch, 
-        nullptr
+        nullptr,
+        true
     };
 
-    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx, true);
+    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx);
 
     CATCH_REQUIRE(result.txsCiphertexts.size() == 2);
     CATCH_REQUIRE(result.txsCiphertexts.totalCiphertextCount() == 2);
@@ -349,8 +350,8 @@ CATCH_TEST_CASE("BiteEngine parse fails on epoch mismatch, when tx uses single c
     txVec->push_back(tx);
     TransactionList txList(txVec);
 
-    BiteRuntimeContext ctx{epochTx + 1, nullptr};
-    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx, true);
+    BiteRuntimeContext ctx{epochTx + 1, nullptr, true};
+    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx);
 
     CATCH_REQUIRE(result.txsCiphertexts.size() == 0);
     CATCH_REQUIRE(result.failedTransactions.size() == 1);
@@ -371,8 +372,8 @@ CATCH_TEST_CASE("BiteEngine ignores non-BITE transactions", "[bite][engine][pars
     txVec->push_back(std::make_shared<Transaction>(encoded, false));
     TransactionList txList(txVec);
 
-    BiteRuntimeContext ctx{0, nullptr};
-    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx, true);
+    BiteRuntimeContext ctx{0, nullptr, true};
+    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx);
 
     CATCH_REQUIRE(result.txsCiphertexts.size() == 0);
     CATCH_REQUIRE(result.failedTransactions.empty());
@@ -529,8 +530,8 @@ CATCH_TEST_CASE("BiteEngine decrypts regular BITE transactions in parallel - sin
     DecryptedAESKeyList aesKeys;
     aesKeys.addKeys(0, decryptedKeys);
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     CATCH_REQUIRE(decrypted.regularTxsMap);
     CATCH_REQUIRE(decrypted.regularTxsMap->size() == 1);
@@ -578,8 +579,8 @@ CATCH_TEST_CASE("BiteEngine decrypts regular BITE transactions in parallel - mul
     }
 
     TransactionList txList(txsVec);
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, decryptedKeysList, ctx, true);
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, decryptedKeysList, ctx);
 
     CATCH_REQUIRE(decrypted.regularTxsMap);
     CATCH_REQUIRE(decrypted.regularTxsMap->size() == numTxs);
@@ -623,8 +624,8 @@ CATCH_TEST_CASE("BiteEngine decrypts mixed BITE and plaintext transactions", "[b
     DecryptedAESKeyList aesKeys;
     aesKeys.addKeys(0, getDecryptedAESKeysForTransaction(biteTx, keys, 1, 1, epoch));
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     CATCH_REQUIRE(decrypted.regularTxsMap);
     CATCH_REQUIRE(decrypted.regularTxsMap->size() == 1);
@@ -662,8 +663,8 @@ CATCH_TEST_CASE("BiteEngine decrypts only CAT transactions", "[bite][engine][dec
     aesKeys.addKeys(0, getDecryptedAESKeysForTransaction(catTx1, keys, 1, 1, epoch));
     aesKeys.addKeys(1, getDecryptedAESKeysForTransaction(catTx2, keys, 1, 1, epoch));
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     CATCH_REQUIRE(decrypted.ctxTxsMap);
     CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 2);
@@ -705,8 +706,8 @@ CATCH_TEST_CASE("BiteEngine decrypts mixed CAT and BITE transactions", "[bite][e
     aesKeys.addKeys(0, getDecryptedAESKeysForTransaction(catTx, keys, 1, 1, epoch));
     aesKeys.addKeys(1, getDecryptedAESKeysForTransaction(biteTx, keys, 1, 1, epoch));
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     // 1 cat decrypted
     CATCH_REQUIRE(decrypted.ctxTxsMap);
@@ -748,8 +749,8 @@ CATCH_TEST_CASE("BiteEngine decrypts treats out of place CAT as regular tx", "[b
     DecryptedAESKeyList aesKeys;
     aesKeys.addKeys(0, getDecryptedAESKeysForTransaction(biteTx, keys, 1, 1, epoch));
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     // no cat decrypted
     CATCH_REQUIRE(decrypted.ctxTxsMap);
@@ -781,8 +782,8 @@ CATCH_TEST_CASE("BiteEngine decrypt regular tx missing AES keys throws", "[bite]
 
     DecryptedAESKeyList aesKeys; // no keys
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    CATCH_REQUIRE_THROWS(engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true));
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    CATCH_REQUIRE_THROWS(engine.decryptTransactionsListInParallel(txList, aesKeys, ctx));
 }
 
 #ifdef BITE2
@@ -808,8 +809,8 @@ CATCH_TEST_CASE("BiteEngine decrypt throws on CAT AES key count mismatch", "[bit
     // CAT tx has 2 ciphertexts; provide only 1 key to force count mismatch
     aesKeys.addKeys(0, makeDecryptedKeys(1, 0x01));
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    CATCH_REQUIRE_THROWS(engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true));
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    CATCH_REQUIRE_THROWS(engine.decryptTransactionsListInParallel(txList, aesKeys, ctx));
 }
 #endif
 
@@ -995,8 +996,8 @@ CATCH_TEST_CASE("BiteEngine decrypts CAT with empty ciphertexts at start of list
     // No keys for tx 0 (empty ciphertexts)
     aesKeys.addKeys(1, getDecryptedAESKeysForTransaction(validCat, keys, 1, 1, epoch));
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     CATCH_REQUIRE(decrypted.ctxTxsMap);
     CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 2);
@@ -1054,8 +1055,8 @@ CATCH_TEST_CASE("BiteEngine decrypts CAT with empty ciphertexts in middle of lis
     // No keys for tx 1 (empty ciphertexts)
     aesKeys.addKeys(2, getDecryptedAESKeysForTransaction(cat2, keys, 1, 1, epoch));
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     CATCH_REQUIRE(decrypted.ctxTxsMap);
     CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 3);
@@ -1118,8 +1119,8 @@ CATCH_TEST_CASE("BiteEngine decrypts CAT with empty ciphertexts at end of list",
     aesKeys.addKeys(1, getDecryptedAESKeysForTransaction(cat1, keys, 1, 1, epoch));
     // No keys for tx 2 (empty ciphertexts)
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     CATCH_REQUIRE(decrypted.ctxTxsMap);
     CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 3);
@@ -1161,8 +1162,8 @@ CATCH_TEST_CASE("BiteEngine decrypts only CAT with empty ciphertexts", "[bite][e
 
     DecryptedAESKeyList aesKeys; // no keys needed
 
-    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
+    BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2), true};
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
 
     CATCH_REQUIRE(decrypted.ctxTxsMap);
     CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 1);

--- a/unittests/bite/BiteEngineTests.cpp
+++ b/unittests/bite/BiteEngineTests.cpp
@@ -328,7 +328,7 @@ CATCH_TEST_CASE("BiteEngine parses BITE txs and reports failures", "[bite][engin
         nullptr
     };
 
-    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx);
+    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx, true);
 
     CATCH_REQUIRE(result.txsCiphertexts.size() == 2);
     CATCH_REQUIRE(result.txsCiphertexts.totalCiphertextCount() == 2);
@@ -350,7 +350,7 @@ CATCH_TEST_CASE("BiteEngine parse fails on epoch mismatch, when tx uses single c
     TransactionList txList(txVec);
 
     BiteRuntimeContext ctx{epochTx + 1, nullptr};
-    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx);
+    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx, true);
 
     CATCH_REQUIRE(result.txsCiphertexts.size() == 0);
     CATCH_REQUIRE(result.failedTransactions.size() == 1);
@@ -372,7 +372,7 @@ CATCH_TEST_CASE("BiteEngine ignores non-BITE transactions", "[bite][engine][pars
     TransactionList txList(txVec);
 
     BiteRuntimeContext ctx{0, nullptr};
-    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx);
+    auto result = BiteEngine::parseAndCacheBITETransactions(txList, ctx, true);
 
     CATCH_REQUIRE(result.txsCiphertexts.size() == 0);
     CATCH_REQUIRE(result.failedTransactions.empty());
@@ -530,7 +530,7 @@ CATCH_TEST_CASE("BiteEngine decrypts regular BITE transactions in parallel - sin
     aesKeys.addKeys(0, decryptedKeys);
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
 
     CATCH_REQUIRE(decrypted.regularTxsMap);
     CATCH_REQUIRE(decrypted.regularTxsMap->size() == 1);
@@ -579,7 +579,7 @@ CATCH_TEST_CASE("BiteEngine decrypts regular BITE transactions in parallel - mul
 
     TransactionList txList(txsVec);
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, decryptedKeysList, ctx);
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, decryptedKeysList, ctx, true);
 
     CATCH_REQUIRE(decrypted.regularTxsMap);
     CATCH_REQUIRE(decrypted.regularTxsMap->size() == numTxs);
@@ -624,7 +624,7 @@ CATCH_TEST_CASE("BiteEngine decrypts mixed BITE and plaintext transactions", "[b
     aesKeys.addKeys(0, getDecryptedAESKeysForTransaction(biteTx, keys, 1, 1, epoch));
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
 
     CATCH_REQUIRE(decrypted.regularTxsMap);
     CATCH_REQUIRE(decrypted.regularTxsMap->size() == 1);
@@ -663,7 +663,7 @@ CATCH_TEST_CASE("BiteEngine decrypts only CAT transactions", "[bite][engine][dec
     aesKeys.addKeys(1, getDecryptedAESKeysForTransaction(catTx2, keys, 1, 1, epoch));
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
 
     CATCH_REQUIRE(decrypted.ctxTxsMap);
     CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 2);
@@ -706,7 +706,7 @@ CATCH_TEST_CASE("BiteEngine decrypts mixed CAT and BITE transactions", "[bite][e
     aesKeys.addKeys(1, getDecryptedAESKeysForTransaction(biteTx, keys, 1, 1, epoch));
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
 
     // 1 cat decrypted
     CATCH_REQUIRE(decrypted.ctxTxsMap);
@@ -749,7 +749,7 @@ CATCH_TEST_CASE("BiteEngine decrypts treats out of place CAT as regular tx", "[b
     aesKeys.addKeys(0, getDecryptedAESKeysForTransaction(biteTx, keys, 1, 1, epoch));
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
 
     // no cat decrypted
     CATCH_REQUIRE(decrypted.ctxTxsMap);
@@ -782,7 +782,7 @@ CATCH_TEST_CASE("BiteEngine decrypt regular tx missing AES keys throws", "[bite]
     DecryptedAESKeyList aesKeys; // no keys
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    CATCH_REQUIRE_THROWS(engine.decryptTransactionsListInParallel(txList, aesKeys, ctx));
+    CATCH_REQUIRE_THROWS(engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true));
 }
 
 #ifdef BITE2
@@ -809,7 +809,7 @@ CATCH_TEST_CASE("BiteEngine decrypt throws on CAT AES key count mismatch", "[bit
     aesKeys.addKeys(0, makeDecryptedKeys(1, 0x01));
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    CATCH_REQUIRE_THROWS(engine.decryptTransactionsListInParallel(txList, aesKeys, ctx));
+    CATCH_REQUIRE_THROWS(engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true));
 }
 #endif
 
@@ -996,7 +996,7 @@ CATCH_TEST_CASE("BiteEngine decrypts CAT with empty ciphertexts at start of list
     aesKeys.addKeys(1, getDecryptedAESKeysForTransaction(validCat, keys, 1, 1, epoch));
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
 
     CATCH_REQUIRE(decrypted.ctxTxsMap);
     CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 2);
@@ -1055,7 +1055,7 @@ CATCH_TEST_CASE("BiteEngine decrypts CAT with empty ciphertexts in middle of lis
     aesKeys.addKeys(2, getDecryptedAESKeysForTransaction(cat2, keys, 1, 1, epoch));
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
 
     CATCH_REQUIRE(decrypted.ctxTxsMap);
     CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 3);
@@ -1119,7 +1119,7 @@ CATCH_TEST_CASE("BiteEngine decrypts CAT with empty ciphertexts at end of list",
     // No keys for tx 2 (empty ciphertexts)
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
 
     CATCH_REQUIRE(decrypted.ctxTxsMap);
     CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 3);
@@ -1162,7 +1162,7 @@ CATCH_TEST_CASE("BiteEngine decrypts only CAT with empty ciphertexts", "[bite][e
     DecryptedAESKeyList aesKeys; // no keys needed
 
     BiteRuntimeContext ctx{epoch, std::make_shared<folly::CPUThreadPoolExecutor>(2)};
-    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx);
+    auto decrypted = engine.decryptTransactionsListInParallel(txList, aesKeys, ctx, true);
 
     CATCH_REQUIRE(decrypted.ctxTxsMap);
     CATCH_REQUIRE(decrypted.ctxTxsMap->size() == 1);

--- a/unittests/db/ReencryptionRandomConsensusTests.cpp
+++ b/unittests/db/ReencryptionRandomConsensusTests.cpp
@@ -90,6 +90,9 @@ void configureTestEnvironment( bool _cleanDataDir, const string& _configDir ) {
  */
 block_id startEngineAndWait( ConsensusEngine*& engine, int64_t lastId, uint64_t runTimeS ) {
     engine = new ConsensusEngine( lastId, 1000000000 );
+#ifdef BITE2
+    engine->setTestPatchTimestamps( { { "bite2PatchTimestamp", 1 } } );
+#endif
     engine->parseTestConfigsAndCreateAllNodes( Consensust::getConfigDirPath(), lastId == -1 );
     engine->slowStartBootStrapTest();
     
@@ -249,8 +252,12 @@ CATCH_TEST_CASE(
         CATCH_REQUIRE( lastId > 0 );
         
         uint64_t checkedBlocks = 0;
+        uint64_t startBlock = 1;
+#ifdef BITE2
+        startBlock = 2;
+#endif
         
-        for ( uint64_t blockId = 1; blockId <= lastId; blockId++ ) {
+        for ( uint64_t blockId = startBlock; blockId <= lastId; blockId++ ) {
             try {
                 // For same committed block id, compare:
                 // getReencryptionRandomForBlockId(id) vs getRandomForBlockId(id)


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/2414

introduced `bite2PatchTimestamp`, which is activated once block timestamp reaches `T`. moved some logic under `if( BITE2_PATCH_ENABLED )` clauses to avoid different behavior and state divergence on nodes that run update in different time.