### PR TITLE
Bite consensus db restart with bite2 blocks fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,15 +339,16 @@ file(GLOB_RECURSE COMMON_TEST_SOURCES
         "tests/unit/db/*.cpp"
         "tests/consensus_tests.cpp"
         "tests/sgx_tests.cpp"
+        "tests/e2e/RestartBootstrapTests.cpp"
 )
 
 set(TEST_SOURCES ${COMMON_TEST_SOURCES})
 
 # Conditionally add rlp test sources if BITE is enabled
 if (DEFINED BITE)
-    file(GLOB_RECURSE BITE_TEST_SOURCES 
-        "tests/unit/bite/*.cpp"
-        "tests/e2e/ReencryptionRandomConsensusTests.cpp"
+    file(GLOB_RECURSE BITE_TEST_SOURCES "tests/unit/bite/*.cpp")
+    list(APPEND BITE_TEST_SOURCES
+        "tests/e2e/bite/ReencryptionRandomConsensusTests.cpp"
     )
     list(APPEND TEST_SOURCES ${BITE_TEST_SOURCES} libBLS/test/utils.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,9 +346,9 @@ set(TEST_SOURCES ${COMMON_TEST_SOURCES})
 
 # Conditionally add rlp test sources if BITE is enabled
 if (DEFINED BITE)
-    file(GLOB_RECURSE BITE_TEST_SOURCES "tests/unit/bite/*.cpp")
-    list(APPEND BITE_TEST_SOURCES
-        "tests/e2e/bite/ReencryptionRandomConsensusTests.cpp"
+    file(GLOB_RECURSE BITE_TEST_SOURCES 
+        "tests/unit/bite/*.cpp"
+        "tests/e2e/bite/*.cpp"
     )
     list(APPEND TEST_SOURCES ${BITE_TEST_SOURCES} libBLS/test/utils.cpp)
 

--- a/Consensust.h
+++ b/Consensust.h
@@ -53,9 +53,7 @@ public:
 class StartFromScratch {
 public:
     StartFromScratch() {
-        int i = system( "rm -rf /tmp/*.db.*" );
-        i = system( "rm -rf /tmp/*.db" );
-        i++;  // make compiler happy
+        system( "rm -rf /tmp/*.db" );
         Consensust::setConfigDirPath( boost::filesystem::system_complete( "." ) );
 
 #ifdef GOOGLE_PROFILE

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1303,9 +1303,20 @@ void Schain::bootstrap(block_id _lastCommittedBlockID, uint64_t _lastCommittedBl
                 _lastCommittedBlockTimeStamp = block->getTimeStampS();
                 _lastCommittedBlockTimeStampMs = block->getTimeStampMs();
                 CONS_LOG(info, "Pushed block to skaled:" << _lastCommittedBlockID);
+            } catch ( exception& e ) {
+                // Cant read the block from db, may be it is corrupt in the  snapshot
+                CONS_LOG(err,
+                    "Bootstrap could not read block "
+                        << (uint64_t) ( _lastCommittedBlockID + 1 )
+                        << " from db. Repair. Exception: " << e.what());
+                SkaleException::logNested(e);
+                // The block will be hopefully pulled by catchup
             } catch (...) {
                 // Cant read the block from db, may be it is corrupt in the  snapshot
-                CONS_LOG(err, "Bootstrap could not read block from db. Repair.");
+                CONS_LOG(err,
+                    "Bootstrap could not read block "
+                        << (uint64_t) ( _lastCommittedBlockID + 1 )
+                        << " from db. Repair. Exception: unknown");
                 // The block will be hopefully pulled by catchup
             }
     }

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1273,7 +1273,7 @@ void Schain::bootstrap(block_id _lastCommittedBlockID, uint64_t _lastCommittedBl
             try {
                 bool isBite2PatchEnabledForBlock = false;
 #ifdef BITE
-                isBite2PatchEnabledForBlock = bite2Patch( getLastCommittedBlockTimeStamp().getS() );
+                isBite2PatchEnabledForBlock = bite2Patch( _lastCommittedBlockTimeStamp );
 #endif
                 auto block = getNode()->getBlockDB()->getBlock(
                     _lastCommittedBlockID + 1, getCryptoManager() );

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -153,6 +153,6 @@ unitTest(
 )
 
 
-# fullConsensusTest("onenode", consensustExecutive, "[consensus-basic]")
-# fullConsensusTest("twonodes", consensustExecutive, "[consensus-basic]")
-# fullConsensusTest("fournodes", consensustExecutive, "[consensus-basic]")
+fullConsensusTest("onenode", consensustExecutive, "[consensus-basic]")
+fullConsensusTest("twonodes", consensustExecutive, "[consensus-basic]")
+fullConsensusTest("fournodes", consensustExecutive, "[consensus-basic]")

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -26,63 +26,133 @@ import os
 import subprocess
 
 
-def run_without_check(_command):
-    print(">" + _command)
-    subprocess.call(_command, shell=True)
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
 
 
-def run(_command):
+def print_separator(_label, _char="="):
+    line = _char * 80
+    print("\n" + line)
+    print(_label)
+    print(line)
+
+
+def normalize_catch_expression(_testType):
+    if len(_testType) >= 2 and _testType[0] == _testType[-1] and _testType[0] in ("'", '"'):
+        return _testType[1:-1]
+    return _testType
+
+
+def list_catch_test_names(_consensustExecutive, _testType):
+    result = subprocess.run(
+        [_consensustExecutive, normalize_catch_expression(_testType), "--list-test-names-only"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    test_names = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if len(test_names) == 0:
+        error_output = result.stderr.strip()
+        raise RuntimeError(
+            "Could not list Catch tests for {} (exit code {}): {}".format(
+                _testType,
+                result.returncode,
+                error_output or "no tests matched",
+            )
+        )
+    return test_names
+
+
+def run(_command, _label=None):
+    if _label:
+        print_separator(_label)
     print(">" + _command)
     subprocess.check_call(_command, shell=True)
 
 
-def unitTest(_consensustExecutive, _testType):
-    run("rm -f ./core")
-    run(_consensustExecutive + " " + _testType)
+def run_args(_command, _label=None):
+    if _label:
+        print_separator(_label)
+    print(">" + " ".join(_command))
+    subprocess.check_call(_command)
+
+
+def run_catch_tests(_consensustExecutive, _testType, _label):
+    # By default, split catch tests into separate runs
+    # There are currently static variables that bleed state between tests
+    # if we try running all under the same catch session, causing tests to fail
+
+    test_names = list_catch_test_names(_consensustExecutive, _testType)
+    if len(test_names) == 0:
+        raise RuntimeError("No Catch tests matched: " + _testType)
+    print_separator(_label + " (" + str(len(test_names)) + " cases)")
+
+    for index, test_name in enumerate(test_names, 1):
+        run_args(
+            # use '"' delimiters to ensure test names with commas are treated as a single argument
+            [_consensustExecutive, '"' + test_name + '"'],
+            "[{}/{}] {}".format(index, len(test_names), test_name),
+        )
+
+
+def unitTest(_consensustExecutive, _testType, _label=None):
+    label = _label or _testType
+    run("rm -f ./core", "Cleanup for " + label)
+    run_catch_tests(_consensustExecutive, _testType, "Catch tests: " + label)
 
 
 def fullConsensusTest(_test, _consensustExecutive, _testType):
-    testDir = "test/" + _test
+    testDir = os.path.join(REPO_ROOT, "test", _test)
     os.chdir(testDir)
-    run("pwd")
-    run("rm -rf " + testDir + "/core")
-    run("rm -rf /tmp/*.db*")
-    run(_consensustExecutive + " " + _testType)
-    os.chdir("../..")
+    run("pwd", "Entering " + testDir)
+    run("rm -rf ./core", "Cleanup core files for " + _test)
+    run("rm -rf /tmp/*.db*", "Cleanup db files for " + _test)
+    run_catch_tests(
+        _consensustExecutive,
+        _testType,
+        "Consensus test: " + _test + " " + _testType,
+    )
+    os.chdir(REPO_ROOT)
 
 
 def getConsensustExecutive():
-    run_without_check("cp -f cmake-build-debug/consensust /tmp/consensust")
-    run_without_check("cp -f build/consensust /tmp/consensust")
-    consensustExecutive = "/tmp/consensust"
-    return consensustExecutive
+    candidates = [
+        os.path.join(REPO_ROOT, "cmake-build-debug", "consensust"),
+        os.path.join(REPO_ROOT, "build", "consensust"),
+    ]
+
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+
+    raise RuntimeError(
+        "Could not find consensust binary. Looked in: {}".format(", ".join(candidates))
+    )
 
 
 print("Starting tests.")
 
-os.chdir("..")
+os.chdir(REPO_ROOT)
 
 run("ccache -M 20G")
 
 consensustExecutive = getConsensustExecutive()
 
 # Run all non-end-to-end and non-performance unit tests
-unitTest(consensustExecutive, "~[end-to-end]~[performance]")
-unitTest(consensustExecutive, "'[end-to-end][db]'")
+unitTest(
+    consensustExecutive,
+    "~[end-to-end]~[performance]",
+    "Non-end-to-end non-performance",
+)
+
+unitTest(
+    consensustExecutive,
+    "'[end-to-end][db]'",
+    "End-to-end db tests",
+)
 
 
-# fullConsensusTest("sixteennodes", consensustExecutive, "[consensus-finalization-download]")
-
-# try:
-#    fullConsensusTest("two_out_of_four", consensustExecutive, "[consensus-stuck]")
-# except:
-#    print("Success")
-
-
-fullConsensusTest("onenode", consensustExecutive, "[consensus-basic]")
-fullConsensusTest("twonodes", consensustExecutive, "[consensus-basic]")
-fullConsensusTest("fournodes", consensustExecutive, "[consensus-basic]")
-#fullConsensusTest("sixteennodes", consensustExecutive, "[consensus-basic]")
-#fullConsensusTest("fournodes_catchup", consensustExecutive, "[consensus-basic]")
-#fullConsensusTest("three_out_of_four", consensustExecutive, "[consensus-basic]")
-
+# fullConsensusTest("onenode", consensustExecutive, "[consensus-basic]")
+# fullConsensusTest("twonodes", consensustExecutive, "[consensus-basic]")
+# fullConsensusTest("fournodes", consensustExecutive, "[consensus-basic]")

--- a/tests/e2e/ConsensusEngineTestAccess.h
+++ b/tests/e2e/ConsensusEngineTestAccess.h
@@ -6,6 +6,14 @@
 
 class ConsensusEngineTestAccess {
 public:
+    static node_id getFirstNodeId( const ConsensusEngine& e ) {
+        CHECK_STATE( e.nodes.size() > 0 );
+        auto it = e.nodes.begin();
+        CHECK_STATE( it != e.nodes.end() );
+        CHECK_STATE( it->second );
+        return it->first;
+    }
+
     static ptr<CommittedBlock> getCommittedBlockForBlockId(
         const ConsensusEngine& e, uint64_t id) {
 
@@ -41,5 +49,45 @@ public:
         CHECK_STATE( block );
         return block;
 
+    }
+
+    static uint64_t getBootstrapBlockIDForNode( const ConsensusEngine& e, node_id node ) {
+        auto it = e.nodes.find( node );
+        CHECK_STATE2( it != e.nodes.end(), "Node with id " + to_string( node ) + " not found" );
+        CHECK_STATE( it->second );
+        auto schain = it->second->getSchain();
+        CHECK_STATE( schain );
+        return (uint64_t) schain->getBootstrapBlockID();
+    }
+
+    static uint64_t getBootstrapBlockID( const ConsensusEngine& e ) {
+        return getBootstrapBlockIDForNode( e, getFirstNodeId( e ) );
+    }
+
+    static block_id getCurrentLastCommittedBlockIDForNode( const ConsensusEngine& e, node_id node ) {
+        auto it = e.nodes.find( node );
+        CHECK_STATE2( it != e.nodes.end(), "Node with id " + to_string( node ) + " not found" );
+        CHECK_STATE( it->second );
+        auto schain = it->second->getSchain();
+        CHECK_STATE( schain );
+        return schain->getLastCommittedBlockID();
+    }
+
+    static block_id getCurrentLastCommittedBlockID( const ConsensusEngine& e ) {
+        return getCurrentLastCommittedBlockIDForNode( e, getFirstNodeId( e ) );
+    }
+
+    static TimeStamp getCurrentLastCommittedBlockTimeStampForNode(
+        const ConsensusEngine& e, node_id node ) {
+        auto it = e.nodes.find( node );
+        CHECK_STATE2( it != e.nodes.end(), "Node with id " + to_string( node ) + " not found" );
+        CHECK_STATE( it->second );
+        auto schain = it->second->getSchain();
+        CHECK_STATE( schain );
+        return schain->getLastCommittedBlockTimeStamp();
+    }
+
+    static TimeStamp getCurrentLastCommittedBlockTimeStamp( const ConsensusEngine& e ) {
+        return getCurrentLastCommittedBlockTimeStampForNode( e, getFirstNodeId( e ) );
     }
 };

--- a/tests/e2e/E2ETestHelper.h
+++ b/tests/e2e/E2ETestHelper.h
@@ -38,6 +38,7 @@ public:
     inline static const string TWO_NODE_TEST_DATA_DIR = TEST_DATA_ROOT_DIR + "/twonodes_sameip";
     static constexpr uint64_t DEFAULT_RUN_TIME_S = 4;
     static constexpr uint64_t CROSS_NODE_RUN_TIME_S = 20;
+    static constexpr uint64_t DEFAULT_STORAGE_LIMIT_BYTES = 1000000000;
 
     static void configureTestEnvironment(
         bool _cleanDataDir,
@@ -64,6 +65,38 @@ public:
         setTestEnvVar( "TEST_TIME_S", "4", 0 );
     }
 
+    static void startEngine(
+        ConsensusEngine*& _engine,
+        int64_t _lastId,
+        const std::map< string, uint64_t >& _patchTimestamps = {
+#ifdef BITE
+            { "bite2PatchTimestamp", 0 }
+#endif
+        },
+        ConsensusExtFace* _extFace = nullptr,
+        uint64_t _lastCommittedBlockTimeStamp = 0,
+        uint64_t _lastCommittedBlockTimeStampMs = 0,
+        bool _useBlockIDFromConsensus = false ) {
+        CATCH_REQUIRE( _engine == nullptr );
+
+        if ( _extFace != nullptr ) {
+            CATCH_REQUIRE( _lastId >= 0 );
+            _engine = new ConsensusEngine( *_extFace, (uint64_t) _lastId,
+                _lastCommittedBlockTimeStamp, _lastCommittedBlockTimeStampMs, _patchTimestamps,
+                DEFAULT_STORAGE_LIMIT_BYTES );
+        } else {
+            _engine = new ConsensusEngine( _lastId, DEFAULT_STORAGE_LIMIT_BYTES );
+            if ( !_patchTimestamps.empty() ) {
+                _engine->setTestPatchTimestamps( _patchTimestamps );
+            }
+        }
+
+        auto useBlockIdFromConsensus = _useBlockIDFromConsensus || ( _extFace == nullptr && _lastId == -1 );
+        _engine->parseTestConfigsAndCreateAllNodes(
+            Consensust::getConfigDirPath(), useBlockIdFromConsensus );
+        _engine->slowStartBootStrapTest();
+    }
+
     static block_id startEngineAndWait(
         ConsensusEngine*& _engine,
         int64_t _lastId,
@@ -73,12 +106,7 @@ public:
             { "bite2PatchTimestamp", 0 }
 #endif 
         } ) {
-        _engine = new ConsensusEngine( _lastId, 1000000000 );
-        if ( !_patchTimestamps.empty() ) {
-            _engine->setTestPatchTimestamps( _patchTimestamps );
-        }
-        _engine->parseTestConfigsAndCreateAllNodes( Consensust::getConfigDirPath(), _lastId == -1 );
-        _engine->slowStartBootStrapTest();
+        startEngine( _engine, _lastId, _patchTimestamps );
 
         usleep( 1000 * 1000 * _runTimeS );
 

--- a/tests/e2e/RestartBootstrapTests.cpp
+++ b/tests/e2e/RestartBootstrapTests.cpp
@@ -1,0 +1,344 @@
+/*
+    Copyright (C) 2026 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+
+    @author SKALE Labs
+    @date 2026
+*/
+
+#include "thirdparty/catch.hpp"
+#include "Consensust.h"
+#include "SkaleCommon.h"
+#include "datastructures/CommittedBlock.h"
+#include "datastructures/TransactionList.h"
+#include "tests/e2e/ConsensusEngineTestAccess.h"
+#include "tests/e2e/E2ETestHelper.h"
+#include "utils/Time.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace RestartBootstrapTests {
+
+using E2EHelper = E2ETestUtils::E2ETestHelper;
+
+static constexpr uint64_t PATCH_DELAY_MS = 4000;
+static constexpr uint64_t SNAPSHOT_WAIT_TIMEOUT_MS = 20000;
+static constexpr uint64_t SNAPSHOT_POLL_INTERVAL_MS = 250;
+static constexpr uint64_t POST_PATCH_SETTLE_MS = 1500;
+static constexpr uint64_t REPLAY_WAIT_TIMEOUT_MS = 10000;
+
+struct BlockSnapshot {
+    uint64_t blockId = 0;
+    uint64_t timestampS = 0;
+    uint32_t timestampMs = 0;
+    uint64_t proposerIndex = 0;
+    size_t txCount = 0;
+    u256 stateRoot = 0;
+#ifdef BITE
+    bool isBite2Enabled = false;
+    std::optional< u256 > reencryptionRandom;
+#endif
+};
+
+struct ReplayStartState {
+    const char* name = "";
+    uint64_t lastCommittedBlockId = 0;
+    uint64_t lastCommittedBlockTimestampS = 0;
+    uint64_t lastCommittedBlockTimestampMs = 0;
+    size_t expectedReplayStartIndex = 0;
+};
+
+// ConsensusExtFace implementation that records blocks created
+// by the engine and allows waiting for a certain number of blocks to be recorded.
+class RecordingConsensusExtFace : public ConsensusExtFace {
+    mutable std::mutex mutex;
+    std::condition_variable condition;
+    std::vector< BlockSnapshot > replayedBlocks;
+
+public:
+    Transactions pendingTransactions( size_t, u256& _stateRoot ) override {
+        _stateRoot = 0;
+        return Transactions();
+    }
+
+    void createBlock( const Transactions& _approvedTransactions,
+#ifdef BITE
+        DecryptedTransactions,
+#endif
+        uint64_t _timeStamp, uint32_t _timeStampMillis, uint64_t _blockID, u256, u256 _stateRoot,
+        uint64_t _winningNodeIndex ) override {
+        {
+            std::lock_guard< std::mutex > lock( mutex );
+            BlockSnapshot snapshot;
+            snapshot.blockId = _blockID;
+            snapshot.timestampS = _timeStamp;
+            snapshot.timestampMs = _timeStampMillis;
+            snapshot.proposerIndex = _winningNodeIndex;
+            snapshot.txCount = _approvedTransactions.size();
+            snapshot.stateRoot = _stateRoot;
+            replayedBlocks.push_back( snapshot );
+        }
+        condition.notify_all();
+    }
+
+    std::vector< BlockSnapshot > waitForAtLeast(
+        size_t _expectedCount, uint64_t _timeoutMs = REPLAY_WAIT_TIMEOUT_MS ) {
+        std::unique_lock< std::mutex > lock( mutex );
+        auto completed = condition.wait_for( lock, std::chrono::milliseconds( _timeoutMs ),
+            [this, _expectedCount]() { return replayedBlocks.size() >= _expectedCount; } );
+        CATCH_REQUIRE( completed );
+        return replayedBlocks;
+    }
+};
+
+#ifdef BITE
+void fillBiteFieldsFromEngine(
+    ConsensusEngine& _engine, std::vector< BlockSnapshot >& _snapshots ) {
+    for ( auto& snapshot : _snapshots ) {
+        try {
+            snapshot.reencryptionRandom =
+                _engine.getReencryptionRandomForBlockId( snapshot.blockId );
+            snapshot.isBite2Enabled = true;
+        } catch ( ... ) {
+            snapshot.reencryptionRandom = std::nullopt;
+            snapshot.isBite2Enabled = false;
+        }
+    }
+}
+#endif
+
+std::vector< BlockSnapshot > buildSnapshots(
+    ConsensusEngine& _engine, uint64_t _lastId ) {
+    std::vector< BlockSnapshot > snapshots;
+
+    for ( uint64_t blockId = 1; blockId <= _lastId; ++blockId ) {
+        auto block = ConsensusEngineTestAccess::getCommittedBlockForBlockId( _engine, blockId );
+        CATCH_REQUIRE( block != nullptr );
+
+        // fill normal fields here directly
+        BlockSnapshot snapshot;
+        snapshot.blockId = blockId;
+        snapshot.timestampS = block->getTimeStampS();
+        snapshot.timestampMs = block->getTimeStampMs();
+        snapshot.proposerIndex = (uint64_t) block->getProposerIndex();
+        snapshot.txCount = (size_t) block->getTransactionList()->size();
+        snapshot.stateRoot = block->getStateRoot();
+
+        snapshots.push_back( snapshot );
+    }
+
+#ifdef BITE
+    // fill bite fields for all blocks
+    fillBiteFieldsFromEngine( _engine, snapshots );
+#endif
+
+    return snapshots;
+}
+
+bool hasBothSidesOfTransition( const std::vector< BlockSnapshot >& _snapshots ) {
+#ifdef BITE
+    bool hasBeforePatch = false;
+    bool hasAfterPatch = false;
+
+    for ( const auto& snapshot : _snapshots ) {
+        hasBeforePatch = hasBeforePatch || !snapshot.isBite2Enabled;
+        hasAfterPatch = hasAfterPatch || snapshot.isBite2Enabled;
+    }
+
+    return hasBeforePatch && hasAfterPatch;
+#else
+    (void) _snapshots;
+    return true;
+#endif
+}
+
+std::vector< BlockSnapshot > waitForCommittedSnapshots(
+    ConsensusEngine& _engine, uint64_t _minWaitMs ) {
+    auto startTimeMs = Time::getCurrentTimeMs();
+    auto deadlineMs = startTimeMs + SNAPSHOT_WAIT_TIMEOUT_MS;
+
+    // wait for a max time
+    while ( Time::getCurrentTimeMs() < deadlineMs ) {
+        auto lastId = (uint64_t) _engine.getLargestCommittedBlockIDInDb();
+        auto elapsedMs = Time::getCurrentTimeMs() - startTimeMs;
+
+        // if passed minimum wait time
+        if ( elapsedMs >= _minWaitMs && lastId > 0 ) {
+            auto snapshots = buildSnapshots( _engine, lastId );
+#ifdef BITE
+            // if we have at least 1 BITE block - return early
+            if ( hasBothSidesOfTransition( snapshots ) ) {
+                return snapshots;
+            }
+#else
+            return snapshots;
+#endif
+        }
+
+        usleep( SNAPSHOT_POLL_INTERVAL_MS * 1000 );
+    }
+
+    CATCH_FAIL( "Timed out waiting for committed blocks to stabilize before restart" );
+    return {};
+}
+
+void runReplayScenario(
+    const ReplayStartState& _startState,
+    const std::map< string, uint64_t >& _patchTimestamps ) {
+    CATCH_CAPTURE( _startState.name );
+    CATCH_CAPTURE( _startState.lastCommittedBlockId );
+    CATCH_CAPTURE( _startState.lastCommittedBlockTimestampS );
+    CATCH_CAPTURE( _startState.lastCommittedBlockTimestampMs );
+    CATCH_CAPTURE( _startState.expectedReplayStartIndex );
+
+    ConsensusEngine* replayEngine = nullptr;
+
+    try {
+        RecordingConsensusExtFace extFace;
+        E2EHelper::startEngine( replayEngine, (int64_t) _startState.lastCommittedBlockId,
+            _patchTimestamps, &extFace, _startState.lastCommittedBlockTimestampS,
+            _startState.lastCommittedBlockTimestampMs, false );
+
+        auto bootstrapBlockID =
+            (uint64_t) ConsensusEngineTestAccess::getBootstrapBlockID( *replayEngine );
+        auto authoritativeSnapshots = buildSnapshots( *replayEngine, bootstrapBlockID );
+        auto expectedReplaySnapshots = std::vector< BlockSnapshot >(
+            authoritativeSnapshots.begin() + _startState.expectedReplayStartIndex,
+            authoritativeSnapshots.end() );
+
+        CATCH_REQUIRE( !expectedReplaySnapshots.empty() );
+        CATCH_REQUIRE( bootstrapBlockID == authoritativeSnapshots.back().blockId );
+
+        auto actualSnapshots = extFace.waitForAtLeast( expectedReplaySnapshots.size() );
+        CATCH_REQUIRE( actualSnapshots.size() >= expectedReplaySnapshots.size() );
+        actualSnapshots.resize( expectedReplaySnapshots.size() );
+
+#ifdef BITE
+        fillBiteFieldsFromEngine( *replayEngine, actualSnapshots );
+#endif
+
+        for ( size_t i = 0; i < expectedReplaySnapshots.size(); ++i ) {
+            CATCH_CAPTURE( i );
+            const auto& expected = expectedReplaySnapshots.at( i );
+            const auto& actual = actualSnapshots.at( i );
+
+            CATCH_REQUIRE( actual.blockId == expected.blockId );
+            CATCH_REQUIRE( actual.timestampS == expected.timestampS );
+            CATCH_REQUIRE( actual.timestampMs == expected.timestampMs );
+            CATCH_REQUIRE( actual.proposerIndex == expected.proposerIndex );
+            CATCH_REQUIRE( actual.txCount == expected.txCount );
+            CATCH_REQUIRE( actual.stateRoot == expected.stateRoot );
+
+#ifdef BITE
+            CATCH_REQUIRE( actual.isBite2Enabled == expected.isBite2Enabled );
+            CATCH_REQUIRE( actual.reencryptionRandom == expected.reencryptionRandom );
+#endif
+        }
+
+        auto currentLastCommittedBlockID =
+            (uint64_t) ConsensusEngineTestAccess::getCurrentLastCommittedBlockID( *replayEngine );
+        auto currentLastCommittedBlockTimeStamp =
+            ConsensusEngineTestAccess::getCurrentLastCommittedBlockTimeStamp( *replayEngine );
+        auto replayTip = expectedReplaySnapshots.back();
+
+        CATCH_REQUIRE( currentLastCommittedBlockID >= bootstrapBlockID );
+        if ( currentLastCommittedBlockID == replayTip.blockId ) {
+            CATCH_REQUIRE( currentLastCommittedBlockTimeStamp.getS() == replayTip.timestampS );
+            CATCH_REQUIRE( currentLastCommittedBlockTimeStamp.getMs() == replayTip.timestampMs );
+        } else {
+            CATCH_REQUIRE( currentLastCommittedBlockTimeStamp.getS() >= replayTip.timestampS );
+            if ( currentLastCommittedBlockTimeStamp.getS() == replayTip.timestampS ) {
+                CATCH_REQUIRE( currentLastCommittedBlockTimeStamp.getMs() >= replayTip.timestampMs );
+            }
+        }
+
+        E2EHelper::stopEngineGracefully( replayEngine );
+    } catch ( ... ) {
+        if ( replayEngine ) {
+            E2EHelper::stopEngineGracefully( replayEngine );
+        }
+        throw;
+    }
+}
+
+}  // namespace RestartBootstrapTests
+
+using namespace RestartBootstrapTests;
+
+CATCH_TEST_CASE(
+    "restart bootstrap replays committed blocks",
+    "[restart-bootstrap][end-to-end][db]" ) {
+    ConsensusEngine* initialEngine = nullptr;
+    std::vector< BlockSnapshot > snapshots;
+    std::map< string, uint64_t > patchTimestamps;
+
+    try {
+        E2EHelper::configureTestEnvironment( true );
+
+        auto bite2PatchTimestamp = ( Time::getCurrentTimeMs() + PATCH_DELAY_MS + 999 ) / 1000;
+        patchTimestamps = {
+#ifdef BITE
+            { "bite2PatchTimestamp", bite2PatchTimestamp }
+#endif
+        };
+
+
+        // ------- 1st Run to produce some blocks -------
+
+        E2EHelper::startEngine( initialEngine, 0, patchTimestamps );
+
+        // wait either for minimum waittime OR until we have at least 1 bite2 block committed.
+        snapshots = waitForCommittedSnapshots(
+            *initialEngine, PATCH_DELAY_MS + POST_PATCH_SETTLE_MS );
+
+        CATCH_REQUIRE( !snapshots.empty() );
+#ifdef BITE
+        CATCH_REQUIRE( hasBothSidesOfTransition( snapshots ) );
+#endif
+
+        E2EHelper::stopEngineGracefully( initialEngine );
+    } catch ( SkaleException& e ) {
+        if ( initialEngine ) {
+            E2EHelper::stopEngineGracefully( initialEngine );
+        }
+        SkaleException::logNested( e );
+        throw;
+    } catch ( ... ) {
+        if ( initialEngine ) {
+            E2EHelper::stopEngineGracefully( initialEngine );
+        }
+        throw;
+    }
+
+    auto midpointIndex = snapshots.size() / 2;
+    CATCH_REQUIRE( midpointIndex > 0 );
+    CATCH_REQUIRE( midpointIndex < snapshots.size() );
+    const auto& midpointSnapshot = snapshots.at( midpointIndex - 1 );
+
+    runReplayScenario(
+        { "replay-from-zero", 0, 0, 0, 0 }, patchTimestamps );
+    runReplayScenario(
+        { "replay-from-midpoint", midpointSnapshot.blockId, midpointSnapshot.timestampS,
+            midpointSnapshot.timestampMs, midpointIndex },
+        patchTimestamps );
+
+    CATCH_SUCCEED();
+}

--- a/tests/e2e/RestartBootstrapTests.cpp
+++ b/tests/e2e/RestartBootstrapTests.cpp
@@ -44,6 +44,7 @@ static constexpr uint64_t SNAPSHOT_WAIT_TIMEOUT_MS = 20000;
 static constexpr uint64_t SNAPSHOT_POLL_INTERVAL_MS = 250;
 static constexpr uint64_t POST_PATCH_SETTLE_MS = 1500;
 static constexpr uint64_t REPLAY_WAIT_TIMEOUT_MS = 10000;
+static constexpr uint64_t MAX_PRE_RESTART_BLOCKS = 100;
 
 struct BlockSnapshot {
     uint64_t blockId = 0;
@@ -179,6 +180,12 @@ std::vector< BlockSnapshot > waitForCommittedSnapshots(
     while ( Time::getCurrentTimeMs() < deadlineMs ) {
         auto lastId = (uint64_t) _engine.getLargestCommittedBlockIDInDb();
         auto elapsedMs = Time::getCurrentTimeMs() - startTimeMs;
+
+        // set max limit of blocks - consensus limits max skaled-consensus delay to be 
+        // 128 blocks
+        if ( lastId >= MAX_PRE_RESTART_BLOCKS ) {
+            return buildSnapshots( _engine, MAX_PRE_RESTART_BLOCKS );
+        }
 
         // if passed minimum wait time
         if ( elapsedMs >= _minWaitMs && lastId > 0 ) {


### PR DESCRIPTION
## Description

- Consensus failed on restart from db in case `ConsensusExt` passed a `lastCommitedBlockId` less than the one from consensus itself for `bite2Patch` blocks.
- This happened because consensus used its own chain `lastCommittedBlockId`, which was always 0 at that time. On every block read, if block was `bite2` block, then the check `lastCommittedBlockId >= bite2Patch` failed

## Solution

- Use the method local `lastCommittedBlockTimestamp` - is already updated in case it was 0 before.
- chains member `lastCommittedBlockId` is still updated after all blocks are pushed to `ConsensusExt`

## Tests

- Added new test case that tests:
   - Previous non-bite behavior on restart
   - New bite2 behavior on restart (some of the blocks are non bite, others are bite)
- Updated `tests.py`
    - Now uses self contained run for each test - avoids static state leaking across tests (should be fixed in the future)
    - removed commented tests
   
   
   
Fixes skalenetwork/internal-support#1426