### PR TITLE
skaled-2420 add pricing validation

### DIFF
--- a/pricing/PricingAgent.cpp
+++ b/pricing/PricingAgent.cpp
@@ -56,6 +56,12 @@ PricingAgent::PricingAgent( Schain& _sChain ) : Agent( _sChain, false ) {
             string( "dynamicPricingMinPrice" ), DEFAULT_MIN_PRICE );
         u256 maxPrice =
             sChain->getNode()->getParamUint64( "dynamicPricingMaxPrice", 1000000000 );
+
+        if ( minPrice > maxPrice ) {
+            BOOST_THROW_EXCEPTION( ParsingException(
+                "dynamicPricingMinPrice > dynamicPricingMaxPrice", __CLASS_NAME__ ) );
+        }
+
         uint64_t optimalLoadPercentage =
             sChain->getNode()->getParamUint64( "dynamicPricingOptimalLoadPercentage", 70 );
         uint64_t adjustmentSpeed =


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/2420

throw an error if `minGasPrice > maxGasPrice`. in this case consensus agent should not start