### PR TITLE
Feature/985 move block finalization to zmq

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,6 @@ jobs:
     - name: run tests (block sizes)
       env:
         CI_BUILD: "1"
-        TEST_TRANSACTIONS_PER_BLOCK: "1000"
       run: |
         cd scripts 
         ./tests.py && cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,7 @@ jobs:
     - name: run tests (block sizes)
       env:
         CI_BUILD: "1"
+        TEST_TRANSACTIONS_PER_BLOCK: "500"
       run: |
         cd scripts 
         ./tests.py && cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,7 @@ file(GLOB_RECURSE COMMON_TEST_SOURCES
         "tests/unit/db/*.cpp"
         "tests/consensus_tests.cpp"
         "tests/sgx_tests.cpp"
+        "tests/e2e/BlockFinalizeTransportCompatTests.cpp"
         "tests/e2e/RestartBootstrapTests.cpp"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ AUX_SOURCE_DIRECTORY(abstracttcpclient abstractcpclient_src)
 AUX_SOURCE_DIRECTORY(blockproposal/pusher blockproposalpusher_src)
 AUX_SOURCE_DIRECTORY(blockfinalize/client blockfinalizeclient_src)
 AUX_SOURCE_DIRECTORY(blockfinalize/received blockfinalizereceived_src)
+AUX_SOURCE_DIRECTORY(blockfinalize/server blockfinalizeserver_src)
 AUX_SOURCE_DIRECTORY(blockproposal/server blockproposalserver_src)
 AUX_SOURCE_DIRECTORY(blockproposal/received blockproposalreceived_src)
 AUX_SOURCE_DIRECTORY(blockproposal blockproposal_src)
@@ -178,6 +179,7 @@ SET(SRC_FILES
         ${blockproposalserver_src}
         ${blockproposalpusher_src}
         ${blockfinalizeclient_src}
+        ${blockfinalizeserver_src}
         ${blockfinalizereceived_src}
         ${blockretriever_src}
         ${blockproposal_src}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,6 +339,7 @@ target_link_libraries(consensusd consensus_full)
 file(GLOB_RECURSE COMMON_TEST_SOURCES
         "tests/unit/datastructures/*.cpp"
         "tests/unit/db/*.cpp"
+        "tests/unit/network/*.cpp"
         "tests/consensus_tests.cpp"
         "tests/sgx_tests.cpp"
         "tests/e2e/BlockFinalizeTransportCompatTests.cpp"

--- a/SkaleCommon.h
+++ b/SkaleCommon.h
@@ -250,10 +250,11 @@ enum port_type {
     BINARY_CONSENSUS = 4,
     ZMQ_BROADCAST = 5,
     MTA = 6,
-    STATUS = 10
+    STATUS = 10,
 #ifdef BITE
-    , BITE_SERVER = 11
-#endif
+    BITE_SERVER = 11,
+#endif  
+    BULK_DATA_ZMQ = 12
 };
 
 

--- a/SkaleCommon.h
+++ b/SkaleCommon.h
@@ -182,6 +182,8 @@ static constexpr uint64_t STUCK_RESTART_INTERVAL_MS = 3 * 60 * 60 * 1000;  // th
 
 static constexpr uint64_t WAIT_AFTER_NETWORK_ERROR_MS = 3000;
 
+static constexpr uint64_t BLOCK_FINALIZE_DOWNLOAD_TCP_FALLBACK_MS = 30 * 60 * 1000; // 30 minutes
+
 static constexpr uint64_t CONNECTION_REFUSED_LOG_INTERVAL_MS = 10 * 60 * 1000;
 
 static constexpr uint64_t CATCHUP_TIMEOUT_SEC = 30;

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -428,7 +428,7 @@ ptr<BlockProposalFragment> BlockFinalizeDownloader::readBlockFragment(
 ) {
     CHECK_ARGUMENT(_serializedFragment)
 
-    CHECK_ARGUMENT(_responseHeader > 0)
+    CHECK_ARGUMENT(_responseHeader.is_object())
 
     MONITOR(__CLASS_NAME__, __FUNCTION__)
 

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -68,6 +68,15 @@
 #include "bite/BiteManager.h"
 #endif
 
+namespace {
+
+struct BlockFinalizeResponse {
+    nlohmann::json header;
+    ptr< vector< uint8_t > > payload;
+};
+
+}  // namespace
+
 
 BlockFinalizeDownloader::BlockFinalizeDownloader(
     Schain *_sChain, block_id _blockId,

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -32,6 +32,9 @@
 #include "network/ClientSocket.h"
 #include "network/IO.h"
 #include "network/Network.h"
+#include "network/Sockets.h"
+#include "network/ZMQHeaderPayloadFrame.h"
+#include "network/ZMQSockets.h"
 #include "node/Node.h"
 
 #include "chains/Schain.h"
@@ -59,6 +62,15 @@
 #include "BlockFinalizeDownloaderThreadPool.h"
 #include "bite/BiteManager.h"
 #include "crypto/CryptoManager.h"
+
+namespace {
+
+struct BlockFinalizeResponse {
+    nlohmann::json header;
+    ptr< vector< uint8_t > > payload;
+};
+
+}  // namespace
 
 
 BlockFinalizeDownloader::BlockFinalizeDownloader(
@@ -100,6 +112,154 @@ nlohmann::json BlockFinalizeDownloader::readBlockFinalizeResponseHeader(
         _socket->getDescriptor(), "Read BlockFinalize response", 10, _socket->getIP());
 }
 
+bool BlockFinalizeDownloader::shouldUseTCPFallback( schain_index _dstIndex ) {
+    LOCK( m );
+    if ( tcpFallbackUntilMs.count( _dstIndex ) == 0 ) {
+        return false;
+    }
+
+    return tcpFallbackUntilMs.at( _dstIndex ) > Time::getCurrentTimeMs();
+}
+
+void BlockFinalizeDownloader::markTCPFallback( schain_index _dstIndex ) {
+    LOCK( m );
+    tcpFallbackUntilMs[_dstIndex] =
+        Time::getCurrentTimeMs() + getNode()->getWaitAfterNetworkErrorMs();
+}
+
+void BlockFinalizeDownloader::clearTCPFallback( schain_index _dstIndex ) {
+    LOCK( m );
+    tcpFallbackUntilMs.erase( _dstIndex );
+}
+
+void BlockFinalizeDownloader::validateBlockFinalizeResponse( nlohmann::json _responseHeader,
+    schain_index _dstIndex, fragment_index _fragmentIndex ) {
+    auto status = ( ConnectionStatus ) Header::getUint64( _responseHeader, "status" );
+    auto substatus = ( ConnectionSubStatus ) Header::getUint64( _responseHeader, "substatus" );
+
+    if ( status == CONNECTION_DISCONNECT && substatus == CONNECTION_FINALIZE_DONT_HAVE_PROPOSAL ) {
+        CONS_LOG( debug,
+            "BLCK_FRG_DWNLD:NO_FRG:" << to_string( _fragmentIndex ) << ":" << to_string( _dstIndex ) );
+        throw DoNotHaveProposalYetException();
+    }
+
+    if ( status != CONNECTION_PROCEED ) {
+        BOOST_THROW_EXCEPTION( NetworkProtocolException(
+            "Server error in BlockFinalize response:" + to_string( status ) + ":" +
+                to_string( substatus ),
+            __CLASS_NAME__ ) );
+    }
+}
+
+void BlockFinalizeDownloader::processBlockFinalizePayload( schain_index _dstIndex,
+    fragment_index _fragmentIndex, nlohmann::json _responseHeader,
+    const ptr< vector< uint8_t > >& _serializedFragment ) {
+    CHECK_ARGUMENT( _serializedFragment );
+
+    ptr< BlockProposalFragment > blockFragment;
+    try {
+        blockFragment =
+            readBlockFragment( _serializedFragment, _responseHeader, _fragmentIndex,
+                getSchain()->getNodeCount()
+#ifdef BITE
+                    ,
+                proposerIndex, _dstIndex
+#endif
+            );
+        CHECK_ARGUMENT( blockFragment )
+    } catch ( ExitRequestedException& ) {
+        throw;
+    } catch ( ... ) {
+        auto errString = "BlockFinalizec step 3: can not read fragment";
+        CONS_LOG( err, errString );
+        throw_with_nested( NetworkProtocolException( errString, __CLASS_NAME__ ) );
+    }
+
+#ifdef BITE
+    auto teDB = getSchain()->getNode()->getTEDecryptionDB();
+    if ( needDecryptionShares( _dstIndex ) ) {
+        auto decryptionShares = blockFragment->getDecryptionShares();
+        CHECK_STATE2(
+            decryptionShares, "The finalization response did not include decryptionshares" );
+
+        try {
+            teDB->addDecryptionShares( decryptionShares );
+        }
+        CATCH_LOG_AND_RETHROW_ANY_EXCEPTION( err, "Could not add decryption shares to DB" );
+    }
+
+    if ( !needFragmentData ) {
+        return;
+    }
+#endif
+
+    fragmentList.addFragment( blockFragment );
+}
+
+void BlockFinalizeDownloader::downloadFragmentTCP( schain_index _dstIndex,
+    fragment_index _fragmentIndex, const ptr< Header >& _header ) {
+    
+    // create brand new socket - includes 3-way handshake
+    auto socket = make_shared< ClientSocket >( *sChain, _dstIndex, CATCHUP );
+    auto io = getSchain()->getIo();
+
+    try {
+        io->writeMagic( socket );
+    } catch ( ExitRequestedException& ) {
+        throw;
+    } catch ( ... ) {
+        throw_with_nested( NetworkProtocolException(
+            "BlockFinalizec: Server disconnect sending magic", __CLASS_NAME__ ) );
+    }
+
+    try {
+        io->writeHeader( socket, _header );
+    } catch ( ExitRequestedException& ) {
+        throw;
+    } catch ( ... ) {
+        auto errString = "BlockFinalizec step 1: can not write BlockFinalize request";
+        CONS_LOG( err, errString );
+        throw_with_nested( NetworkProtocolException( errString, __CLASS_NAME__ ) );
+    }
+
+    BlockFinalizeResponse response;
+    try {
+        response.header = readBlockFinalizeResponseHeader( socket );
+    } catch ( ExitRequestedException& ) {
+        throw;
+    } catch ( ... ) {
+        auto errString = "BlockFinalizec step 2: can not read BlockFinalize response";
+        CONS_LOG( err, errString );
+        throw_with_nested( NetworkProtocolException( errString, __CLASS_NAME__ ) );
+    }
+
+    validateBlockFinalizeResponse( response.header, _dstIndex, _fragmentIndex );
+    response.payload = readSerializedBlockFragment( socket, response.header );
+    processBlockFinalizePayload( _dstIndex, _fragmentIndex, response.header, response.payload );
+}
+
+void BlockFinalizeDownloader::downloadFragmentZMQ( schain_index _dstIndex,
+    fragment_index _fragmentIndex, const ptr< Header >& _header ) {
+    auto nodeInfo = getNode()->getNodeInfoByIndex( _dstIndex );
+    CHECK_STATE( nodeInfo );
+
+    auto socket =
+        getNode()->getSockets()->getBulkDataZMQSockets()->getDestinationSocket( nodeInfo );
+    auto requestFrame = ZMQHeaderPayloadFrame::packMessage( _header );
+    ZMQHeaderPayloadFrame::sendFrame( *getSchain(), socket, requestFrame );
+
+    auto responseFrame =
+        ZMQHeaderPayloadFrame::receiveFrame( *getSchain(), socket, nullptr, "Could not read ZMQ response" );
+
+    BlockFinalizeResponse response;
+    response.header = ZMQHeaderPayloadFrame::unpackMessage( responseFrame->data(), responseFrame->size(),
+        response.payload, "Could not parse ZMQ response" );
+
+    validateBlockFinalizeResponse( response.header, _dstIndex, _fragmentIndex );
+    CHECK_STATE( response.payload );
+    processBlockFinalizePayload( _dstIndex, _fragmentIndex, response.header, response.payload );
+}
+
 
 void BlockFinalizeDownloader::downloadFragment(
     schain_index _dstIndex, fragment_index _fragmentIndex) {
@@ -131,103 +291,57 @@ void BlockFinalizeDownloader::downloadFragment(
         , needFragmentData
 #endif
     );
+    
     CHECK_STATE(_dstIndex != ( uint64_t ) getSchain()->getSchainIndex())
     if (getSchain()->getDeathTimeMs((uint64_t) _dstIndex) + NODE_DEATH_INTERVAL_MS >
         Time::getCurrentTimeMs()) {
         BOOST_THROW_EXCEPTION(ConnectionRefusedException(
             "Dead node:" + to_string( _dstIndex ), 5, __CLASS_NAME__ ));
     }
-    auto socket = make_shared<ClientSocket>(*sChain, _dstIndex, CATCHUP);
 
-    auto io = getSchain()->getIo();
-
-    try {
-        io->writeMagic(socket);
-    } catch (ExitRequestedException &) {
-        throw;
-    } catch (...) {
-        throw_with_nested(NetworkProtocolException(
-            "BlockFinalizec: Server disconnect sending magic", __CLASS_NAME__));
-    }
-
-    try {
-        io->writeHeader(socket, header);
-    } catch (ExitRequestedException &) {
-        throw;
-    } catch (...) {
-        auto errString = "BlockFinalizec step 1: can not write BlockFinalize request";
-        CONS_LOG(err, errString);
-        throw_with_nested(NetworkProtocolException(errString, __CLASS_NAME__));
-    }
-
-    nlohmann::json response;
-
-    try {
-        response = readBlockFinalizeResponseHeader(socket);
-    } catch (ExitRequestedException &) {
-        throw;
-    } catch (...) {
-        auto errString = "BlockFinalizec step 2: can not read BlockFinalize response";
-        CONS_LOG(err, errString);
-        throw_with_nested(NetworkProtocolException(errString, __CLASS_NAME__));
-    }
-
-
-    auto status = (ConnectionStatus) Header::getUint64(response, "status");
-    auto substatus = (ConnectionSubStatus) Header::getUint64(response, "substatus");
-
-    if (status == CONNECTION_DISCONNECT && substatus == CONNECTION_FINALIZE_DONT_HAVE_PROPOSAL) {
-        CONS_LOG(debug, "BLCK_FRG_DWNLD:NO_FRG:" << to_string( _fragmentIndex ) << ":"
-            << to_string( _dstIndex ));
-        throw DoNotHaveProposalYetException();
-    }
-
-
-    if (status != CONNECTION_PROCEED) {
-        BOOST_THROW_EXCEPTION(NetworkProtocolException(
-            "Server error in BlockFinalize response:" + to_string( status ) + ":" +
-            to_string(substatus), __CLASS_NAME__ ));
-    }
-
-
-    ptr<BlockProposalFragment> blockFragment;
-
-    try {
-        blockFragment =
-                readBlockFragment(socket, response, _fragmentIndex, getSchain()->getNodeCount()
-#ifdef BITE
-                                  , proposerIndex, _dstIndex
-#endif
-                );
-        CHECK_ARGUMENT(blockFragment)
-    } catch (ExitRequestedException &) {
-        throw;
-    } catch (...) {
-        auto errString = "BlockFinalizec step 3: can not read fragment";
-        CONS_LOG(err, errString);
-        throw_with_nested(NetworkProtocolException(errString, __CLASS_NAME__));
-    }
-
-#ifdef BITE
-    auto teDB = getSchain()->getNode()->getTEDecryptionDB();
-    if (needDecryptionShares(_dstIndex)) {
-        auto decryptionShares = blockFragment->getDecryptionShares();
-        CHECK_STATE2(decryptionShares, "The finalization response did not include decryptionshares");
-
-        try {
-            teDB->addDecryptionShares(decryptionShares);
-        }
-        CATCH_LOG_AND_RETHROW_ANY_EXCEPTION(err, "Could not add decryption shares to DB");
-    }
-
-
-    if (!needFragmentData) {
+    // If this node is marked as TCP fallback in local cache, use TCP to download fragment, 
+    // and do not try ZMQ for this node, to avoid repeated network errors and retries.
+    if ( shouldUseTCPFallback( _dstIndex ) ) {
+        downloadFragmentTCP( _dstIndex, _fragmentIndex, header );
         return;
     }
 
-#endif
+    // If node is not marked as TCP fallback, try ZMQ first, and if it fails, mark it as TCP fallback and retry using TCP.
+    try {
+        downloadFragmentZMQ( _dstIndex, _fragmentIndex, header );
+        clearTCPFallback( _dstIndex );
+        return;
+    } catch ( DoNotHaveProposalYetException& ) {
+        throw;
+    } catch ( ExitRequestedException& ) {
+        throw;
+    } catch ( ... ) {
+        // peer is not usable via ZMQ, mark it as TCP fallback and retry using TCP
+        getNode()->getSockets()->getBulkDataZMQSockets()->closeDestinationSocket( _dstIndex );
+        markTCPFallback( _dstIndex );
+    }
 
-    fragmentList.addFragment(blockFragment);
+    // retry using TCP, maybe its an old node running TCP interface.
+    downloadFragmentTCP( _dstIndex, _fragmentIndex, header );
+}
+
+ptr< vector< uint8_t > > BlockFinalizeDownloader::readSerializedBlockFragment(
+    const ptr< ClientSocket >& _socket, nlohmann::json _responseHeader ) {
+    CHECK_ARGUMENT( _socket );
+
+    auto fragmentSize = readFragmentSize( _responseHeader );
+    auto serializedFragment = make_shared< vector< uint8_t > >( fragmentSize );
+
+    try {
+        getSchain()->getIo()->readBytes(
+            _socket->getDescriptor(), serializedFragment, msg_len( fragmentSize ), 30 );
+    } catch ( ExitRequestedException& ) {
+        throw;
+    } catch ( ... ) {
+        throw_with_nested( NetworkProtocolException( "Could not read blocks", __CLASS_NAME__ ) );
+    }
+
+    return serializedFragment;
 }
 
 uint64_t BlockFinalizeDownloader::readFragmentSize(nlohmann::json _responseHeader) {
@@ -292,14 +406,14 @@ bool BlockFinalizeDownloader::needDecryptionShares(schain_index _decryptorIndex)
 
 
 ptr<BlockProposalFragment> BlockFinalizeDownloader::readBlockFragment(
-    const ptr<ClientSocket> &_socket, nlohmann::json _responseHeader,
+    const ptr<vector<uint8_t> > &_serializedFragment, nlohmann::json _responseHeader,
     fragment_index _fragmentIndex, node_count _nodeCount
 #ifdef BITE
     , schain_index _proposerIndex
     , schain_index _destinationIndex
 #endif
 ) {
-    CHECK_ARGUMENT(_socket)
+    CHECK_ARGUMENT(_serializedFragment)
 
     CHECK_ARGUMENT(_responseHeader > 0)
 
@@ -333,16 +447,7 @@ ptr<BlockProposalFragment> BlockFinalizeDownloader::readBlockFragment(
     }
 #endif
 
-    auto serializedFragment = make_shared<vector<uint8_t> >(fragmentSize);
-
-    try {
-        getSchain()->getIo()->readBytes(
-            _socket->getDescriptor(), serializedFragment, msg_len(fragmentSize), 30);
-    } catch (ExitRequestedException &) {
-        throw;
-    } catch (...) {
-        throw_with_nested(NetworkProtocolException("Could not read blocks", __CLASS_NAME__));
-    }
+    CHECK_STATE( _serializedFragment->size() == fragmentSize )
 
     ptr<BlockProposalFragment> fragment = nullptr;
 
@@ -355,7 +460,7 @@ ptr<BlockProposalFragment> BlockFinalizeDownloader::readBlockFragment(
 #endif
 
                                                       (uint64_t) _nodeCount - 1,
-                                                      _fragmentIndex, serializedFragment, blockSize, blockHash);
+                                                      _fragmentIndex, _serializedFragment, blockSize, blockHash);
     } catch (ExitRequestedException &) {
         throw;
     } catch (...) {

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -27,6 +27,7 @@
 #include "exceptions/ConnectionRefusedException.h"
 #include "exceptions/ExitRequestedException.h"
 #include "exceptions/DoNotHaveProposalYetException.h"
+#include "exceptions/ZMQTransportException.h"
 
 #include "abstracttcpserver/ConnectionStatus.h"
 
@@ -311,17 +312,14 @@ void BlockFinalizeDownloader::downloadFragment(
         return;
     }
 
-    // If node is not marked as TCP fallback, try ZMQ first, and if it fails, mark it as TCP fallback and retry using TCP.
+    // If node is not marked as TCP fallback, try ZMQ first. Downgrade to TCP only for
+    // explicit ZMQ transport failures, not for parsing, protocol, or local-state errors.
     try {
         downloadFragmentZMQ( _dstIndex, _fragmentIndex, header );
         clearTCPFallback( _dstIndex );
         return;
-    } catch ( DoNotHaveProposalYetException& ) {
-        throw;
-    } catch ( ExitRequestedException& ) {
-        throw;
-    } catch ( ... ) {
-        // peer is not usable via ZMQ, mark it as TCP fallback and retry using TCP
+    } catch ( const ZMQTransportException& e ) {
+        // peer is not usable via ZMQ transport right now, mark it as TCP fallback
         getNode()->getSockets()->getBulkDataZMQSockets()->closeDestinationSocket( _dstIndex );
         getSchain()->noteBlockFinalizeZmqClientFallbackToTcp();
         markTCPFallback( _dstIndex );

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -119,7 +119,7 @@ bool BlockFinalizeDownloader::shouldUseTCPFallback( schain_index _dstIndex ) {
 void BlockFinalizeDownloader::markTCPFallback( schain_index _dstIndex ) {
     LOCK( m );
     tcpFallbackUntilMs[_dstIndex] =
-        Time::getCurrentTimeMs() + getNode()->getWaitAfterNetworkErrorMs();
+        Time::getCurrentTimeMs() + getNode()->getBlockFinalizeDownloadTcpFallbackMs();
 }
 
 void BlockFinalizeDownloader::clearTCPFallback( schain_index _dstIndex ) {

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -22,55 +22,50 @@
 */
 
 #include "Log.h"
-#include <exceptions/ConnectionRefusedException.h>
-#include "exceptions/ExitRequestedException.h"
+#include <boost/endian/buffers.hpp>
 
+#include "exceptions/ConnectionRefusedException.h"
+#include "exceptions/ExitRequestedException.h"
+#include "exceptions/DoNotHaveProposalYetException.h"
 
 #include "abstracttcpserver/ConnectionStatus.h"
 
-#include "chains/TestConfig.h"
 #include "network/ClientSocket.h"
 #include "network/IO.h"
 #include "network/Network.h"
 #include "network/Sockets.h"
 #include "network/ZMQHeaderPayloadFrame.h"
 #include "network/ZMQSockets.h"
+
 #include "node/Node.h"
 
 #include "chains/Schain.h"
-#include "crypto/TrivialSignature.h"
-#include "datastructures/BlockProposalFragment.h"
+#include "chains/BlockErrorAnalyzer.h"
+#include "chains/TestConfig.h"
 
+#include "crypto/TrivialSignature.h"
+#include "crypto/CryptoManager.h"
+
+#include "datastructures/BlockProposalFragment.h"
 #include "datastructures/CommittedBlock.h"
 #include "datastructures/DAProof.h"
+
 #include "db/BlockProposalDB.h"
 #include "db/DAProofDB.h"
-#include "exceptions/DoNotHaveProposalYetException.h"
-#ifdef BITE
-#include "db/TEDecryptionDB.h"
-#endif
+
 #include "headers/BlockFinalizeRequestHeader.h"
-#include "headers/BlockProposalRequestHeader.h"
 #include "monitoring/LivelinessMonitor.h"
 #include "pendingqueue/PendingTransactionsAgent.h"
 #include "utils/Time.h"
-#include "chains/BlockErrorAnalyzer.h"
+
 #include "BlockFinalizeDownloader.h"
-
-#include <boost/endian/buffers.hpp>
-
 #include "BlockFinalizeDownloaderThreadPool.h"
+
+
+#ifdef BITE
+#include "db/TEDecryptionDB.h"
 #include "bite/BiteManager.h"
-#include "crypto/CryptoManager.h"
-
-namespace {
-
-struct BlockFinalizeResponse {
-    nlohmann::json header;
-    ptr< vector< uint8_t > > payload;
-};
-
-}  // namespace
+#endif
 
 
 BlockFinalizeDownloader::BlockFinalizeDownloader(
@@ -132,7 +127,7 @@ void BlockFinalizeDownloader::clearTCPFallback( schain_index _dstIndex ) {
     tcpFallbackUntilMs.erase( _dstIndex );
 }
 
-void BlockFinalizeDownloader::validateBlockFinalizeResponse( nlohmann::json _responseHeader,
+void BlockFinalizeDownloader::validateBlockFinalizeResponse( const nlohmann::json& _responseHeader,
     schain_index _dstIndex, fragment_index _fragmentIndex ) {
     auto status = ( ConnectionStatus ) Header::getUint64( _responseHeader, "status" );
     auto substatus = ( ConnectionSubStatus ) Header::getUint64( _responseHeader, "substatus" );
@@ -152,7 +147,7 @@ void BlockFinalizeDownloader::validateBlockFinalizeResponse( nlohmann::json _res
 }
 
 void BlockFinalizeDownloader::processBlockFinalizePayload( schain_index _dstIndex,
-    fragment_index _fragmentIndex, nlohmann::json _responseHeader,
+    fragment_index _fragmentIndex, const nlohmann::json& _responseHeader,
     const ptr< vector< uint8_t > >& _serializedFragment ) {
     CHECK_ARGUMENT( _serializedFragment );
 
@@ -337,7 +332,7 @@ void BlockFinalizeDownloader::downloadFragment(
 }
 
 ptr< vector< uint8_t > > BlockFinalizeDownloader::readSerializedBlockFragment(
-    const ptr< ClientSocket >& _socket, nlohmann::json _responseHeader ) {
+    const ptr< ClientSocket >& _socket, const nlohmann::json& _responseHeader ) {
     CHECK_ARGUMENT( _socket );
 
     auto fragmentSize = readFragmentSize( _responseHeader );
@@ -355,7 +350,7 @@ ptr< vector< uint8_t > > BlockFinalizeDownloader::readSerializedBlockFragment(
     return serializedFragment;
 }
 
-uint64_t BlockFinalizeDownloader::readFragmentSize(nlohmann::json _responseHeader) {
+uint64_t BlockFinalizeDownloader::readFragmentSize(const nlohmann::json& _responseHeader) {
     uint64_t result = Header::getUint64(_responseHeader, "fragmentSize");
 
     if (result == 0) {
@@ -365,7 +360,7 @@ uint64_t BlockFinalizeDownloader::readFragmentSize(nlohmann::json _responseHeade
     return result;
 }
 
-uint64_t BlockFinalizeDownloader::readBlockSize(nlohmann::json _responseHeader) {
+uint64_t BlockFinalizeDownloader::readBlockSize(const nlohmann::json& _responseHeader) {
     uint64_t result = Header::getUint64(_responseHeader, "blockSize");
 
     if (result == 0) {
@@ -375,12 +370,12 @@ uint64_t BlockFinalizeDownloader::readBlockSize(nlohmann::json _responseHeader) 
     return result;
 }
 
-string BlockFinalizeDownloader::readBlockHash(nlohmann::json _responseHeader) {
+string BlockFinalizeDownloader::readBlockHash(const nlohmann::json& _responseHeader) {
     auto result = Header::getString(_responseHeader, "blockHash");
     return result;
 }
 
-string BlockFinalizeDownloader::readDAProofSig(nlohmann::json _responseHeader) {
+string BlockFinalizeDownloader::readDAProofSig(const nlohmann::json& _responseHeader) {
     if (getSchain()->verifyDASigsPatch(getSchain()->getLastCommittedBlockTimeStamp().getS())) {
         return Header::getString(_responseHeader, "daSig");
     } else {
@@ -389,7 +384,7 @@ string BlockFinalizeDownloader::readDAProofSig(nlohmann::json _responseHeader) {
 }
 
 
-void BlockFinalizeDownloader::processDAProofSig(nlohmann::json _responseHeader, string h) {
+void BlockFinalizeDownloader::processDAProofSig(const nlohmann::json& _responseHeader, string h) {
     auto sig = readDAProofSig(_responseHeader); {
         LOCK(m)
 
@@ -417,7 +412,7 @@ bool BlockFinalizeDownloader::needDecryptionShares(schain_index _decryptorIndex)
 
 
 ptr<BlockProposalFragment> BlockFinalizeDownloader::readBlockFragment(
-    const ptr<vector<uint8_t> > &_serializedFragment, nlohmann::json _responseHeader,
+    const ptr<vector<uint8_t> > &_serializedFragment, const nlohmann::json& _responseHeader,
     fragment_index _fragmentIndex, node_count _nodeCount
 #ifdef BITE
     , schain_index _proposerIndex

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -191,6 +191,8 @@ void BlockFinalizeDownloader::processBlockFinalizePayload( schain_index _dstInde
     if ( !needFragmentData ) {
         return;
     }
+#else
+    (void) _dstIndex;  // unused parameter
 #endif
 
     fragmentList.addFragment( blockFragment );
@@ -198,6 +200,7 @@ void BlockFinalizeDownloader::processBlockFinalizePayload( schain_index _dstInde
 
 void BlockFinalizeDownloader::downloadFragmentTCP( schain_index _dstIndex,
     fragment_index _fragmentIndex, const ptr< Header >& _header ) {
+    getSchain()->noteBlockFinalizeTcpClientRequest();
     
     // create brand new socket - includes 3-way handshake
     auto socket = make_shared< ClientSocket >( *sChain, _dstIndex, CATCHUP );
@@ -240,6 +243,7 @@ void BlockFinalizeDownloader::downloadFragmentTCP( schain_index _dstIndex,
 
 void BlockFinalizeDownloader::downloadFragmentZMQ( schain_index _dstIndex,
     fragment_index _fragmentIndex, const ptr< Header >& _header ) {
+    getSchain()->noteBlockFinalizeZmqClientAttempt();
     auto nodeInfo = getNode()->getNodeInfoByIndex( _dstIndex );
     CHECK_STATE( nodeInfo );
 
@@ -299,6 +303,12 @@ void BlockFinalizeDownloader::downloadFragment(
             "Dead node:" + to_string( _dstIndex ), 5, __CLASS_NAME__ ));
     }
 
+    // If ZMQ disabled - try TCP right away
+    if ( !getNode()->getTestConfig()->isBlockFinalizeZmqClientEnabled() ) {
+        downloadFragmentTCP( _dstIndex, _fragmentIndex, header );
+        return;
+    }
+
     // If this node is marked as TCP fallback in local cache, use TCP to download fragment, 
     // and do not try ZMQ for this node, to avoid repeated network errors and retries.
     if ( shouldUseTCPFallback( _dstIndex ) ) {
@@ -318,6 +328,7 @@ void BlockFinalizeDownloader::downloadFragment(
     } catch ( ... ) {
         // peer is not usable via ZMQ, mark it as TCP fallback and retry using TCP
         getNode()->getSockets()->getBulkDataZMQSockets()->closeDestinationSocket( _dstIndex );
+        getSchain()->noteBlockFinalizeZmqClientFallbackToTcp();
         markTCPFallback( _dstIndex );
     }
 

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -299,7 +299,7 @@ void BlockFinalizeDownloader::downloadFragment(
     }
 
     // If ZMQ disabled - try TCP right away
-    if ( !getNode()->getTestConfig()->isBlockFinalizeZmqClientEnabled() ) {
+    if ( !getNode()->isBlockFinalizeZmqEnabled() ) {
         downloadFragmentTCP( _dstIndex, _fragmentIndex, header );
         return;
     }

--- a/blockfinalize/client/BlockFinalizeDownloader.h
+++ b/blockfinalize/client/BlockFinalizeDownloader.h
@@ -35,11 +35,26 @@ class BlockProposal;
 class BlockFinalizeDownloaderThreadPool;
 class BlockProposalSet;
 class ThresholdSignature;
+class Header;
 
 #include <folly/synchronization/Baton.h>
 #include <folly/SharedMutex.h>
 #include "datastructures/BlockProposalFragmentList.h"
 
+/**
+ * Client-side BlockFinalize recovery agent.
+ *
+ * Schain creates this after a block has already been decided and signed, but the local node still
+ * lacks some data required to finalize it locally. The downloader contacts peer nodes and fetches:
+ * - missing proposal fragments
+ * - the DA proof signature, when needed
+ * - under BITE, missing decryption shares from other nodes
+ *
+ * Transport behavior:
+ * - prefer the new persistent ZMQ bulk-data lane
+ * - fall back to the legacy per-request TCP CATCHUP path for older or unavailable peers
+ * - cache that fallback decision per peer for a short cooldown period
+ */
 class BlockFinalizeDownloader : public Agent {
     block_id blockId = 0;
 
@@ -56,6 +71,12 @@ private:
     ptr< ThresholdSignature > daSig = nullptr;
 
     recursive_mutex m;
+
+    // Track which nodes are using old TCP interface.
+    // We keep a timestamp until which we should keep using TCP (even if ZMQ is available) 
+    // for each node that we know is using TCP fallback, to avoid repeatedly trying ZMQ for nodes that don't support it.
+    // Eventually all nodes will move to ZMQ, and this map will become mostly unused.
+    map< schain_index, uint64_t > tcpFallbackUntilMs;
 
     std::atomic<uint64_t> fragmentDownloadCounter = 0;
 
@@ -96,8 +117,52 @@ public:
 
     nlohmann::json readBlockFinalizeResponseHeader( const ptr< ClientSocket >& _socket );
 
+    /**
+     * Downloads block fragment from '_dstIndex' node using TCP connection. 
+     * This is the old interface, used only as a fallback when ZMQ download fails, 
+     * and is marked in local cache to keep using TCP for this node for some time in the future.
+     */
+    void downloadFragmentTCP( schain_index _dstIndex, fragment_index _fragmentIndex,
+        const ptr< Header >& _header );
 
-    ptr< BlockProposalFragment > readBlockFragment( const ptr< ClientSocket >& _socket,
+    /**
+     * Downloads block fragment from '_dstIndex' node using ZMQ connection.
+     * This is the new interface, preferred over TCP, and should be used in newer nodes (that 
+     * execute current codebase)
+     */
+    void downloadFragmentZMQ( schain_index _dstIndex, fragment_index _fragmentIndex,
+        const ptr< Header >& _header );
+
+    /**
+     * Check local cache if '_dstIndex' node was using TCP
+     * recently. If so, it should be marked to keep TCP fallback.
+     * Else, returns false, meaning we can try ZMQ for this node.
+     */
+    bool shouldUseTCPFallback( schain_index _dstIndex );
+
+    /**
+     * Mark '_dstIndex' node to use TCP fallback for some time in the future, 
+     * based on current time + configured wait time after network error.
+     */
+    void markTCPFallback( schain_index _dstIndex );
+
+    /**
+     * Clears TCP fallback mark for '_dstIndex' node, 
+     * allowing to try ZMQ for this node again.
+     */
+    void clearTCPFallback( schain_index _dstIndex );
+
+    ptr< vector< uint8_t > > readSerializedBlockFragment(
+        const ptr< ClientSocket >& _socket, nlohmann::json _responseHeader );
+
+    void validateBlockFinalizeResponse(
+        nlohmann::json _responseHeader, schain_index _dstIndex, fragment_index _fragmentIndex );
+
+    void processBlockFinalizePayload( schain_index _dstIndex, fragment_index _fragmentIndex,
+        nlohmann::json _responseHeader, const ptr< vector< uint8_t > >& _serializedFragment );
+
+
+    ptr< BlockProposalFragment > readBlockFragment( const ptr< vector< uint8_t > >& _serializedFragment,
         nlohmann::json responseHeader, fragment_index _fragmentIndex, node_count _nodeCount
 #ifdef BITE
         , schain_index _proposerIndex
@@ -127,6 +192,12 @@ public:
 
     bool needDAProof();
 #ifdef BITE
+    /**
+     * Checks if we have enough shares from other nodes.
+     * If we do, we don't need this node's shares - return false.
+     * Else, check if we have enough shares from '_decryptorIndex' node.
+     * If not, return true.
+     */
     bool needDecryptionShares(schain_index _decryptorIndex);
 #endif
 

--- a/blockfinalize/client/BlockFinalizeDownloader.h
+++ b/blockfinalize/client/BlockFinalizeDownloader.h
@@ -42,16 +42,6 @@ class Header;
 #include <folly/SharedMutex.h>
 #include "datastructures/BlockProposalFragmentList.h"
 
-namespace {
-
-struct BlockFinalizeResponse {
-    nlohmann::json header;
-    ptr< vector< uint8_t > > payload;
-};
-
-}  // namespace
-
-
 /**
  * Client-side BlockFinalize recovery agent.
  *

--- a/blockfinalize/client/BlockFinalizeDownloader.h
+++ b/blockfinalize/client/BlockFinalizeDownloader.h
@@ -41,6 +41,16 @@ class Header;
 #include <folly/SharedMutex.h>
 #include "datastructures/BlockProposalFragmentList.h"
 
+namespace {
+
+struct BlockFinalizeResponse {
+    nlohmann::json header;
+    ptr< vector< uint8_t > > payload;
+};
+
+}  // namespace
+
+
 /**
  * Client-side BlockFinalize recovery agent.
  *
@@ -153,41 +163,41 @@ public:
     void clearTCPFallback( schain_index _dstIndex );
 
     ptr< vector< uint8_t > > readSerializedBlockFragment(
-        const ptr< ClientSocket >& _socket, nlohmann::json _responseHeader );
+        const ptr< ClientSocket >& _socket, const nlohmann::json& _responseHeader );
 
     void validateBlockFinalizeResponse(
-        nlohmann::json _responseHeader, schain_index _dstIndex, fragment_index _fragmentIndex );
+        const nlohmann::json& _responseHeader, schain_index _dstIndex, fragment_index _fragmentIndex );
 
     void processBlockFinalizePayload( schain_index _dstIndex, fragment_index _fragmentIndex,
-        nlohmann::json _responseHeader, const ptr< vector< uint8_t > >& _serializedFragment );
+        const nlohmann::json& _responseHeader, const ptr< vector< uint8_t > >& _serializedFragment );
 
 
     ptr< BlockProposalFragment > readBlockFragment( const ptr< vector< uint8_t > >& _serializedFragment,
-        nlohmann::json responseHeader, fragment_index _fragmentIndex, node_count _nodeCount
+        const nlohmann::json& responseHeader, fragment_index _fragmentIndex, node_count _nodeCount
 #ifdef BITE
         , schain_index _proposerIndex
         , schain_index _destinationIndex
 #endif
     );
 
-    static uint64_t readFragmentSize( nlohmann::json _responseHeader );
+    static uint64_t readFragmentSize( const nlohmann::json& _responseHeader );
 
     bool downloadProposalDAProofAndDecryptions();
 
 
     bool completeAndNeedToExitAllThreads();
 
-    string readBlockHash( nlohmann::json _responseHeader );
+    string readBlockHash( const nlohmann::json& _responseHeader );
 
     block_id getBlockId();
 
     schain_index getProposerIndex();
 
-    static uint64_t readBlockSize( nlohmann::json _responseHeader );
+    static uint64_t readBlockSize( const nlohmann::json& _responseHeader );
 
-    string readDAProofSig( nlohmann::json _responseHeader );
+    string readDAProofSig( const nlohmann::json& _responseHeader );
 
-    void processDAProofSig(nlohmann::json _responseHeader, string h);
+    void processDAProofSig(const nlohmann::json& _responseHeader, string h);
 
 
     bool needDAProof();

--- a/blockfinalize/client/BlockFinalizeDownloader.h
+++ b/blockfinalize/client/BlockFinalizeDownloader.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <exception>
 
 class CommittedBlockList;
 class ClientSocket;
@@ -129,7 +130,7 @@ public:
 
     /**
      * Downloads block fragment from '_dstIndex' node using TCP connection. 
-     * This is the old interface, used only as a fallback when ZMQ download fails, 
+     * This is the old interface, used only as a fallback when ZMQ transport fails, 
      * and is marked in local cache to keep using TCP for this node for some time in the future.
      */
     void downloadFragmentTCP( schain_index _dstIndex, fragment_index _fragmentIndex,

--- a/blockfinalize/client/BlockFinalizeDownloader.h
+++ b/blockfinalize/client/BlockFinalizeDownloader.h
@@ -151,8 +151,8 @@ public:
     bool shouldUseTCPFallback( schain_index _dstIndex );
 
     /**
-     * Mark '_dstIndex' node to use TCP fallback for some time in the future, 
-     * based on current time + configured wait time after network error.
+     * Mark '_dstIndex' node to use TCP fallback for some time in the future,
+     * based on current time + configured TCP fallback duration.
      */
     void markTCPFallback( schain_index _dstIndex );
 

--- a/blockfinalize/server/BlockFinalizeResponder.cpp
+++ b/blockfinalize/server/BlockFinalizeResponder.cpp
@@ -1,0 +1,195 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "SkaleCommon.h"
+#include "Log.h"
+
+#include "blockfinalize/server/BlockFinalizeResponder.h"
+
+#include "abstracttcpserver/ConnectionStatus.h"
+#include "chains/Schain.h"
+#include "crypto/BLAKE3Hash.h"
+#ifdef BITE
+#include "crypto/AESKeyDecryptionShareList.h"
+#include "db/TEDecryptionDB.h"
+#endif
+#include "datastructures/BlockProposalFragment.h"
+#include "datastructures/CommittedBlock.h"
+#include "db/BlockProposalDB.h"
+#include "db/DAProofDB.h"
+#include "exceptions/ExitRequestedException.h"
+#include "exceptions/InvalidNodeIDException.h"
+#include "exceptions/InvalidSchainException.h"
+#include "headers/BlockFinalizeResponseHeader.h"
+#include "headers/Header.h"
+#include "monitoring/LivelinessMonitor.h"
+#include "node/Node.h"
+#include "node/NodeInfo.h"
+
+BlockFinalizeResponder::BlockFinalizeResponder( Schain& _sChain ) : sChain( _sChain ) {}
+
+BlockFinalizeRequestData BlockFinalizeResponder::parseRequest( const nlohmann::json& _jsonRequest ) {
+    BlockFinalizeRequestData request;
+
+    auto jsonRequest = _jsonRequest;
+    request.schainID = Header::getUint64( jsonRequest, "schainID" );
+    request.blockID = Header::getUint64( jsonRequest, "blockID" );
+    request.proposerIndex = Header::getUint64( jsonRequest, "proposerIndex" );
+    request.fragmentIndex = Header::getUint64( jsonRequest, "fragmentIndex" );
+    request.nodeID = Header::getUint64( jsonRequest, "nodeID" );
+#ifdef BITE
+    request.epochID = Header::getUint64( jsonRequest, "epochID" );
+    request.needDAProofSig = Header::getBool( jsonRequest, "needDASig" );
+    request.needDecryptionShares = Header::getBool( jsonRequest, "needShares" );
+    request.needFragmentData = Header::getBool( jsonRequest, "needData" );
+#endif
+
+    return request;
+}
+
+ptr< vector< uint8_t > > BlockFinalizeResponder::createResponse(
+    const BlockFinalizeRequestData& _request,
+    const ptr< BlockFinalizeResponseHeader >& _responseHeader ) {
+    CHECK_ARGUMENT( _responseHeader );
+
+    try {
+        if ( ( uint64_t ) sChain.getSchainID() != _request.schainID ) {
+            _responseHeader->setStatusSubStatus(
+                CONNECTION_ERROR, CONNECTION_ERROR_UNKNOWN_SCHAIN_ID );
+            BOOST_THROW_EXCEPTION( InvalidSchainException(
+                "Incorrect schain " + to_string( _request.schainID ), __CLASS_NAME__ ) );
+        }
+
+        auto nmi = sChain.getNode()->getNodeInfoById( _request.nodeID );
+        if ( nmi == nullptr ) {
+            _responseHeader->setStatusSubStatus(
+                CONNECTION_ERROR, CONNECTION_ERROR_DONT_KNOW_THIS_NODE );
+            BOOST_THROW_EXCEPTION( InvalidNodeIDException(
+                "Could not find node info for NODE_ID:" + to_string( ( uint64_t ) _request.nodeID ),
+                __CLASS_NAME__ ) );
+        }
+
+        if ( _request.fragmentIndex < 1 ||
+             ( uint64_t ) _request.fragmentIndex > sChain.getNodeCount() - 1 ) {
+            CONS_LOG( debug, "Incorrect fragment index:" << to_string( _request.fragmentIndex ) );
+            _responseHeader->setStatusSubStatus(
+                CONNECTION_DISCONNECT, CONNECTION_ERROR_INVALID_FRAGMENT_INDEX );
+            _responseHeader->setComplete();
+            return nullptr;
+        }
+
+        if ( _request.proposerIndex < 1 ||
+             ( uint64_t ) _request.proposerIndex > sChain.getNodeCount() ) {
+            CONS_LOG( debug, "Incorrect proposer index:" << to_string( _request.proposerIndex ) );
+            _responseHeader->setStatusSubStatus(
+                CONNECTION_DISCONNECT, CONNECTION_ERROR_INVALID_PROPOSER_INDEX );
+            _responseHeader->setComplete();
+            return nullptr;
+        }
+
+        auto proposal = sChain.getNode()->getBlockProposalDB()->getBlockProposal(
+            _request.blockID, _request.proposerIndex );
+        string daSig;
+
+        if ( !proposal || !sChain.getNode()->getDaProofDB()->haveDAProof( proposal ) ) {
+            auto committedBlock = sChain.getBlock( _request.blockID );
+
+            if ( committedBlock ) {
+                if ( committedBlock->getProposerIndex() != ( uint64_t ) _request.proposerIndex ) {
+                    _responseHeader->setStatusSubStatus( CONNECTION_DISCONNECT,
+                        CONNECTION_FINALIZER_CLIENT_ASKING_FOR_INCORRECT_PROPOSER_INDEX );
+                    CONS_LOG( err,
+                        "Client asked for proposal with incorrect proposer index:" +
+                            to_string( _request.proposerIndex ) +
+                            ":committed block proposer index:" +
+                            to_string( committedBlock->getProposerIndex() ) );
+                    _responseHeader->setComplete();
+                    return nullptr;
+                }
+
+                proposal = committedBlock;
+                daSig = committedBlock->getDaSig();
+            } else {
+                _responseHeader->setStatusSubStatus(
+                    CONNECTION_DISCONNECT, CONNECTION_FINALIZE_DONT_HAVE_PROPOSAL );
+                _responseHeader->setComplete();
+                return nullptr;
+            }
+        } else {
+            daSig = sChain.getNode()->getDaProofDB()->getDASig(
+                proposal->getBlockID(), proposal->getProposerIndex() );
+        }
+
+        CHECK_STATE2( !daSig.empty(), "Proposal has empty daSig" );
+
+        auto hash = proposal->getHash().toHex();
+        CHECK_STATE2( !hash.empty(), "Proposal has empty hash" );
+
+#ifdef BITE
+        ptr< AESKeyDecryptionShareList > myDecryptionShares;
+        if ( _request.needDecryptionShares ) {
+            myDecryptionShares = sChain.getNode()->getTEDecryptionDB()->getMyDecryptionShares(
+                proposal->getBlockID(), proposal->getProposerIndex() );
+            if ( !myDecryptionShares ) {
+                _responseHeader->setStatusSubStatus(
+                    CONNECTION_DISCONNECT, CONNECTION_FINALIZE_DONT_HAVE_DECRYPTION_SHARES );
+                _responseHeader->setComplete();
+                return nullptr;
+            }
+        } else {
+            myDecryptionShares = make_shared< AESKeyDecryptionShareList >(
+                _request.blockID, _request.proposerIndex, sChain.getSchainIndex() );
+        }
+#endif
+
+        auto fragment = proposal->getFragment( ( uint64_t ) sChain.getNodeCount() - 1,
+            _request.fragmentIndex
+#ifdef BITE
+            ,
+            sChain.getSchainIndex(), myDecryptionShares
+#endif
+        );
+
+        CHECK_STATE( fragment );
+
+        _responseHeader->setStatusSubStatus( CONNECTION_PROCEED, CONNECTION_OK );
+
+        auto serializedFragment = fragment->serialize(
+#ifdef BITE
+            _request.needDecryptionShares, _request.needFragmentData
+#endif
+        );
+        CHECK_STATE( serializedFragment );
+
+#ifdef BITE
+        if ( !_request.needDAProofSig ) {
+            daSig = "";
+        }
+#endif
+
+        _responseHeader->setFragmentParams(
+            serializedFragment->size(), proposal->serializeProposal()->size(), hash, daSig );
+
+        return serializedFragment;
+    } catch ( ExitRequestedException& ) {
+        throw;
+    } catch ( ... ) {
+        throw_with_nested( InvalidStateException( __PRETTY_FUNCTION__, __CLASS_NAME__ ) );
+    }
+}

--- a/blockfinalize/server/BlockFinalizeResponder.h
+++ b/blockfinalize/server/BlockFinalizeResponder.h
@@ -1,0 +1,67 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "SkaleCommon.h"
+#include "thirdparty/json.hpp"
+
+class BlockFinalizeResponseHeader;
+class Schain;
+
+/**
+ * Transport-neutral BlockFinalize request fields.
+ *
+ * Both the legacy TCP path and the new ZMQ path parse their incoming headers into this structure,
+ * then hand it to BlockFinalizeResponder so the actual finalization semantics live in one place.
+ */
+struct BlockFinalizeRequestData {
+    schain_id schainID = 0;
+    block_id blockID = 0;
+    schain_index proposerIndex = 0;
+    fragment_index fragmentIndex = 0;
+    node_id nodeID = 0;
+#ifdef BITE
+    epoch_id epochID = 0;
+    bool needDAProofSig = false;
+    bool needDecryptionShares = false;
+    bool needFragmentData = false;
+#endif
+};
+
+/**
+ * Shared BlockFinalize server-side logic.
+ *
+ * This class knows how to validate a BlockFinalize request, find the proposal / committed block,
+ * add DA proof and BITE share data when needed, and fill the response header + payload. It is used
+ * by both CatchupServerAgent (legacy TCP) and BlockFinalizeZmqServerAgent (new persistent ZMQ lane).
+ */
+class BlockFinalizeResponder {
+    Schain& sChain;
+
+public:
+    explicit BlockFinalizeResponder( Schain& _sChain );
+
+    // Parse JSON request fields into a transport-neutral request object.
+    static BlockFinalizeRequestData parseRequest( const nlohmann::json& _jsonRequest );
+
+    // Apply BlockFinalize semantics and produce the binary payload, if any.
+    ptr< vector< uint8_t > > createResponse( const BlockFinalizeRequestData& _request,
+        const ptr< BlockFinalizeResponseHeader >& _responseHeader );
+};

--- a/blockfinalize/server/BlockFinalizeZmqServerAgent.cpp
+++ b/blockfinalize/server/BlockFinalizeZmqServerAgent.cpp
@@ -100,6 +100,7 @@ void BlockFinalizeZmqServerAgent::processNextRequest( void* _socket ) {
                 "Unknown bulk-data request type:" + type, __CLASS_NAME__ ) );
         }
 
+        getSchain()->noteBlockFinalizeZmqServerRequestServed();
         auto request = BlockFinalizeResponder::parseRequest( jsonRequest );
         MONITOR( "BlockFinalizeResponder", __FUNCTION__ );
         serializedBinary = blockFinalizeResponder->createResponse( request, responseHeader );

--- a/blockfinalize/server/BlockFinalizeZmqServerAgent.cpp
+++ b/blockfinalize/server/BlockFinalizeZmqServerAgent.cpp
@@ -1,0 +1,125 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "SkaleCommon.h"
+
+#include "blockfinalize/server/BlockFinalizeResponder.h"
+#include "blockfinalize/server/BlockFinalizeZmqServerAgent.h"
+#include "blockfinalize/server/BlockFinalizeZmqServerThreadPool.h"
+
+#include "chains/Schain.h"
+#include "exceptions/CouldNotSendMessageException.h"
+#include "exceptions/ExitRequestedException.h"
+#include "exceptions/InvalidMessageFormatException.h"
+#include "exceptions/NetworkProtocolException.h"
+#include "exceptions/SkaleException.h"
+#include "headers/BlockFinalizeResponseHeader.h"
+#include "headers/Header.h"
+#include "monitoring/LivelinessMonitor.h"
+#include "network/Sockets.h"
+#include "network/ZMQHeaderPayloadFrame.h"
+#include "network/ZMQSockets.h"
+#include "node/Node.h"
+
+BlockFinalizeZmqServerAgent::BlockFinalizeZmqServerAgent(
+    Schain& _schain, const ptr< ZMQSockets >& _sockets )
+    : Agent( _schain, true ), sockets( _sockets ) {
+    CHECK_ARGUMENT( _sockets );
+
+    blockFinalizeResponder = make_shared< BlockFinalizeResponder >( _schain );
+    // ZMQ receive sockets are used from a single reader thread in the existing consensus path.
+    // Keep the bulk-data receive side on the same model and scale later via a different socket layout.
+    workerThreadPool = make_shared< BlockFinalizeZmqServerThreadPool >( num_threads( 1 ), this );
+    workerThreadPool->startService();
+}
+
+BlockFinalizeZmqServerAgent::~BlockFinalizeZmqServerAgent() {
+    if ( workerThreadPool ) {
+        workerThreadPool->joinAll();
+    }
+}
+
+void BlockFinalizeZmqServerAgent::workerThreadZmqServerLoop( BlockFinalizeZmqServerAgent* _agent ) {
+    CHECK_ARGUMENT( _agent );
+
+    logThreadLocal_ = _agent->getNode()->getLog();
+    _agent->waitOnGlobalStartBarrier();
+
+    auto socket = _agent->sockets->getReceiveSocket();
+
+    while ( !_agent->getNode()->isExitRequested() ) {
+        try {
+            _agent->processNextRequest( socket );
+        } catch ( ExitRequestedException& ) {
+            break;
+        } catch ( exception& e ) {
+            SkaleException::logNested( e );
+        }
+    }
+}
+
+void BlockFinalizeZmqServerAgent::processNextRequest( void* _socket ) {
+    CHECK_ARGUMENT( _socket );
+
+    uint32_t routingId = 0;
+    auto requestFrame = ZMQHeaderPayloadFrame::receiveFrame(
+        *getSchain(), _socket, &routingId, "Could not read ZMQ request", false );
+    if ( !requestFrame ) {
+        return;
+    }
+    CHECK_STATE( routingId > 0 );
+
+    ptr< vector< uint8_t > > requestPayload;
+    auto jsonRequest = ZMQHeaderPayloadFrame::unpackMessage(
+        requestFrame->data(), requestFrame->size(), requestPayload, "Could not parse ZMQ request" );
+    CHECK_STATE( !requestPayload );
+
+    auto responseHeader = make_shared< BlockFinalizeResponseHeader >();
+    ptr< vector< uint8_t > > serializedBinary = nullptr;
+
+    try {
+        auto type = Header::getString( jsonRequest, "type" );
+        if ( type.compare( Header::BLOCK_FINALIZE_REQ ) != 0 ) {
+            BOOST_THROW_EXCEPTION( InvalidMessageFormatException(
+                "Unknown bulk-data request type:" + type, __CLASS_NAME__ ) );
+        }
+
+        auto request = BlockFinalizeResponder::parseRequest( jsonRequest );
+        MONITOR( "BlockFinalizeResponder", __FUNCTION__ );
+        serializedBinary = blockFinalizeResponder->createResponse( request, responseHeader );
+    } catch ( ExitRequestedException& ) {
+        throw;
+    } catch ( ... ) {
+        try {
+            responseHeader->setStatusSubStatus( CONNECTION_ERROR, CONNECTION_SUBSTATUS_UNKNOWN );
+            responseHeader->setComplete();
+        } catch ( ... ) {
+        }
+    }
+
+    try {
+        auto responseFrame = ZMQHeaderPayloadFrame::packMessage( responseHeader, serializedBinary );
+        ZMQHeaderPayloadFrame::sendFrameToRoutingId( *getSchain(), _socket, routingId, responseFrame );
+    } catch ( ExitRequestedException& ) {
+        throw;
+    } catch ( ... ) {
+        throw_with_nested(
+            CouldNotSendMessageException( "Could not send ZMQ BlockFinalize response", __CLASS_NAME__ ) );
+    }
+}

--- a/blockfinalize/server/BlockFinalizeZmqServerAgent.h
+++ b/blockfinalize/server/BlockFinalizeZmqServerAgent.h
@@ -1,0 +1,49 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "Agent.h"
+
+class BlockFinalizeResponder;
+class BlockFinalizeZmqServerThreadPool;
+class ZMQSockets;
+
+/**
+ * ZMQ server for BlockFinalize requests on the bulk-data lane.
+ *
+ * This is the new persistent request/reply transport used by upgraded nodes. It intentionally does
+ * not own BlockFinalize semantics itself; it only decodes the ZMQ frame, delegates to
+ * BlockFinalizeResponder, then sends the response frame back.
+ */
+class BlockFinalizeZmqServerAgent : public Agent {
+    ptr< ZMQSockets > sockets;
+    ptr< BlockFinalizeResponder > blockFinalizeResponder;
+    ptr< BlockFinalizeZmqServerThreadPool > workerThreadPool;
+
+    // Handle one ZMQ BlockFinalize request on the already-bound receive socket.
+    void processNextRequest( void* _socket );
+
+public:
+    BlockFinalizeZmqServerAgent( Schain& _schain, const ptr< ZMQSockets >& _sockets );
+    ~BlockFinalizeZmqServerAgent() override;
+
+    // Main receive loop for the bulk-data ZMQ lane.
+    static void workerThreadZmqServerLoop( BlockFinalizeZmqServerAgent* _agent );
+};

--- a/blockfinalize/server/BlockFinalizeZmqServerThreadPool.cpp
+++ b/blockfinalize/server/BlockFinalizeZmqServerThreadPool.cpp
@@ -1,0 +1,40 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "SkaleCommon.h"
+
+#include "blockfinalize/server/BlockFinalizeZmqServerAgent.h"
+#include "blockfinalize/server/BlockFinalizeZmqServerThreadPool.h"
+#include "node/Node.h"
+
+BlockFinalizeZmqServerThreadPool::BlockFinalizeZmqServerThreadPool(
+    num_threads _numThreads, Agent* _agent )
+    : WorkerThreadPool( _numThreads, _agent, false ) {}
+
+void BlockFinalizeZmqServerThreadPool::createThread( uint64_t threadNumber ) {
+    auto func = [threadNumber, this]() {
+        setThreadName( "BlFnZmqSrv" + to_string( threadNumber ),
+            this->agent->getNode()->getConsensusEngine() );
+        BlockFinalizeZmqServerAgent::workerThreadZmqServerLoop(
+            reinterpret_cast< BlockFinalizeZmqServerAgent* >( this->agent ) );
+    };
+
+    LOCK( threadPoolLock );
+    this->threadpool.push_back( make_shared< thread >( func ) );
+}

--- a/blockfinalize/server/BlockFinalizeZmqServerThreadPool.h
+++ b/blockfinalize/server/BlockFinalizeZmqServerThreadPool.h
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "threads/WorkerThreadPool.h"
+
+class BlockFinalizeZmqServerAgent;
+
+/**
+ * Thin thread-pool wrapper for BlockFinalizeZmqServerAgent.
+ *
+ * Kept as a separate class to match the repo's existing server-agent pattern, even though the
+ * current ZMQ receive side uses a single worker thread.
+ */
+class BlockFinalizeZmqServerThreadPool : public WorkerThreadPool {
+    void createThread( uint64_t threadNumber ) override;
+
+public:
+    BlockFinalizeZmqServerThreadPool( num_threads _numThreads, Agent* _agent );
+};

--- a/catchup/server/CatchupServerAgent.cpp
+++ b/catchup/server/CatchupServerAgent.cpp
@@ -24,6 +24,7 @@
 #include "SkaleCommon.h"
 #include "Log.h"
 
+#include "blockfinalize/server/BlockFinalizeResponder.h"
 #include "crypto/BLAKE3Hash.h"
 
 #include "exceptions/ExitRequestedException.h"
@@ -38,15 +39,9 @@
 
 #include "db/BlockDB.h"
 #include "db/DAProofDB.h"
-#ifdef BITE
-#include "db/TEDecryptionDB.h"
-#include "crypto/AESKeyDecryptionShareList.h"
-#endif
-
 #include "abstracttcpserver/ConnectionStatus.h"
 
 #include "exceptions/CouldNotSendMessageException.h"
-#include "exceptions/InvalidNodeIDException.h"
 #include "exceptions/InvalidSchainException.h"
 #include "exceptions/OldBlockIDException.h"
 
@@ -76,6 +71,7 @@ CatchupServerAgent::CatchupServerAgent(Schain &_schain, const ptr<TCPServerSocke
     // we increased the catchup server thread pool to 8 threads since the catchup
     // server now serves both catchup and BITE finalize requests
     catchupWorkerThreadPool = make_shared<CatchupWorkerThreadPool>(num_threads(8), this);
+    blockFinalizeResponder = make_shared<BlockFinalizeResponder>(_schain);
     catchupWorkerThreadPool->startService();
     createNetworkReadThread();
 }
@@ -209,20 +205,12 @@ ptr<vector<uint8_t> > CatchupServerAgent::createResponseHeaderAndBinary(
                                                           dynamic_pointer_cast<CatchupResponseHeader>(_responseHeader),
                                                           blockID);
         } else if (type.compare(Header::BLOCK_FINALIZE_REQ) == 0) {
-            ptr<NodeInfo> nmi = sChain->getNode()->getNodeInfoById(nodeID);
-
-            if (nmi == nullptr) {
-                _responseHeader->setStatusSubStatus(
-                    CONNECTION_ERROR, CONNECTION_ERROR_DONT_KNOW_THIS_NODE);
-                BOOST_THROW_EXCEPTION(InvalidNodeIDException(
-                    "Could not find node info for NODE_ID:" + to_string( ( uint64_t ) nodeID ),
-                    __CLASS_NAME__ ));
-            }
-
-
-            serializedBinary = createBlockFinalizeResponse(_jsonRequest,
-                                                           dynamic_pointer_cast<BlockFinalizeResponseHeader>(
-                                                               _responseHeader), blockID);
+            auto request = BlockFinalizeResponder::parseRequest(_jsonRequest);
+            request.blockID = blockID;
+            request.nodeID = nodeID;
+            MONITOR( "BlockFinalizeResponder", __FUNCTION__ );
+            serializedBinary = blockFinalizeResponder->createResponse(
+                request, dynamic_pointer_cast<BlockFinalizeResponseHeader>(_responseHeader));
         }
 
 
@@ -296,149 +284,5 @@ ptr<vector<uint8_t> > CatchupServerAgent::createBlockCatchupResponse(
         throw;
     } catch (...) {
         throw_with_nested(InvalidStateException(__FUNCTION__, __CLASS_NAME__));
-    }
-}
-
-
-ptr<vector<uint8_t> > CatchupServerAgent::createBlockFinalizeResponse(
-    nlohmann::json _jsonRequest, const ptr<BlockFinalizeResponseHeader> &_responseHeader,
-    block_id _blockID) {
-    CHECK_ARGUMENT(_responseHeader);
-
-    MONITOR(__CLASS_NAME__, __FUNCTION__);
-
-    try {
-        fragment_index fragmentIndex = Header::getUint64(_jsonRequest, "fragmentIndex");
-
-        if (fragmentIndex < 1 || (uint64_t) fragmentIndex > getSchain()->getNodeCount() - 1) {
-            CONS_LOG(debug, "Incorrect fragment index:" << to_string( fragmentIndex ));
-            _responseHeader->setStatusSubStatus(
-                CONNECTION_DISCONNECT, CONNECTION_ERROR_INVALID_FRAGMENT_INDEX);
-            _responseHeader->setComplete();
-            return nullptr;
-        }
-
-
-        schain_index proposerIndex = Header::getUint64(_jsonRequest, "proposerIndex");
-
-
-        if (proposerIndex < 1 || (uint64_t) fragmentIndex > getSchain()->getNodeCount()) {
-            CONS_LOG(debug, "Incorrect proposer index:" << to_string( proposerIndex ));
-            _responseHeader->setStatusSubStatus(
-                CONNECTION_DISCONNECT, CONNECTION_ERROR_INVALID_PROPOSER_INDEX);
-            _responseHeader->setComplete();
-            return nullptr;
-        }
-
-#ifdef BITE
-        bool needDAProofSig = Header::getBool(_jsonRequest, "needDASig");
-        bool needDecryptionShares = Header::getBool(_jsonRequest, "needShares");
-        bool needFragmentData = Header::getBool(_jsonRequest, "needData");
-#endif
-
-        // We could have either a proposal or a committed block. Try proposal first.
-
-        auto proposal = getSchain()->getNode()->getBlockProposalDB()->getBlockProposal(
-            _blockID, proposerIndex);
-        string daSig;
-
-
-        // did not find the proposal or we do not have da proof f`rom it
-        // try committed block
-        if (!proposal || !getNode()->getDaProofDB()->haveDAProof(proposal)) {
-            // Could not find proposal with DA proof. Try committed block
-
-            auto committedBlock = getSchain()->getBlock(_blockID);
-
-            // found committed block
-            if (committedBlock) {
-                // first check that the proposer index
-                // the client should not be asking for an incorrect proposer index
-                // since at this time we already not which index has been committed
-                if (committedBlock->getProposerIndex() != (uint64_t) proposerIndex) {
-                    _responseHeader->setStatusSubStatus(CONNECTION_DISCONNECT,
-                                                        CONNECTION_FINALIZER_CLIENT_ASKING_FOR_INCORRECT_PROPOSER_INDEX);
-                    CONS_LOG(err, "Client asked for proposal with incorrect proposer index:" +
-                        to_string( proposerIndex ) + ":committed block proposer index:" +
-                        to_string( committedBlock->getProposerIndex() ));
-                    _responseHeader->setComplete();
-                    return nullptr;
-                }
-                proposal = committedBlock;
-                daSig = committedBlock->getDaSig();
-            } else {
-                _responseHeader->setStatusSubStatus(
-                    CONNECTION_DISCONNECT, CONNECTION_FINALIZE_DONT_HAVE_PROPOSAL);
-                _responseHeader->setComplete();
-                return nullptr;
-            }
-        } else {
-            daSig = getNode()->getDaProofDB()->getDASig(
-                proposal->getBlockID(), proposal->getProposerIndex());
-        }
-
-        CHECK_STATE2(!daSig.empty(), "Proposal has empty daSig");
-
-        auto hash = proposal->getHash().toHex();
-
-        CHECK_STATE2(!hash.empty(), "Proposal has empty hash");
-
-#ifdef BITE
-
-        ptr<AESKeyDecryptionShareList> myDecryptionShares;
-
-        if (needDecryptionShares) {
-            myDecryptionShares = getNode()->getTEDecryptionDB()->getMyDecryptionShares(proposal->getBlockID(),
-                proposal->getProposerIndex());
-            if (!myDecryptionShares) {
-                _responseHeader->setStatusSubStatus(
-                    CONNECTION_DISCONNECT, CONNECTION_FINALIZE_DONT_HAVE_DECRYPTION_SHARES);
-                _responseHeader->setComplete();
-                return nullptr;
-            }
-        } else {
-            // just returtn emptyu list
-            myDecryptionShares = make_shared<AESKeyDecryptionShareList>(_blockID, proposerIndex,
-                                                                        getSchain()->getSchainIndex());
-        }
-#endif
-
-
-        auto fragment =
-                proposal->getFragment((uint64_t) getSchain()->getNodeCount() - 1, fragmentIndex
-#ifdef BITE
-                                      , getSchain()->getSchainIndex()
-                                      , myDecryptionShares
-#endif
-                );
-
-
-        CHECK_STATE(fragment);
-
-        _responseHeader->setStatusSubStatus(CONNECTION_PROCEED, CONNECTION_OK);
-
-
-        auto serializedFragment = fragment->serialize(
-#ifdef BITE
-            needDecryptionShares,
-            needFragmentData
-#endif
-        );
-        CHECK_STATE(serializedFragment);
-#ifdef BITE
-        if (!needDAProofSig) {
-            // return empty sig
-            daSig = "";
-        }
-#endif
-
-        _responseHeader->setFragmentParams(serializedFragment->size(),
-                                           proposal->serializeProposal()->size(), hash, daSig);
-
-        return serializedFragment;
-    } catch (ExitRequestedException &e) {
-        throw;
-    } catch (...) {
-        throw_with_nested(InvalidStateException(__PRETTY_FUNCTION__, __CLASS_NAME__));
     }
 }

--- a/catchup/server/CatchupServerAgent.cpp
+++ b/catchup/server/CatchupServerAgent.cpp
@@ -205,6 +205,7 @@ ptr<vector<uint8_t> > CatchupServerAgent::createResponseHeaderAndBinary(
                                                           dynamic_pointer_cast<CatchupResponseHeader>(_responseHeader),
                                                           blockID);
         } else if (type.compare(Header::BLOCK_FINALIZE_REQ) == 0) {
+            getSchain()->noteBlockFinalizeTcpServerRequestServed();
             auto request = BlockFinalizeResponder::parseRequest(_jsonRequest);
             request.blockID = blockID;
             request.nodeID = nodeID;

--- a/catchup/server/CatchupServerAgent.h
+++ b/catchup/server/CatchupServerAgent.h
@@ -40,17 +40,15 @@ class CommittedBlock;
 class CommittedBlockList;
 class CatchupResponseHeader;
 class BlockFinalizeResponseHeader;
+class BlockFinalizeResponder;
 
 class CatchupServerAgent : public AbstractServerAgent {
     ptr< CatchupWorkerThreadPool > catchupWorkerThreadPool;
+    ptr< BlockFinalizeResponder > blockFinalizeResponder;
 
     ptr< vector< uint8_t > > createBlockCatchupResponse( const ptr< ServerConnection >& _connectionEnvelope,
         nlohmann::json _jsonRequest, const ptr< CatchupResponseHeader >& _responseHeader,
         block_id _blockID );
-
-
-    ptr< vector< uint8_t > > createBlockFinalizeResponse( nlohmann::json _jsonRequest,
-        const ptr< BlockFinalizeResponseHeader >& _responseHeader, block_id _blockID );
 
 
 public:

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1506,8 +1506,11 @@ void Schain::constructServers(const ptr<Sockets> &_sockets) {
     MONITOR(__CLASS_NAME__, __FUNCTION__)
 
     catchupServerAgent = make_shared<CatchupServerAgent>(*this, _sockets->catchupSocket);
-    blockFinalizeZmqServerAgent =
-        make_shared<BlockFinalizeZmqServerAgent>(*this, _sockets->getBulkDataZMQSockets());
+    
+    if ( getNode()->getTestConfig()->isBlockFinalizeZmqServerEnabled() ) {
+        blockFinalizeZmqServerAgent =
+            make_shared<BlockFinalizeZmqServerAgent>(*this, _sockets->getBulkDataZMQSockets());
+    }
 
 
     if (getNode()->isSyncOnlyNode())

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -51,6 +51,7 @@
 #include "utils/Time.h"
 
 #include "blockfinalize/client/BlockFinalizeDownloader.h"
+#include "blockfinalize/server/BlockFinalizeZmqServerAgent.h"
 #include "blockproposal/server/BlockProposalServerAgent.h"
 #include "catchup/client/CatchupClientAgent.h"
 #include "catchup/server/CatchupServerAgent.h"
@@ -1494,6 +1495,8 @@ void Schain::constructServers(const ptr<Sockets> &_sockets) {
     MONITOR(__CLASS_NAME__, __FUNCTION__)
 
     catchupServerAgent = make_shared<CatchupServerAgent>(*this, _sockets->catchupSocket);
+    blockFinalizeZmqServerAgent =
+        make_shared<BlockFinalizeZmqServerAgent>(*this, _sockets->getBulkDataZMQSockets());
 
 
     if (getNode()->isSyncOnlyNode())

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -1507,7 +1507,7 @@ void Schain::constructServers(const ptr<Sockets> &_sockets) {
 
     catchupServerAgent = make_shared<CatchupServerAgent>(*this, _sockets->catchupSocket);
     
-    if ( getNode()->getTestConfig()->isBlockFinalizeZmqServerEnabled() ) {
+    if ( getNode()->isBlockFinalizeZmqEnabled() ) {
         blockFinalizeZmqServerAgent =
             make_shared<BlockFinalizeZmqServerAgent>(*this, _sockets->getBulkDataZMQSockets());
     }

--- a/chains/Schain.h
+++ b/chains/Schain.h
@@ -54,6 +54,7 @@ class BlockProposalPusherThreadPool;
 
 class BlockFinalizeDownloader;
 class BlockFinalizeDownloaderThreadPool;
+class BlockFinalizeZmqServerAgent;
 
 
 class SchainMessageThreadPool;
@@ -135,8 +136,12 @@ class Schain : public Agent {
 
     ptr< BlockProposalServerAgent > blockProposalServerAgent;
 
+    // Includes both Catchup & BlockFinalize server agents. Uses TCP
     ptr<  CatchupServerAgent > catchupServerAgent;
-
+    // Block Finalize Client. Supports both TCP & ZMQ
+    ptr<BlockFinalizeDownloader> downloaderAgent;
+    // Block Finalize ZMQ Server. Only supports ZMQ
+    ptr<BlockFinalizeZmqServerAgent> blockFinalizeZmqServerAgent;
 
     ptr< MonitoringAgent > monitoringAgent;
 
@@ -147,7 +152,6 @@ class Schain : public Agent {
     ptr< PendingTransactionsAgent > pendingTransactionsAgent;
 
     ptr< BlockProposalClientAgent > blockProposalClient;
-
     ptr< CatchupClientAgent > catchupClientAgent;
 
     ptr< PricingAgent > pricingAgent;
@@ -159,8 +163,6 @@ class Schain : public Agent {
 #endif
 
     ptr<OptimizerAgent> optimizerAgent;
-
-    ptr<BlockFinalizeDownloader> downloaderAgent;
 
     ptr< IO > io;
 

--- a/chains/Schain.h
+++ b/chains/Schain.h
@@ -106,6 +106,14 @@ class CPUThreadPoolExecutor;
 }
 #endif
 
+struct BlockFinalizeTransportStats {
+    uint64_t zmqClientAttempts = 0;
+    uint64_t zmqClientFallbacksToTcp = 0;
+    uint64_t tcpClientRequests = 0;
+    uint64_t zmqServerRequestsServed = 0;
+    uint64_t tcpServerRequestsServed = 0;
+};
+
 class Schain : public Agent {
     queue< ptr< MessageEnvelope > > messageQueue;
 
@@ -212,6 +220,13 @@ class Schain : public Agent {
     atomic< bool > isStateInitialized = false;
 
     ptr< NodeInfo > thisNodeInfo = nullptr;
+
+    // blockFinalize metrics
+    atomic< uint64_t > blockFinalizeZmqClientAttempts = 0;
+    atomic< uint64_t > blockFinalizeZmqClientFallbacksToTcp = 0;
+    atomic< uint64_t > blockFinalizeTcpClientRequests = 0;
+    atomic< uint64_t > blockFinalizeZmqServerRequestsServed = 0;
+    atomic< uint64_t > blockFinalizeTcpServerRequestsServed = 0;
 
     uint64_t verifyDaSigsPatchTimestamp = 0;
     uint64_t fastConsensusPatchTimestamp = 0;
@@ -514,6 +529,13 @@ public:
     const ptr<CatchupClientAgent> &getCatchupClientAgent() const;
 
     ptr< OptimizerAgent > getOptimizerAgent() const;
+
+    void noteBlockFinalizeZmqClientAttempt();
+    void noteBlockFinalizeZmqClientFallbackToTcp();
+    void noteBlockFinalizeTcpClientRequest();
+    void noteBlockFinalizeZmqServerRequestServed();
+    void noteBlockFinalizeTcpServerRequestServed();
+    BlockFinalizeTransportStats getBlockFinalizeTransportStats() const;
 
     bool fastConsensusPatchEnabled( uint64_t _blockTimeStampSec );
 

--- a/chains/Schain.h
+++ b/chains/Schain.h
@@ -112,6 +112,19 @@ struct BlockFinalizeTransportStats {
     uint64_t tcpClientRequests = 0;
     uint64_t zmqServerRequestsServed = 0;
     uint64_t tcpServerRequestsServed = 0;
+
+    void add( const BlockFinalizeTransportStats& _other ) {
+        zmqClientAttempts += _other.zmqClientAttempts;
+        zmqClientFallbacksToTcp += _other.zmqClientFallbacksToTcp;
+        tcpClientRequests += _other.tcpClientRequests;
+        zmqServerRequestsServed += _other.zmqServerRequestsServed;
+        tcpServerRequestsServed += _other.tcpServerRequestsServed;
+    }
+
+    uint64_t totalRequests() const {
+        return zmqClientAttempts + zmqClientFallbacksToTcp + tcpClientRequests +
+            zmqServerRequestsServed + tcpServerRequestsServed;
+    }
 };
 
 class Schain : public Agent {

--- a/chains/SchainGettersSetters.cpp
+++ b/chains/SchainGettersSetters.cpp
@@ -35,6 +35,7 @@
 #include "monitoring/StuckDetectionAgent.h"
 #include "utils/Time.h"
 
+#include "TestConfig.h"
 
 #include "SchainMessageThreadPool.h"
 #include "crypto/ConsensusBLSSigShare.h"
@@ -285,6 +286,51 @@ ptr< BiteManager > Schain::getBiteManager() const {
 ptr< OptimizerAgent > Schain::getOptimizerAgent() const {
     CHECK_STATE( optimizerAgent );
     return optimizerAgent;
+}
+
+void Schain::noteBlockFinalizeZmqClientAttempt() {
+    if ( !getNode()->getTestConfig()->isBlockFinalizeTransportStatsEnabled() ) {
+        return;
+    }
+    ++blockFinalizeZmqClientAttempts;
+}
+
+void Schain::noteBlockFinalizeZmqClientFallbackToTcp() {
+    if ( !getNode()->getTestConfig()->isBlockFinalizeTransportStatsEnabled() ) {
+        return;
+    }
+    ++blockFinalizeZmqClientFallbacksToTcp;
+}
+
+void Schain::noteBlockFinalizeTcpClientRequest() {
+    if ( !getNode()->getTestConfig()->isBlockFinalizeTransportStatsEnabled() ) {
+        return;
+    }
+    ++blockFinalizeTcpClientRequests;
+}
+
+void Schain::noteBlockFinalizeZmqServerRequestServed() {
+    if ( !getNode()->getTestConfig()->isBlockFinalizeTransportStatsEnabled() ) {
+        return;
+    }
+    ++blockFinalizeZmqServerRequestsServed;
+}
+
+void Schain::noteBlockFinalizeTcpServerRequestServed() {
+    if ( !getNode()->getTestConfig()->isBlockFinalizeTransportStatsEnabled() ) {
+        return;
+    }
+    ++blockFinalizeTcpServerRequestsServed;
+}
+
+BlockFinalizeTransportStats Schain::getBlockFinalizeTransportStats() const {
+    BlockFinalizeTransportStats stats;
+    stats.zmqClientAttempts = blockFinalizeZmqClientAttempts.load();
+    stats.zmqClientFallbacksToTcp = blockFinalizeZmqClientFallbacksToTcp.load();
+    stats.tcpClientRequests = blockFinalizeTcpClientRequests.load();
+    stats.zmqServerRequestsServed = blockFinalizeZmqServerRequestsServed.load();
+    stats.tcpServerRequestsServed = blockFinalizeTcpServerRequestsServed.load();
+    return stats;
 }
 
 

--- a/chains/TestConfig.cpp
+++ b/chains/TestConfig.cpp
@@ -30,14 +30,6 @@ bool TestConfig::isFinalizationDownloadOnly() const {
     return finalizationDownloadOnly;
 }
 
-bool TestConfig::isBlockFinalizeZmqClientEnabled() const {
-    return blockFinalizeZmqClientEnabled;
-}
-
-bool TestConfig::isBlockFinalizeZmqServerEnabled() const {
-    return blockFinalizeZmqServerEnabled;
-}
-
 bool TestConfig::isBlockFinalizeTransportStatsEnabled() const {
     return blockFinalizeTransportStatsEnabled;
 }
@@ -47,24 +39,12 @@ TestConfig::TestConfig( nlohmann::json cgf ) {
     finalizationDownloadOnly = ( option != nullptr );
 
     if ( cgf.is_object() ) {
-        blockFinalizeZmqClientEnabled =
-            cgf.value( "testBlockFinalizeZmqClientEnabled", true );
-        blockFinalizeZmqServerEnabled =
-            cgf.value( "testBlockFinalizeZmqServerEnabled", true );
         blockFinalizeTransportStatsEnabled =
             cgf.value( "testBlockFinalizeTransportStatsEnabled", false );
     }
 
     if ( finalizationDownloadOnly ) {
         CONS_LOG( info, "Testing the case of only finalization download" );
-    }
-
-    if ( !blockFinalizeZmqClientEnabled ) {
-        CONS_LOG( info, "Testing BlockFinalize with ZMQ client disabled" );
-    }
-
-    if ( !blockFinalizeZmqServerEnabled ) {
-        CONS_LOG( info, "Testing BlockFinalize with ZMQ server disabled" );
     }
 
     if ( blockFinalizeTransportStatsEnabled ) {

--- a/chains/TestConfig.cpp
+++ b/chains/TestConfig.cpp
@@ -30,11 +30,44 @@ bool TestConfig::isFinalizationDownloadOnly() const {
     return finalizationDownloadOnly;
 }
 
-TestConfig::TestConfig( nlohmann::json /*cgf */ ) {
+bool TestConfig::isBlockFinalizeZmqClientEnabled() const {
+    return blockFinalizeZmqClientEnabled;
+}
+
+bool TestConfig::isBlockFinalizeZmqServerEnabled() const {
+    return blockFinalizeZmqServerEnabled;
+}
+
+bool TestConfig::isBlockFinalizeTransportStatsEnabled() const {
+    return blockFinalizeTransportStatsEnabled;
+}
+
+TestConfig::TestConfig( nlohmann::json cgf ) {
     auto option = std::getenv( "TEST_FINALIZATION_DOWNLOAD_ONLY" );
     finalizationDownloadOnly = ( option != nullptr );
 
+    if ( cgf.is_object() ) {
+        blockFinalizeZmqClientEnabled =
+            cgf.value( "testBlockFinalizeZmqClientEnabled", true );
+        blockFinalizeZmqServerEnabled =
+            cgf.value( "testBlockFinalizeZmqServerEnabled", true );
+        blockFinalizeTransportStatsEnabled =
+            cgf.value( "testBlockFinalizeTransportStatsEnabled", false );
+    }
+
     if ( finalizationDownloadOnly ) {
         CONS_LOG( info, "Testing the case of only finalization download" );
+    }
+
+    if ( !blockFinalizeZmqClientEnabled ) {
+        CONS_LOG( info, "Testing BlockFinalize with ZMQ client disabled" );
+    }
+
+    if ( !blockFinalizeZmqServerEnabled ) {
+        CONS_LOG( info, "Testing BlockFinalize with ZMQ server disabled" );
+    }
+
+    if ( blockFinalizeTransportStatsEnabled ) {
+        CONS_LOG( info, "Testing BlockFinalize transport stats collection enabled" );
     }
 }

--- a/chains/TestConfig.h
+++ b/chains/TestConfig.h
@@ -27,14 +27,10 @@
 
 class TestConfig {
     bool finalizationDownloadOnly = false;
-    bool blockFinalizeZmqClientEnabled = true;
-    bool blockFinalizeZmqServerEnabled = true;
     bool blockFinalizeTransportStatsEnabled = false;
 
 public:
     bool isFinalizationDownloadOnly() const;
-    bool isBlockFinalizeZmqClientEnabled() const;
-    bool isBlockFinalizeZmqServerEnabled() const;
     bool isBlockFinalizeTransportStatsEnabled() const;
 
     TestConfig( nlohmann::json cgf );

--- a/chains/TestConfig.h
+++ b/chains/TestConfig.h
@@ -23,12 +23,19 @@
 #ifndef SKALED_TESTCONFIG_H
 #define SKALED_TESTCONFIG_H
 
+#include "thirdparty/json.hpp"
 
 class TestConfig {
     bool finalizationDownloadOnly = false;
+    bool blockFinalizeZmqClientEnabled = true;
+    bool blockFinalizeZmqServerEnabled = true;
+    bool blockFinalizeTransportStatsEnabled = false;
 
 public:
     bool isFinalizationDownloadOnly() const;
+    bool isBlockFinalizeZmqClientEnabled() const;
+    bool isBlockFinalizeZmqServerEnabled() const;
+    bool isBlockFinalizeTransportStatsEnabled() const;
 
     TestConfig( nlohmann::json cgf );
 };

--- a/exceptions/ZMQTransportException.h
+++ b/exceptions/ZMQTransportException.h
@@ -1,0 +1,38 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+
+    @file ZMQTransportException.h
+    @author Sidnei Teixeira
+    @date 2026
+*/
+
+#pragma once
+
+#include "NetworkProtocolException.h"
+
+class ZMQTransportException : public NetworkProtocolException {
+    int zmqErrno = 0;
+
+public:
+    ZMQTransportException( const string& _message, int _zmqErrno, const string& _className )
+        : NetworkProtocolException( _message, _className ), zmqErrno( _zmqErrno ) {}
+
+    [[nodiscard]] int getZmqErrno() const {
+        return zmqErrno;
+    }
+};

--- a/headers/BasicHeader.cpp
+++ b/headers/BasicHeader.cpp
@@ -67,7 +67,7 @@ ptr< Buffer > BasicHeader::toBuffer() {
 }
 
 
-void BasicHeader::nullCheck( nlohmann::json& js, const char* _name ) {
+void BasicHeader::nullCheck( const nlohmann::json& js, const char* _name ) {
     CHECK_ARGUMENT( _name );
     if ( js.find( _name ) == js.end() ) {
         BOOST_THROW_EXCEPTION(
@@ -75,14 +75,14 @@ void BasicHeader::nullCheck( nlohmann::json& js, const char* _name ) {
     }
 };
 
-uint64_t BasicHeader::getUint64( nlohmann::json& _js, const char* _name ) {
+uint64_t BasicHeader::getUint64( const nlohmann::json& _js, const char* _name ) {
     CHECK_ARGUMENT( _name );
     nullCheck( _js, _name );
     uint64_t result = _js[_name];
     return result;
 };
 
-uint64_t BasicHeader::getUint64Rapid( rapidjson::Document& _d, const char* _name ) {
+uint64_t BasicHeader::getUint64Rapid( const rapidjson::Document& _d, const char* _name ) {
     CHECK_ARGUMENT( _name );
     CHECK_STATE2( _d.HasMember( _name ), "No JSON member:" + string( _name ) );
     const rapidjson::Value& a = _d[_name];
@@ -90,7 +90,7 @@ uint64_t BasicHeader::getUint64Rapid( rapidjson::Document& _d, const char* _name
     return a.GetUint64();
 };
 
-string BasicHeader::getStringRapid( rapidjson::Document& _d, const char* _name ) {
+string BasicHeader::getStringRapid( const rapidjson::Document& _d, const char* _name ) {
     CHECK_ARGUMENT( _name );
     CHECK_STATE2( _d.HasMember( _name ), "No JSON member:" + string( _name ) );
     CHECK_STATE( _d[_name].IsString() );
@@ -98,7 +98,7 @@ string BasicHeader::getStringRapid( rapidjson::Document& _d, const char* _name )
 };
 
 
-int32_t BasicHeader::getInt32( nlohmann::json& _js, const char* _name ) {
+int32_t BasicHeader::getInt32( const nlohmann::json& _js, const char* _name ) {
     CHECK_ARGUMENT( _name );
     nullCheck( _js, _name );
     int32_t result = _js[_name];
@@ -106,21 +106,21 @@ int32_t BasicHeader::getInt32( nlohmann::json& _js, const char* _name ) {
 };
 
 
-uint32_t BasicHeader::getUint32( nlohmann::json& _js, const char* _name ) {
+uint32_t BasicHeader::getUint32( const nlohmann::json& _js, const char* _name ) {
     CHECK_ARGUMENT( _name );
     nullCheck( _js, _name );
     uint32_t result = _js[_name];
     return result;
 };
 
-string BasicHeader::getString( nlohmann::json& _js, const char* _name ) {
+string BasicHeader::getString( const nlohmann::json& _js, const char* _name ) {
     CHECK_ARGUMENT( _name );
     nullCheck( _js, _name );
     string result = _js[_name];
     return result;
 }
 
-bool  BasicHeader::getBool( nlohmann::json& _js, const char* _name ) {
+bool  BasicHeader::getBool( const nlohmann::json& _js, const char* _name ) {
     CHECK_ARGUMENT( _name );
     nullCheck( _js, _name );
     bool result = _js[_name];
@@ -128,7 +128,7 @@ bool  BasicHeader::getBool( nlohmann::json& _js, const char* _name ) {
 }
 
 
-string BasicHeader::maybeGetString( nlohmann::json& _js, const char* _name ) {
+string BasicHeader::maybeGetString( const nlohmann::json& _js, const char* _name ) {
     CHECK_ARGUMENT( _name );
     if ( _js.find( _name ) == _js.end() ) {
         return "";

--- a/headers/BasicHeader.h
+++ b/headers/BasicHeader.h
@@ -70,7 +70,7 @@ public:
 
     void setComplete() { complete = true; }
 
-    static void nullCheck( nlohmann::json& js, const char* _name );
+    static void nullCheck( const nlohmann::json& js, const char* _name );
 
 
     virtual string serializeToString();
@@ -79,19 +79,19 @@ public:
 
     virtual void addFields( nlohmann::json& j ) = 0;
 
-    static uint64_t getUint64( nlohmann::json& _js, const char* _name );
+    static uint64_t getUint64( const nlohmann::json& _js, const char* _name );
 
-    static string getStringRapid( rapidjson::Document& _d, const char* _name );
+    static string getStringRapid( const rapidjson::Document& _d, const char* _name );
 
-    static uint64_t getUint64Rapid( rapidjson::Document& _d, const char* _name );
+    static uint64_t getUint64Rapid( const rapidjson::Document& _d, const char* _name );
 
-    static uint32_t getUint32( nlohmann::json& _js, const char* _name );
+    static uint32_t getUint32( const nlohmann::json& _js, const char* _name );
 
-    static int32_t getInt32( nlohmann::json& _js, const char* _name );
+    static int32_t getInt32( const nlohmann::json& _js, const char* _name );
 
-    static string getString( nlohmann::json& _js, const char* _name );
+    static string getString( const nlohmann::json& _js, const char* _name );
 
-    static bool getBool( nlohmann::json& _js, const char* _name );
+    static bool getBool( const nlohmann::json& _js, const char* _name );
 
-    static string maybeGetString( nlohmann::json& _js, const char* _name );
+    static string maybeGetString( const nlohmann::json& _js, const char* _name );
 };

--- a/network/ServerSocket.cpp
+++ b/network/ServerSocket.cpp
@@ -29,16 +29,13 @@
 #include "Utils.h"
 
 
-ServerSocket::ServerSocket( const string& _bindIP, uint16_t _basePort, port_type _portType )
-    : bindIP( _bindIP ) {
+ServerSocket::ServerSocket( const string& _bindIP, uint16_t _port )
+    : bindIP( _bindIP ), bindPort( _port) {
     CHECK_ARGUMENT( !_bindIP.empty() )
-
-    bindPort = _basePort + _portType;
 
     CHECK_STATE( Utils::isValidIpAddress( _bindIP ) );
 
-    CONS_LOG( debug, "Binding ip: " << _bindIP << " " << to_string( bindPort ) << " "
-                               << to_string( _basePort ) );
+    CONS_LOG( debug, "Binding ip: " << _bindIP << ":" << to_string( bindPort ) );
 }
 
 

--- a/network/SocketPortDeltas.h
+++ b/network/SocketPortDeltas.h
@@ -16,26 +16,23 @@
     You should have received a copy of the GNU Affero General Public License
     along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
 
-    @file ServerSocket.h
-    @author Stan Kladko
-    @date 2018
+    @file SocketPorts.h
+    @author Sidnei Teixeira
+    @date 2026
 */
 
 #pragma once
 
+#include <cstdint>
+#include "SkaleCommon.h"
 
-class ServerSocket {
-protected:
-    recursive_mutex m;
-
-    string bindIP;
-
-    uint32_t bindPort = 0;
-
-public:
-    ServerSocket( const string& _bindIP, uint16_t _port );
-
-    virtual ~ServerSocket();
-
-    virtual void closeAndCleanupAll() = 0;
+/**
+ * Holds the port deltas for different network sockets used by the node.
+ * These deltas are added to the base port to calculate the final port numbers.
+ */
+struct SocketPortDeltas {
+    uint16_t ZMQBinaryConsensusPortDelta = BINARY_CONSENSUS;
+    uint16_t ZMQBulkDataPortDelta        = BULK_DATA_ZMQ;
+    uint16_t TCPBlockProposalPortDelta   = PROPOSAL;
+    uint16_t TCPCatchupPortDelta         = CATCHUP;
 };

--- a/network/Sockets.cpp
+++ b/network/Sockets.cpp
@@ -34,15 +34,22 @@
 
 using namespace std;
 
-void Sockets::initSockets( const string& _bindIP, uint16_t _basePort ) {
+void Sockets::initSockets( const string& _bindIP, uint16_t basePort, const SocketPortDeltas& ports ) {
     CHECK_ARGUMENT( !_bindIP.empty() );
 
     CONS_LOG( debug, "Initing network processing\n" );
 
-    consensusZMQSockets = make_shared< ZMQSockets >( _bindIP, _basePort, BINARY_CONSENSUS );
-    bulkDataZMQSockets = make_shared< ZMQSockets >( _bindIP, _basePort, BULK_DATA_ZMQ );
-    blockProposalSocket = make_shared< TCPServerSocket >( _bindIP, _basePort, PROPOSAL );
-    catchupSocket = make_shared< TCPServerSocket >( _bindIP, _basePort, CATCHUP );
+    // ZMQ sockets use the base port plus lane delta for both local bind and remote connect.
+    consensusZMQSockets =
+        make_shared< ZMQSockets >( _bindIP, basePort + ports.ZMQBinaryConsensusPortDelta,
+            static_cast< port_type >( ports.ZMQBinaryConsensusPortDelta ) );
+    bulkDataZMQSockets =
+        make_shared< ZMQSockets >( _bindIP, basePort + ports.ZMQBulkDataPortDelta,
+            static_cast< port_type >( ports.ZMQBulkDataPortDelta ) );
+    
+    // TCP sockets used only for server side - no need to differentiate port types
+    blockProposalSocket = make_shared< TCPServerSocket >( _bindIP, basePort + ports.TCPBlockProposalPortDelta );
+    catchupSocket = make_shared< TCPServerSocket >( _bindIP, basePort + ports.TCPCatchupPortDelta );
 }
 
 

--- a/network/Sockets.cpp
+++ b/network/Sockets.cpp
@@ -40,6 +40,7 @@ void Sockets::initSockets( const string& _bindIP, uint16_t _basePort ) {
     CONS_LOG( debug, "Initing network processing\n" );
 
     consensusZMQSockets = make_shared< ZMQSockets >( _bindIP, _basePort, BINARY_CONSENSUS );
+    bulkDataZMQSockets = make_shared< ZMQSockets >( _bindIP, _basePort, BULK_DATA_ZMQ );
     blockProposalSocket = make_shared< TCPServerSocket >( _bindIP, _basePort, PROPOSAL );
     catchupSocket = make_shared< TCPServerSocket >( _bindIP, _basePort, CATCHUP );
 }
@@ -71,4 +72,9 @@ Node& Sockets::getNode() const {
 ptr< ZMQSockets > Sockets::getConsensusZMQSockets() const {
     CHECK_STATE( consensusZMQSockets );
     return consensusZMQSockets;
+}
+
+ptr< ZMQSockets > Sockets::getBulkDataZMQSockets() const {
+    CHECK_STATE( bulkDataZMQSockets );
+    return bulkDataZMQSockets;
 }

--- a/network/Sockets.h
+++ b/network/Sockets.h
@@ -39,10 +39,16 @@ class Sockets {
     Node& node;
 
 public:
+
+    // Network used specifically for low latency consensus messages
     ptr< ZMQSockets > consensusZMQSockets;
 
     ptr< TCPServerSocket > blockProposalSocket;
 
+    // ---- Bulk Data ZMQ Lane ----
+    // Request/reply traffic with larger payloads uses a separate ZMQ lane so it
+    // does not interfere with the consensus gossip channel.
+    ptr< ZMQSockets > bulkDataZMQSockets;
     ptr< TCPServerSocket > catchupSocket;
 
 
@@ -51,6 +57,7 @@ public:
     Sockets( Node& node );
 
     ptr< ZMQSockets > getConsensusZMQSockets() const;
+    ptr< ZMQSockets > getBulkDataZMQSockets() const;
 
     static ptr< sockaddr_in > createSocketAddress( const string& _ip, uint16_t port );
 

--- a/network/Sockets.h
+++ b/network/Sockets.h
@@ -25,12 +25,9 @@
 
 
 #include <arpa/inet.h>
-#include <mutex>
-#include <memory>
-#include "SkaleCommon.h"
-#include "node/Node.h"
+#include "SocketPortDeltas.h"
 
-
+class Node;
 class ServerSocker;
 class TCPServerSocket;
 class ZMQSockets;
@@ -61,5 +58,5 @@ public:
 
     static ptr< sockaddr_in > createSocketAddress( const string& _ip, uint16_t port );
 
-    void initSockets( const string& _bindIP, uint16_t _basePort );
+    void initSockets( const string& _bindIP, uint16_t basePort, const SocketPortDeltas& ports );
 };

--- a/network/Sockets.h
+++ b/network/Sockets.h
@@ -28,7 +28,6 @@
 #include "SocketPortDeltas.h"
 
 class Node;
-class ServerSocker;
 class TCPServerSocket;
 class ZMQSockets;
 

--- a/network/TCPServerSocket.cpp
+++ b/network/TCPServerSocket.cpp
@@ -32,8 +32,8 @@
 #include "Sockets.h"
 #include "TCPServerSocket.h"
 
-TCPServerSocket::TCPServerSocket( const string& _bindIP, uint16_t _basePort, port_type _portType )
-    : ServerSocket( _bindIP, _basePort, _portType ) {
+TCPServerSocket::TCPServerSocket( const string& _bindIP, uint16_t _bindPort )
+    : ServerSocket( _bindIP, _bindPort ) {
     socketaddr = Sockets::createSocketAddress( bindIP, bindPort );
 
     CHECK_STATE( socketaddr );
@@ -92,6 +92,6 @@ int TCPServerSocket::getDescriptor() {
 void TCPServerSocket::closeAndCleanupAll() {
     auto previous = descriptor.exchange( 0 );
     if ( previous != 0 ) {
-        close( descriptor );
+        close( previous );
     }
 }

--- a/network/TCPServerSocket.h
+++ b/network/TCPServerSocket.h
@@ -33,7 +33,7 @@ class TCPServerSocket : public ServerSocket {
     atomic< int > descriptor;
 
 public:
-    TCPServerSocket( const string& _bindIP, uint16_t _basePort, port_type _portType );
+    TCPServerSocket( const string& _bindIP, uint16_t _bindPort );
 
     void touch();
 

--- a/network/ZMQErrorClassifier.h
+++ b/network/ZMQErrorClassifier.h
@@ -1,0 +1,42 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+
+    @file ZMQErrorClassifier.h
+    @author Sidnei Teixeira
+    @date 2026
+*/
+
+#pragma once
+
+#include <cerrno>
+
+inline bool isZMQTransportErrorForTcpFallback( int _zmqErrno ) {
+    switch ( _zmqErrno ) {
+    case EAGAIN:
+    case ETIMEDOUT:
+    case ECONNRESET:
+    case ECONNREFUSED:
+    case ENETDOWN:
+    case ENETUNREACH:
+    case EHOSTUNREACH:
+    case EPIPE:
+        return true;
+    default:
+        return false;
+    }
+}

--- a/network/ZMQHeaderPayloadFrame.cpp
+++ b/network/ZMQHeaderPayloadFrame.cpp
@@ -1,0 +1,180 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "SkaleCommon.h"
+
+#include "chains/Schain.h"
+#include "exceptions/ExitRequestedException.h"
+#include "exceptions/NetworkProtocolException.h"
+#include "exceptions/ParsingException.h"
+#include "headers/Header.h"
+#include "node/Node.h"
+#include "utils/Time.h"
+#include "ZMQHeaderPayloadFrame.h"
+#include "zmq.h"
+
+using namespace std;
+
+namespace {
+void maybeSimulateDelay( Schain& _sChain ) {
+    auto simulatedDelay = _sChain.getNode()->getSimulateNetworkWriteDelayMs();
+    if ( simulatedDelay > 0 ) {
+        usleep( simulatedDelay * 1000 );
+    }
+}
+}
+
+ptr< vector< uint8_t > > ZMQHeaderPayloadFrame::packMessage(
+    const ptr< Header >& _header, const ptr< vector< uint8_t > >& _payload ) {
+    CHECK_ARGUMENT( _header );
+    CHECK_ARGUMENT( _header->isComplete() );
+
+    auto headerStr = _header->serializeToString();
+    auto headerLen = ( uint64_t ) headerStr.size();
+    auto payloadLen = _payload ? _payload->size() : 0;
+    auto frame = make_shared< vector< uint8_t > >( sizeof( headerLen ) + headerLen + payloadLen );
+
+    memcpy( frame->data(), &headerLen, sizeof( headerLen ) );
+    memcpy( frame->data() + sizeof( headerLen ), headerStr.data(), headerLen );
+
+    if ( _payload && !_payload->empty() ) {
+        memcpy( frame->data() + sizeof( headerLen ) + headerLen, _payload->data(), payloadLen );
+    }
+
+    return frame;
+}
+
+nlohmann::json ZMQHeaderPayloadFrame::unpackMessage( const void* _data, size_t _len,
+    ptr< vector< uint8_t > >& _payload, const char* _errorString, uint64_t _maxHeaderLen ) {
+    CHECK_ARGUMENT( _data );
+    CHECK_ARGUMENT( _errorString );
+
+    if ( _len < sizeof( uint64_t ) ) {
+        BOOST_THROW_EXCEPTION( ParsingException(
+            string( _errorString ) + ":frame too short", __CLASS_NAME__ ) );
+    }
+
+    uint64_t headerLen = 0;
+    memcpy( &headerLen, _data, sizeof( headerLen ) );
+
+    if ( headerLen < 2 || headerLen > _maxHeaderLen || sizeof( headerLen ) + headerLen > _len ) {
+        BOOST_THROW_EXCEPTION( ParsingException(
+            string( _errorString ) + ":invalid header len:" + to_string( headerLen ),
+            __CLASS_NAME__ ) );
+    }
+
+    auto headerData = reinterpret_cast< const char* >( _data ) + sizeof( headerLen );
+    auto header = string( headerData, headerLen );
+
+    try {
+        auto js = nlohmann::json::parse( header );
+        auto payloadLen = _len - sizeof( headerLen ) - headerLen;
+
+        if ( payloadLen > 0 ) {
+            _payload = make_shared< vector< uint8_t > >( payloadLen );
+            memcpy( _payload->data(), headerData + headerLen, payloadLen );
+        } else {
+            _payload = nullptr;
+        }
+
+        return js;
+    } catch ( ExitRequestedException& ) {
+        throw;
+    } catch ( ... ) {
+        BOOST_THROW_EXCEPTION( ParsingException(
+            string( _errorString ) + ":could not parse frame header", __CLASS_NAME__ ) );
+    }
+}
+
+void ZMQHeaderPayloadFrame::sendFrame( Schain& _sChain, void* _socket, const ptr< vector< uint8_t > >& _frame ) {
+    CHECK_ARGUMENT( _socket );
+    CHECK_ARGUMENT( _frame );
+
+    maybeSimulateDelay( _sChain );
+
+    auto rc = zmq_send( _socket, _frame->data(), _frame->size(), 0 );
+    if ( rc < 0 ) {
+        BOOST_THROW_EXCEPTION( NetworkProtocolException(
+            "ZMQ send failed:" + string( zmq_strerror( errno ) ), __CLASS_NAME__ ) );
+    }
+}
+
+void ZMQHeaderPayloadFrame::sendFrameToRoutingId( Schain& _sChain, void* _socket, uint32_t _routingId,
+    const ptr< vector< uint8_t > >& _frame ) {
+    CHECK_ARGUMENT( _socket );
+    CHECK_ARGUMENT( _frame );
+    CHECK_ARGUMENT( _routingId > 0 );
+
+    maybeSimulateDelay( _sChain );
+
+    zmq_msg_t msg;
+    auto rc = zmq_msg_init_size( &msg, _frame->size() );
+    CHECK_STATE( rc == 0 );
+
+    memcpy( zmq_msg_data( &msg ), _frame->data(), _frame->size() );
+    rc = zmq_msg_set_routing_id( &msg, _routingId );
+    CHECK_STATE( rc == 0 );
+
+    rc = zmq_msg_send( &msg, _socket, 0 );
+    if ( rc < 0 ) {
+        zmq_msg_close( &msg );
+        BOOST_THROW_EXCEPTION( NetworkProtocolException(
+            "ZMQ send failed:" + string( zmq_strerror( errno ) ), __CLASS_NAME__ ) );
+    }
+
+    rc = zmq_msg_close( &msg );
+    CHECK_STATE( rc == 0 );
+}
+
+ptr< vector< uint8_t > > ZMQHeaderPayloadFrame::receiveFrame(
+    Schain& _sChain, void* _socket, uint32_t* _routingId, const char* _errorString,
+    bool _throwOnTimeout ) {
+    CHECK_ARGUMENT( _socket );
+    CHECK_ARGUMENT( _errorString );
+
+    zmq_msg_t msg;
+    auto rc = zmq_msg_init( &msg );
+    CHECK_STATE( rc == 0 );
+
+    rc = zmq_msg_recv( &msg, _socket, 0 );
+    if ( rc < 0 ) {
+        zmq_msg_close( &msg );
+        if ( errno == EAGAIN ) {
+            // check if timeout happened during exit
+            _sChain.getNode()->exitCheck();
+
+            // If we're here, it means we got a timeout but exit was not requested. 
+            if ( !_throwOnTimeout ) {
+                return nullptr;
+            }
+        }
+        BOOST_THROW_EXCEPTION( NetworkProtocolException(
+            string( _errorString ) + ":" + zmq_strerror( errno ), __CLASS_NAME__ ) );
+    }
+
+    auto frame = make_shared< vector< uint8_t > >( rc );
+    memcpy( frame->data(), zmq_msg_data( &msg ), rc );
+
+    if ( _routingId ) {
+        *_routingId = zmq_msg_routing_id( &msg );
+    }
+
+    zmq_msg_close( &msg );
+    return frame;
+}

--- a/network/ZMQHeaderPayloadFrame.cpp
+++ b/network/ZMQHeaderPayloadFrame.cpp
@@ -23,7 +23,9 @@
 #include "exceptions/ExitRequestedException.h"
 #include "exceptions/NetworkProtocolException.h"
 #include "exceptions/ParsingException.h"
+#include "exceptions/ZMQTransportException.h"
 #include "headers/Header.h"
+#include "network/ZMQErrorClassifier.h"
 #include "node/Node.h"
 #include "utils/Time.h"
 #include "ZMQHeaderPayloadFrame.h"
@@ -37,6 +39,17 @@ void maybeSimulateDelay( Schain& _sChain ) {
     if ( simulatedDelay > 0 ) {
         usleep( simulatedDelay * 1000 );
     }
+}
+
+[[noreturn]] void throwZMQCommunicationException( const string& _message ) {
+    auto zmqErrno = zmq_errno();
+    auto errorMessage = _message + ":" + string( zmq_strerror( zmqErrno ) );
+
+    if ( isZMQTransportErrorForTcpFallback( zmqErrno ) ) {
+        BOOST_THROW_EXCEPTION( ZMQTransportException( errorMessage, zmqErrno, __CLASS_NAME__ ) );
+    }
+
+    BOOST_THROW_EXCEPTION( NetworkProtocolException( errorMessage, __CLASS_NAME__ ) );
 }
 }
 
@@ -110,8 +123,7 @@ void ZMQHeaderPayloadFrame::sendFrame( Schain& _sChain, void* _socket, const ptr
 
     auto rc = zmq_send( _socket, _frame->data(), _frame->size(), 0 );
     if ( rc < 0 ) {
-        BOOST_THROW_EXCEPTION( NetworkProtocolException(
-            "ZMQ send failed:" + string( zmq_strerror( errno ) ), __CLASS_NAME__ ) );
+        throwZMQCommunicationException( "ZMQ send failed" );
     }
 }
 
@@ -134,8 +146,7 @@ void ZMQHeaderPayloadFrame::sendFrameToRoutingId( Schain& _sChain, void* _socket
     rc = zmq_msg_send( &msg, _socket, 0 );
     if ( rc < 0 ) {
         zmq_msg_close( &msg );
-        BOOST_THROW_EXCEPTION( NetworkProtocolException(
-            "ZMQ send failed:" + string( zmq_strerror( errno ) ), __CLASS_NAME__ ) );
+        throwZMQCommunicationException( "ZMQ send failed" );
     }
 
     rc = zmq_msg_close( &msg );
@@ -154,8 +165,9 @@ ptr< vector< uint8_t > > ZMQHeaderPayloadFrame::receiveFrame(
 
     rc = zmq_msg_recv( &msg, _socket, 0 );
     if ( rc < 0 ) {
+        auto zmqErrno = zmq_errno();
         zmq_msg_close( &msg );
-        if ( errno == EAGAIN ) {
+        if ( zmqErrno == EAGAIN ) {
             // check if timeout happened during exit
             _sChain.getNode()->exitCheck();
 
@@ -164,8 +176,12 @@ ptr< vector< uint8_t > > ZMQHeaderPayloadFrame::receiveFrame(
                 return nullptr;
             }
         }
-        BOOST_THROW_EXCEPTION( NetworkProtocolException(
-            string( _errorString ) + ":" + zmq_strerror( errno ), __CLASS_NAME__ ) );
+        auto errorMessage = string( _errorString ) + ":" + string( zmq_strerror( zmqErrno ) );
+        if ( isZMQTransportErrorForTcpFallback( zmqErrno ) ) {
+            BOOST_THROW_EXCEPTION(
+                ZMQTransportException( errorMessage, zmqErrno, __CLASS_NAME__ ) );
+        }
+        BOOST_THROW_EXCEPTION( NetworkProtocolException( errorMessage, __CLASS_NAME__ ) );
     }
 
     auto frame = make_shared< vector< uint8_t > >( rc );

--- a/network/ZMQHeaderPayloadFrame.h
+++ b/network/ZMQHeaderPayloadFrame.h
@@ -1,0 +1,62 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "SkaleCommon.h"
+#include "thirdparty/json.hpp"
+
+class Header;
+class Schain;
+
+/**
+ * Helper for ZMQ request/reply protocols that use a small structured header
+ * plus an optional binary payload.
+ *
+ * This is intended for generic use (e.g. bulk-data or recovery-style traffic such as
+ * BlockFinalize, catchup, or similar non-hot-path requests). It is not meant
+ * for the latency-sensitive consensus message path, which uses its own more
+ * compact message format.
+ *
+ * Wire format:
+ * [uint64 header_len][serialized JSON header][optional payload bytes]
+ */
+class ZMQHeaderPayloadFrame {
+public:
+    // Serialize a completed Header plus optional binary body into one ZMQ frame.
+    static ptr< vector< uint8_t > > packMessage(
+        const ptr< Header >& _header, const ptr< vector< uint8_t > >& _payload = nullptr );
+
+    // Parse one ZMQ frame back into JSON header + optional binary body.
+    static nlohmann::json unpackMessage( const void* _data, size_t _len,
+        ptr< vector< uint8_t > >& _payload, const char* _errorString,
+        uint64_t _maxHeaderLen = MAX_HEADER_SIZE );
+
+    // Send a frame on a client socket.
+    static void sendFrame( Schain& _sChain, void* _socket, const ptr< vector< uint8_t > >& _frame );
+
+    // Send a frame from a server socket back to the request's routing id.
+    static void sendFrameToRoutingId( Schain& _sChain, void* _socket, uint32_t _routingId,
+        const ptr< vector< uint8_t > >& _frame );
+
+    // Receive one frame. Server-side loops can opt out of throwing on idle timeout.
+    static ptr< vector< uint8_t > > receiveFrame(
+        Schain& _sChain, void* _socket, uint32_t* _routingId, const char* _errorString,
+        bool _throwOnTimeout = true );
+};

--- a/network/ZMQSockets.cpp
+++ b/network/ZMQSockets.cpp
@@ -32,7 +32,7 @@
 #include "zmq.h"
 
 ZMQSockets::ZMQSockets( const string& _bindIP, uint16_t _basePort, port_type _portType )
-    : ServerSocket( _bindIP, _basePort, _portType ) {
+    : ServerSocket( _bindIP, _basePort, _portType ), portType( _portType ) {
     CHECK_ARGUMENT( !_bindIP.empty() )
     context = zmq_ctx_new();
 }
@@ -80,8 +80,8 @@ void* ZMQSockets::getDestinationSocket( const ptr< NodeInfo >& _remoteNodeInfo )
     zmq_setsockopt( requester, ZMQ_LINGER, &linger, sizeof( int ) );
 
 
-    int result = zmq_connect( requester,
-        ( "tcp://" + ipAddress + ":" + to_string( basePort + BINARY_CONSENSUS ) ).c_str() );
+    int result = zmq_connect(
+        requester, ( "tcp://" + ipAddress + ":" + to_string( basePort + portType ) ).c_str() );
     CONS_LOG( debug, "Connected ZMQ socket" << to_string( result ) );
     sendSockets[schainIndex] = requester;
 
@@ -164,6 +164,22 @@ void ZMQSockets::closeSend() {
                 CONS_LOG( err, "zmq_close returned an error on sendSocket;" );
             }
         }
+    }
+    sendSockets.clear();
+}
+
+void ZMQSockets::closeDestinationSocket( schain_index _schainIndex ) {
+    LOCK( m );
+
+    if ( sendSockets.count( _schainIndex ) == 0 ) {
+        return;
+    }
+
+    auto socket = sendSockets.at( _schainIndex );
+    sendSockets.erase( _schainIndex );
+
+    if ( socket && zmq_close( socket ) != 0 ) {
+        CONS_LOG( err, "zmq_close returned an error on peer sendSocket;" );
     }
 }
 

--- a/network/ZMQSockets.cpp
+++ b/network/ZMQSockets.cpp
@@ -31,8 +31,8 @@
 #include "exceptions/ExitRequestedException.h"
 #include "zmq.h"
 
-ZMQSockets::ZMQSockets( const string& _bindIP, uint16_t _basePort, port_type _portType )
-    : ServerSocket( _bindIP, _basePort, _portType ), portType( _portType ) {
+ZMQSockets::ZMQSockets( const string& _bindIP, uint16_t _bindPort, port_type _portType )
+    : ServerSocket( _bindIP, _bindPort ), portType( _portType ) {
     CHECK_ARGUMENT( !_bindIP.empty() )
     context = zmq_ctx_new();
 }
@@ -48,7 +48,6 @@ void* ZMQSockets::getDestinationSocket( const ptr< NodeInfo >& _remoteNodeInfo )
 
 
     auto ipAddress = _remoteNodeInfo->getBaseIP();
-
     auto basePort = _remoteNodeInfo->getPort();
 
     auto schainIndex = _remoteNodeInfo->getSchainIndex();

--- a/network/ZMQSockets.h
+++ b/network/ZMQSockets.h
@@ -30,6 +30,11 @@ class ZMQSockets : public ServerSocket {
     atomic< bool > closeSendCalled = false;
     atomic< bool > closeReceiveCalled = false;
     void* context = nullptr;
+
+    // port type to allow differentiating between different ZMQ socket sets 
+    // (e.g. consensus vs bulk data)
+    port_type portType;
+    
     map< schain_index, void* > sendSockets;
     void* receiveSocket = nullptr;
     void closeSend();
@@ -39,6 +44,7 @@ public:
     ZMQSockets( const string& _bindIP, uint16_t _basePort, port_type _portType );
     void* getReceiveSocket();
     void* getDestinationSocket( const ptr< NodeInfo >& _remoteNodeInfo );
+    void closeDestinationSocket( schain_index _schainIndex );
     void closeAndCleanupAll();
     virtual ~ZMQSockets();
 };

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -863,6 +863,10 @@ void ConsensusEngine::exitGracefullyAsync() {
             it.second->getSchain()->stopAndDestroyFinalizationExecutor();
 #endif
         }
+
+        for ( auto&& it : nodes ) {
+            it.second->closeZMQSocketsAfterJoin();
+        }
     } catch ( exception& e ) {
         SkaleException::logNested( e );
         status = CONSENSUS_EXITED;

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -294,6 +294,11 @@ void Node::initParamsFromConfig() {
     syncNodeReadJsonHeaderTimeoutSec =
         getParamUint64( "syncNodeReadJsonHeaderTimeoutSec", SYNC_NODE_READ_JSON_HEADER_TIMEOUT_SEC );
     testNet = ( getParamUint64( "isTestNet", 0 ) > 0 );
+    
+    if ( cfg.find( "blockFinalizeZmqEnabled" ) != cfg.end() ) {
+        blockFinalizeZmqEnabled =
+            cfg.at( "blockFinalizeZmqEnabled" ).get< bool >();
+    }
 
     blockDBSize = storageLimits->getBlockDbSize();
     proposalHashDBSize = storageLimits->getProposalHashDbSize();

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -314,6 +314,10 @@ void Node::initParamsFromConfig() {
 
     simulateNetworkWriteDelayMs = getParamInt64( "simulateNetworkWriteDelayMs", 0 );
 
+    // Socket port deltas may be overwritten in config.
+    socketPortDeltas.ZMQBulkDataPortDelta = static_cast< uint16_t >( getParamUint64(
+        "ZMQBulkDataPortDelta", socketPortDeltas.ZMQBulkDataPortDelta ) );
+
     testConfig = make_shared< TestConfig >( cfg );
 
     // For tests, allow env/config overrides while preserving any values already
@@ -417,7 +421,7 @@ void Node::startServers( ptr< vector< uint8_t > > _startingFromSnapshotWithThisA
 
     this->sockets = make_shared< Sockets >( *this );
 
-    sockets->initSockets( bindIP, ( uint16_t ) basePort );
+    sockets->initSockets( bindIP, static_cast<uint16_t>( basePort ), socketPortDeltas );
 
     CONS_LOG( trace, "Constructing servers" );
 

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -278,6 +278,8 @@ void Node::initParamsFromConfig() {
     stuckRestartIntervalMs = getParamUint64( "stuckRestartIntervalMs", STUCK_RESTART_INTERVAL_MS );
     waitAfterNetworkErrorMs =
         getParamUint64( "waitAfterNetworkErrorMs", WAIT_AFTER_NETWORK_ERROR_MS );
+    blockFinalizeDownloadTcpFallbackMs =
+        getParamUint64( "blockFinalizeDownloadTcpFallbackMs", BLOCK_FINALIZE_DOWNLOAD_TCP_FALLBACK_MS );
     maxCatchupDownloadBytes =
         getParamUint64( "maxCatchupDownloadBytes", MAX_CATCHUP_DOWNLOAD_BYTES );
     maxTransactionsPerBlock =

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -718,8 +718,13 @@ void Node::closeAllSocketsAndNotifyAllAgentsAndThreads() {
 
     CONS_LOG( info, "consensus engine exiting: catchup socket touched" );
 
-    if ( isSyncOnlyNode() )
+    if ( isSyncOnlyNode() ) {
+        if ( sockets ) {
+            sockets->getConsensusZMQSockets()->closeAndCleanupAll();
+            sockets->getBulkDataZMQSockets()->closeAndCleanupAll();
+        }
         return;
+    }
 
     if ( sockets && sockets->blockProposalSocket ) {
         sockets->blockProposalSocket->touch();
@@ -732,6 +737,8 @@ void Node::closeAllSocketsAndNotifyAllAgentsAndThreads() {
     if ( sockets ) {
         sockets->getConsensusZMQSockets()->closeAndCleanupAll();
         CONS_LOG( info, "consensus engine exiting: ZMQ sockets closeAndCleanupAll called" );
+        sockets->getBulkDataZMQSockets()->closeAndCleanupAll();
+        CONS_LOG( info, "consensus engine exiting: bulk-data ZMQ sockets closeAndCleanupAll called" );
     }
 
 #ifdef BITE

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -669,7 +669,7 @@ void Node::exitImmediately() {
 
     CONS_LOG( info, "Status server stopped" );
 
-    closeAllSocketsAndNotifyAllAgentsAndThreads();
+    notifyAllAgentsAndInterruptIo();
 
     CONS_LOG( info, __FUNCTION__ << string( " completed" ) );
 }
@@ -690,7 +690,7 @@ void Node::checkForExitOnBlockBoundaryAndExitIfNeeded() {
 }
 
 
-void Node::closeAllSocketsAndNotifyAllAgentsAndThreads() {
+void Node::notifyAllAgentsAndInterruptIo() {
     CONS_LOG( info, "consensus engine exiting: close all sockets called" );
 
     // guaranteed to run only once
@@ -719,10 +719,6 @@ void Node::closeAllSocketsAndNotifyAllAgentsAndThreads() {
     CONS_LOG( info, "consensus engine exiting: catchup socket touched" );
 
     if ( isSyncOnlyNode() ) {
-        if ( sockets ) {
-            sockets->getConsensusZMQSockets()->closeAndCleanupAll();
-            sockets->getBulkDataZMQSockets()->closeAndCleanupAll();
-        }
         return;
     }
 
@@ -734,19 +730,23 @@ void Node::closeAllSocketsAndNotifyAllAgentsAndThreads() {
     getSchain()->getCryptoManager()->exitZMQClient();
     CONS_LOG( info, "consensus engine exiting: exitZMQClient called" );
 
-    if ( sockets ) {
-        sockets->getConsensusZMQSockets()->closeAndCleanupAll();
-        CONS_LOG( info, "consensus engine exiting: ZMQ sockets closeAndCleanupAll called" );
-        sockets->getBulkDataZMQSockets()->closeAndCleanupAll();
-        CONS_LOG( info, "consensus engine exiting: bulk-data ZMQ sockets closeAndCleanupAll called" );
-    }
-
 #ifdef BITE
     if ( biteBlockFinalizeServer ) {
         biteBlockFinalizeServer->exitProxygenServer();
         CONS_LOG( info, "consensus engine exiting: exitProxygenServer called" );
     }
 #endif
+}
+
+void Node::closeZMQSocketsAfterJoin() {
+    if ( !sockets ) {
+        return;
+    }
+
+    sockets->getConsensusZMQSockets()->closeAndCleanupAll();
+    CONS_LOG( info, "consensus engine exiting: ZMQ sockets closeAndCleanupAll called" );
+    sockets->getBulkDataZMQSockets()->closeAndCleanupAll();
+    CONS_LOG( info, "consensus engine exiting: bulk-data ZMQ sockets closeAndCleanupAll called" );
 }
 
 /*

--- a/node/Node.h
+++ b/node/Node.h
@@ -278,7 +278,7 @@ class Node {
 
     void releaseGlobalClientBarrier();
 
-    void closeAllSocketsAndNotifyAllAgentsAndThreads();
+    void notifyAllAgentsAndInterruptIo();
 
     atomic< bool > exitOnBlockBoundaryRequested = false;
 
@@ -301,6 +301,9 @@ public:
     void initiateApplicationExitOnFatalConsensusError( const string& message );
 
     void doSoftAndThenHardExit();
+
+    // Called by ConsensusEngine after all worker threads have been joined.
+    void closeZMQSocketsAfterJoin();
 
     string getEcdsaKeyName();
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -221,6 +221,8 @@ class Node {
 
     uint64_t blockFinalizeDownloadTcpFallbackMs = 0;
 
+    bool blockFinalizeZmqEnabled = true;
+
     uint64_t emptyBlockIntervalMs = 0;
 
     uint64_t emptyBlockIntervalAfterCatchupMs = 0;
@@ -332,6 +334,8 @@ public:
     bool isSgxEnabled();
 
     bool isTestNet() const;
+
+    bool isBlockFinalizeZmqEnabled() const;
 
     [[nodiscard]] const ptr< TestConfig >& getTestConfig() const;
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -25,6 +25,7 @@
 
 #include <mutex>
 #include "thirdparty/json.hpp"
+#include "network/SocketPortDeltas.h"
 
 using namespace std;
 
@@ -260,6 +261,9 @@ class Node {
     uint64_t teDecryptionDBSize = 0;
 #endif
     uint64_t visualizationType = 0;
+
+    // Socket ports - already default initializes all port deltas
+    SocketPortDeltas socketPortDeltas;
 
 
     string gethURL = "";

--- a/node/Node.h
+++ b/node/Node.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <mutex>
+#include "thirdparty/json.hpp"
 
 using namespace std;
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -56,6 +56,7 @@ class TestConfig;
 class BlockSigShareDB;
 class DASigShareDB;
 class DAProofDB;
+class NodeTestAccess;
 
 #ifdef BITE
     class TEDecryptionDB;
@@ -79,6 +80,7 @@ enum PricingStrategyEnum { ZERO, DOS_PROTECT };
 
 class Node {
     friend class Schain;  // Allow Schain to access private barrier methods for teardown
+    friend class NodeTestAccess; // Allow test access to private members
     
     ConsensusEngine* consensusEngine;
 
@@ -216,6 +218,8 @@ class Node {
     uint64_t stuckRestartIntervalMs = 0;
 
     uint64_t waitAfterNetworkErrorMs = 0;
+
+    uint64_t blockFinalizeDownloadTcpFallbackMs = 0;
 
     uint64_t emptyBlockIntervalMs = 0;
 
@@ -484,6 +488,8 @@ public:
     uint64_t getsyncNodeReadJsonHeaderTimeoutSec() const;
 
     uint64_t getWaitAfterNetworkErrorMs();
+
+    uint64_t getBlockFinalizeDownloadTcpFallbackMs();
 
 #ifdef FAIR
     uint64_t getConstantGasPrice() const;

--- a/node/NodeGettersSetters.cpp
+++ b/node/NodeGettersSetters.cpp
@@ -279,6 +279,10 @@ uint64_t Node::getWaitAfterNetworkErrorMs() {
     return waitAfterNetworkErrorMs;
 }
 
+uint64_t Node::getBlockFinalizeDownloadTcpFallbackMs() {
+    return blockFinalizeDownloadTcpFallbackMs;
+}
+
 uint64_t Node::getEmptyBlockIntervalMs() const {
     return emptyBlockIntervalMs;
 }

--- a/node/NodeGettersSetters.cpp
+++ b/node/NodeGettersSetters.cpp
@@ -463,6 +463,10 @@ bool Node::isTestNet() const {
     return testNet;
 }
 
+bool Node::isBlockFinalizeZmqEnabled() const {
+    return blockFinalizeZmqEnabled;
+}
+
 void Node::setExitOnBlockBoundaryRequested() {
     CONS_LOG( info, "Set exit on block boundary" );
     exitOnBlockBoundaryRequested = true;

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -28,7 +28,7 @@ import subprocess
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
-BASIC_CONSENSUS_MAX_TRANSACTIONS_PER_BLOCK = "50
+BASIC_CONSENSUS_MAX_TRANSACTIONS_PER_BLOCK = "500"
 
 
 def print_separator(_label, _char="="):

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -28,7 +28,7 @@ import subprocess
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
-BASIC_CONSENSUS_MAX_TRANSACTIONS_PER_BLOCK = "500"
+TEST_TRANSACTIONS_PER_BLOCK = "500"
 
 
 def print_separator(_label, _char="="):
@@ -174,7 +174,7 @@ unitTest(
 
 
 basicConsensusEnv = {
-    "maxTransactionsPerBlock": BASIC_CONSENSUS_MAX_TRANSACTIONS_PER_BLOCK,
+    "TEST_TRANSACTIONS_PER_BLOCK": TEST_TRANSACTIONS_PER_BLOCK,
 }
 
 fullConsensusTest("onenode", consensustExecutive, "[consensus-basic]", basicConsensusEnv)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -154,23 +154,23 @@ run("ccache -M 20G")
 consensustExecutive = getConsensustExecutive()
 
 # Run all non-end-to-end and non-performance unit tests
-# unitTest(
-#     consensustExecutive,
-#     "~[end-to-end]~[performance]",
-#     "Non-end-to-end non-performance",
-# )
+unitTest(
+    consensustExecutive,
+    "~[end-to-end]~[performance]",
+    "Non-end-to-end non-performance",
+)
 
-# unitTest(
-#     consensustExecutive,
-#     "'[end-to-end][db]'",
-#     "End-to-end db tests",
-# )
+unitTest(
+    consensustExecutive,
+    "'[end-to-end][db]'",
+    "End-to-end db tests",
+)
 
-# unitTest(
-#     consensustExecutive,
-#     "[blockfinalize-transport]",
-#     "Blockfinalize backward compatibility tests",
-# )
+unitTest(
+    consensustExecutive,
+    "[blockfinalize-transport]",
+    "Blockfinalize backward compatibility tests",
+)
 
 
 basicConsensusEnv = {

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -28,6 +28,7 @@ import subprocess
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
+BASIC_CONSENSUS_MAX_TRANSACTIONS_PER_BLOCK = "512"
 
 
 def print_separator(_label, _char="="):
@@ -102,18 +103,31 @@ def unitTest(_consensustExecutive, _testType, _label=None):
     run_catch_tests(_consensustExecutive, _testType, "Catch tests: " + label)
 
 
-def fullConsensusTest(_test, _consensustExecutive, _testType):
+def fullConsensusTest(_test, _consensustExecutive, _testType, _extraEnv=None):
     testDir = os.path.join(REPO_ROOT, "test", _test)
+    previousEnv = {}
+    if _extraEnv:
+        for key, value in _extraEnv.items():
+            previousEnv[key] = os.environ.get(key)
+            os.environ[key] = value
     os.chdir(testDir)
-    run("pwd", "Entering " + testDir)
-    run("rm -rf ./core", "Cleanup core files for " + _test)
-    run("rm -rf /tmp/*.db*", "Cleanup db files for " + _test)
-    run_catch_tests(
-        _consensustExecutive,
-        _testType,
-        "Consensus test: " + _test + " " + _testType,
-    )
-    os.chdir(REPO_ROOT)
+    try:
+        run("pwd", "Entering " + testDir)
+        run("rm -rf ./core", "Cleanup core files for " + _test)
+        run("rm -rf /tmp/*.db*", "Cleanup db files for " + _test)
+        run_catch_tests(
+            _consensustExecutive,
+            _testType,
+            "Consensus test: " + _test + " " + _testType,
+        )
+    finally:
+        os.chdir(REPO_ROOT)
+        if _extraEnv:
+            for key, value in previousEnv.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
 
 
 def getConsensustExecutive():
@@ -140,25 +154,29 @@ run("ccache -M 20G")
 consensustExecutive = getConsensustExecutive()
 
 # Run all non-end-to-end and non-performance unit tests
-unitTest(
-    consensustExecutive,
-    "~[end-to-end]~[performance]",
-    "Non-end-to-end non-performance",
-)
+# unitTest(
+#     consensustExecutive,
+#     "~[end-to-end]~[performance]",
+#     "Non-end-to-end non-performance",
+# )
 
-unitTest(
-    consensustExecutive,
-    "'[end-to-end][db]'",
-    "End-to-end db tests",
-)
+# unitTest(
+#     consensustExecutive,
+#     "'[end-to-end][db]'",
+#     "End-to-end db tests",
+# )
 
-unitTest(
-    consensustExecutive,
-    "[blockfinalize-transport]",
-    "Blockfinalize backward compatibility tests",
-)
+# unitTest(
+#     consensustExecutive,
+#     "[blockfinalize-transport]",
+#     "Blockfinalize backward compatibility tests",
+# )
 
 
-fullConsensusTest("onenode", consensustExecutive, "[consensus-basic]")
-fullConsensusTest("twonodes", consensustExecutive, "[consensus-basic]")
-fullConsensusTest("fournodes", consensustExecutive, "[consensus-basic]")
+basicConsensusEnv = {
+    "maxTransactionsPerBlock": BASIC_CONSENSUS_MAX_TRANSACTIONS_PER_BLOCK,
+}
+
+fullConsensusTest("onenode", consensustExecutive, "[consensus-basic]", basicConsensusEnv)
+fullConsensusTest("twonodes", consensustExecutive, "[consensus-basic]", basicConsensusEnv)
+fullConsensusTest("fournodes", consensustExecutive, "[consensus-basic]", basicConsensusEnv)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -28,7 +28,7 @@ import subprocess
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
-BASIC_CONSENSUS_MAX_TRANSACTIONS_PER_BLOCK = "512"
+BASIC_CONSENSUS_MAX_TRANSACTIONS_PER_BLOCK = "50
 
 
 def print_separator(_label, _char="="):

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -152,6 +152,12 @@ unitTest(
     "End-to-end db tests",
 )
 
+unitTest(
+    consensustExecutive,
+    "[blockfinalize-transport]",
+    "Blockfinalize backward compatibility tests",
+)
+
 
 fullConsensusTest("onenode", consensustExecutive, "[consensus-basic]")
 fullConsensusTest("twonodes", consensustExecutive, "[consensus-basic]")

--- a/test/twonodes_blockfinalize_both_new_zmq/node1/Node.json
+++ b/test/twonodes_blockfinalize_both_new_zmq/node1/Node.json
@@ -1,0 +1,11 @@
+{
+  "nodeName": "Node1",
+  "nodeID": 1,
+  "bindIP": "127.0.0.1",
+  "basePort": 1231,
+  "logLevel": "info",
+  "simulateNetworkWriteDelayMs": 100,
+  "testBlockFinalizeZmqClientEnabled": true,
+  "testBlockFinalizeZmqServerEnabled": true,
+  "testBlockFinalizeTransportStatsEnabled": true
+}

--- a/test/twonodes_blockfinalize_both_new_zmq/node1/Node.json
+++ b/test/twonodes_blockfinalize_both_new_zmq/node1/Node.json
@@ -5,7 +5,6 @@
   "basePort": 1231,
   "logLevel": "info",
   "simulateNetworkWriteDelayMs": 100,
-  "testBlockFinalizeZmqClientEnabled": true,
-  "testBlockFinalizeZmqServerEnabled": true,
+  "blockFinalizeZmqEnabled": true,
   "testBlockFinalizeTransportStatsEnabled": true
 }

--- a/test/twonodes_blockfinalize_both_new_zmq/node1/schains/schain1.json
+++ b/test/twonodes_blockfinalize_both_new_zmq/node1/schains/schain1.json
@@ -1,0 +1,10 @@
+{
+  "schainName": "TestChain",
+  "schainID": 1,
+  "nodes": [
+    { "nodeID": 1, "ip": "127.0.0.1", "basePort": 1231, "schainIndex" : 1},
+    { "nodeID": 2, "ip": "127.0.0.1", "basePort":2231, "schainIndex" : 2}
+  ],
+
+  "blockProposalTest": "SLOW"
+}

--- a/test/twonodes_blockfinalize_both_new_zmq/node2/Node.json
+++ b/test/twonodes_blockfinalize_both_new_zmq/node2/Node.json
@@ -1,0 +1,11 @@
+{
+  "nodeName": "Node2",
+  "nodeID": 2,
+  "bindIP": "127.0.0.1",
+  "basePort": 2231,
+  "logLevel": "info",
+  "simulateNetworkWriteDelayMs": 100,
+  "testBlockFinalizeZmqClientEnabled": true,
+  "testBlockFinalizeZmqServerEnabled": true,
+  "testBlockFinalizeTransportStatsEnabled": true
+}

--- a/test/twonodes_blockfinalize_both_new_zmq/node2/Node.json
+++ b/test/twonodes_blockfinalize_both_new_zmq/node2/Node.json
@@ -5,7 +5,6 @@
   "basePort": 2231,
   "logLevel": "info",
   "simulateNetworkWriteDelayMs": 100,
-  "testBlockFinalizeZmqClientEnabled": true,
-  "testBlockFinalizeZmqServerEnabled": true,
+  "blockFinalizeZmqEnabled": true,
   "testBlockFinalizeTransportStatsEnabled": true
 }

--- a/test/twonodes_blockfinalize_both_new_zmq/node2/schains/schain1.json
+++ b/test/twonodes_blockfinalize_both_new_zmq/node2/schains/schain1.json
@@ -1,0 +1,10 @@
+{
+  "schainName": "TestChain",
+  "schainID": 1,
+  "nodes": [
+    { "nodeID": 1, "ip": "127.0.0.1", "basePort": 1231, "schainIndex" : 1},
+    { "nodeID": 2, "ip": "127.0.0.1", "basePort":2231, "schainIndex" : 2}
+  ],
+
+  "blockProposalTest": "SLOW"
+}

--- a/test/twonodes_blockfinalize_new_client_old_server/node1/Node.json
+++ b/test/twonodes_blockfinalize_new_client_old_server/node1/Node.json
@@ -1,0 +1,11 @@
+{
+  "nodeName": "Node1",
+  "nodeID": 1,
+  "bindIP": "127.0.0.1",
+  "basePort": 1231,
+  "logLevel": "info",
+  "simulateNetworkWriteDelayMs": 100,
+  "testBlockFinalizeZmqClientEnabled": true,
+  "testBlockFinalizeZmqServerEnabled": false,
+  "testBlockFinalizeTransportStatsEnabled": true
+}

--- a/test/twonodes_blockfinalize_new_client_old_server/node1/Node.json
+++ b/test/twonodes_blockfinalize_new_client_old_server/node1/Node.json
@@ -5,7 +5,6 @@
   "basePort": 1231,
   "logLevel": "info",
   "simulateNetworkWriteDelayMs": 100,
-  "testBlockFinalizeZmqClientEnabled": true,
-  "testBlockFinalizeZmqServerEnabled": false,
+  "blockFinalizeZmqEnabled": true,
   "testBlockFinalizeTransportStatsEnabled": true
 }

--- a/test/twonodes_blockfinalize_new_client_old_server/node1/schains/schain1.json
+++ b/test/twonodes_blockfinalize_new_client_old_server/node1/schains/schain1.json
@@ -1,0 +1,10 @@
+{
+  "schainName": "TestChain",
+  "schainID": 1,
+  "nodes": [
+    { "nodeID": 1, "ip": "127.0.0.1", "basePort": 1231, "schainIndex" : 1},
+    { "nodeID": 2, "ip": "127.0.0.1", "basePort":2231, "schainIndex" : 2}
+  ],
+
+  "blockProposalTest": "SLOW"
+}

--- a/test/twonodes_blockfinalize_new_client_old_server/node2/Node.json
+++ b/test/twonodes_blockfinalize_new_client_old_server/node2/Node.json
@@ -1,0 +1,11 @@
+{
+  "nodeName": "Node2",
+  "nodeID": 2,
+  "bindIP": "127.0.0.1",
+  "basePort": 2231,
+  "logLevel": "info",
+  "simulateNetworkWriteDelayMs": 100,
+  "testBlockFinalizeZmqClientEnabled": true,
+  "testBlockFinalizeZmqServerEnabled": false,
+  "testBlockFinalizeTransportStatsEnabled": true
+}

--- a/test/twonodes_blockfinalize_new_client_old_server/node2/Node.json
+++ b/test/twonodes_blockfinalize_new_client_old_server/node2/Node.json
@@ -5,7 +5,6 @@
   "basePort": 2231,
   "logLevel": "info",
   "simulateNetworkWriteDelayMs": 100,
-  "testBlockFinalizeZmqClientEnabled": true,
-  "testBlockFinalizeZmqServerEnabled": false,
+  "blockFinalizeZmqEnabled": false,
   "testBlockFinalizeTransportStatsEnabled": true
 }

--- a/test/twonodes_blockfinalize_new_client_old_server/node2/schains/schain1.json
+++ b/test/twonodes_blockfinalize_new_client_old_server/node2/schains/schain1.json
@@ -1,0 +1,10 @@
+{
+  "schainName": "TestChain",
+  "schainID": 1,
+  "nodes": [
+    { "nodeID": 1, "ip": "127.0.0.1", "basePort": 1231, "schainIndex" : 1},
+    { "nodeID": 2, "ip": "127.0.0.1", "basePort":2231, "schainIndex" : 2}
+  ],
+
+  "blockProposalTest": "SLOW"
+}

--- a/test/twonodes_blockfinalize_old_client_new_server/node1/Node.json
+++ b/test/twonodes_blockfinalize_old_client_new_server/node1/Node.json
@@ -1,0 +1,11 @@
+{
+  "nodeName": "Node1",
+  "nodeID": 1,
+  "bindIP": "127.0.0.1",
+  "basePort": 1231,
+  "logLevel": "info",
+  "simulateNetworkWriteDelayMs": 100,
+  "testBlockFinalizeZmqClientEnabled": false,
+  "testBlockFinalizeZmqServerEnabled": true,
+  "testBlockFinalizeTransportStatsEnabled": true
+}

--- a/test/twonodes_blockfinalize_old_client_new_server/node1/Node.json
+++ b/test/twonodes_blockfinalize_old_client_new_server/node1/Node.json
@@ -5,7 +5,6 @@
   "basePort": 1231,
   "logLevel": "info",
   "simulateNetworkWriteDelayMs": 100,
-  "testBlockFinalizeZmqClientEnabled": false,
-  "testBlockFinalizeZmqServerEnabled": true,
+  "blockFinalizeZmqEnabled": false,
   "testBlockFinalizeTransportStatsEnabled": true
 }

--- a/test/twonodes_blockfinalize_old_client_new_server/node1/schains/schain1.json
+++ b/test/twonodes_blockfinalize_old_client_new_server/node1/schains/schain1.json
@@ -1,0 +1,10 @@
+{
+  "schainName": "TestChain",
+  "schainID": 1,
+  "nodes": [
+    { "nodeID": 1, "ip": "127.0.0.1", "basePort": 1231, "schainIndex" : 1},
+    { "nodeID": 2, "ip": "127.0.0.1", "basePort":2231, "schainIndex" : 2}
+  ],
+
+  "blockProposalTest": "SLOW"
+}

--- a/test/twonodes_blockfinalize_old_client_new_server/node2/Node.json
+++ b/test/twonodes_blockfinalize_old_client_new_server/node2/Node.json
@@ -1,0 +1,11 @@
+{
+  "nodeName": "Node2",
+  "nodeID": 2,
+  "bindIP": "127.0.0.1",
+  "basePort": 2231,
+  "logLevel": "info",
+  "simulateNetworkWriteDelayMs": 100,
+  "testBlockFinalizeZmqClientEnabled": false,
+  "testBlockFinalizeZmqServerEnabled": true,
+  "testBlockFinalizeTransportStatsEnabled": true
+}

--- a/test/twonodes_blockfinalize_old_client_new_server/node2/Node.json
+++ b/test/twonodes_blockfinalize_old_client_new_server/node2/Node.json
@@ -5,7 +5,6 @@
   "basePort": 2231,
   "logLevel": "info",
   "simulateNetworkWriteDelayMs": 100,
-  "testBlockFinalizeZmqClientEnabled": false,
-  "testBlockFinalizeZmqServerEnabled": true,
+  "blockFinalizeZmqEnabled": true,
   "testBlockFinalizeTransportStatsEnabled": true
 }

--- a/test/twonodes_blockfinalize_old_client_new_server/node2/schains/schain1.json
+++ b/test/twonodes_blockfinalize_old_client_new_server/node2/schains/schain1.json
@@ -1,0 +1,10 @@
+{
+  "schainName": "TestChain",
+  "schainID": 1,
+  "nodes": [
+    { "nodeID": 1, "ip": "127.0.0.1", "basePort": 1231, "schainIndex" : 1},
+    { "nodeID": 2, "ip": "127.0.0.1", "basePort":2231, "schainIndex" : 2}
+  ],
+
+  "blockProposalTest": "SLOW"
+}

--- a/tests/TestUtils.h
+++ b/tests/TestUtils.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 
@@ -35,6 +36,59 @@
 #include "thirdparty/catch.hpp"
 
 namespace TestUtils {
+
+struct TestEnvVarSnapshot {
+    bool hadPreviousValue = false;
+    string previousValue;
+};
+
+inline TestEnvVarSnapshot captureTestEnvVar( const string& _envName ) {
+    TestEnvVarSnapshot snapshot;
+    const char* previousValue = std::getenv( _envName.c_str() );
+    if ( previousValue != nullptr ) {
+        snapshot.hadPreviousValue = true;
+        snapshot.previousValue = previousValue;
+    }
+    return snapshot;
+}
+
+inline TestEnvVarSnapshot setTestEnvVar(
+    const string& _envName, const string& _envValue, int _overwrite = 1 ) {
+    auto snapshot = captureTestEnvVar( _envName );
+    CATCH_REQUIRE( setenv( _envName.c_str(), _envValue.c_str(), _overwrite ) == 0 );
+    return snapshot;
+}
+
+inline void unsetTestEnvVar( const string& _envName ) {
+    CATCH_REQUIRE( unsetenv( _envName.c_str() ) == 0 );
+}
+
+inline void restoreTestEnvVar( const string& _envName, const TestEnvVarSnapshot& _snapshot ) {
+    if ( _snapshot.hadPreviousValue ) {
+        CATCH_REQUIRE( setenv( _envName.c_str(), _snapshot.previousValue.c_str(), 1 ) == 0 );
+    } else {
+        unsetTestEnvVar( _envName );
+    }
+}
+
+class TestEnvVarGuard {
+    string envName;
+    TestEnvVarSnapshot snapshot;
+
+public:
+    explicit TestEnvVarGuard( const string& _envName )
+        : envName( _envName ), snapshot( captureTestEnvVar( _envName ) ) {
+        unsetTestEnvVar( envName );
+    }
+
+    ~TestEnvVarGuard() {
+        if ( snapshot.hadPreviousValue ) {
+            setenv( envName.c_str(), snapshot.previousValue.c_str(), 1 );
+        } else {
+            unsetenv( envName.c_str() );
+        }
+    }
+};
 
 /**
  * @brief Creates a minimal test Node with the given configuration

--- a/tests/e2e/BlockFinalizeTransportCompatTests.cpp
+++ b/tests/e2e/BlockFinalizeTransportCompatTests.cpp
@@ -1,0 +1,111 @@
+/*
+    Copyright (C) 2026 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "thirdparty/catch.hpp"
+#include "SkaleCommon.h"
+#include "node/ConsensusEngine.h"
+#include "tests/e2e/ConsensusEngineTestAccess.h"
+#include "tests/e2e/E2ETestHelper.h"
+
+namespace BlockFinalizeTransportCompatTests {
+
+using E2EHelper = E2ETestUtils::E2ETestHelper;
+
+static constexpr const char* FINALIZATION_DOWNLOAD_ONLY_ENV =
+    "TEST_FINALIZATION_DOWNLOAD_ONLY";
+static constexpr useconds_t POLL_INTERVAL_US = 250 * 1000;
+static constexpr size_t MAX_POLL_ROUNDS = 20;
+
+struct ScenarioResult {
+    block_id lastCommittedBlockId = 0;
+    BlockFinalizeTransportStats stats;
+};
+
+static ScenarioResult runScenario( const string& _configDir ) {
+    ConsensusEngine* testEngine = nullptr;
+    auto finalizationDownloadOnlySnapshot =
+        E2EHelper::setTestEnvVar( FINALIZATION_DOWNLOAD_ONLY_ENV, "1", 1 );
+
+    try {
+        E2EHelper::configureTestEnvironment( true, _configDir );
+        auto lastId = ( uint64_t ) E2EHelper::startEngineAndWait(
+            testEngine, 0, E2EHelper::CROSS_NODE_RUN_TIME_S );
+
+        CATCH_REQUIRE( testEngine != nullptr );
+        CATCH_REQUIRE( ( uint64_t ) testEngine->nodesCount() == 2 );
+        CATCH_REQUIRE( lastId > 0 );
+
+        auto stats = ConsensusEngineTestAccess::getBlockFinalizeTransportStats( *testEngine );
+
+        CATCH_REQUIRE( stats.totalRequests() > 0 );
+
+        E2EHelper::stopEngineGracefully( testEngine );
+        E2EHelper::restoreTestEnvVar(
+            FINALIZATION_DOWNLOAD_ONLY_ENV, finalizationDownloadOnlySnapshot );
+
+        return { block_id( lastId ), stats };
+    } catch ( ... ) {
+        if ( testEngine != nullptr ) {
+            E2EHelper::stopEngineGracefully( testEngine );
+        }
+        E2EHelper::restoreTestEnvVar(
+            FINALIZATION_DOWNLOAD_ONLY_ENV, finalizationDownloadOnlySnapshot );
+        throw;
+    }
+}
+
+}  // namespace BlockFinalizeTransportCompatTests
+
+using namespace BlockFinalizeTransportCompatTests;
+
+CATCH_TEST_CASE( "BlockFinalize uses ZMQ between upgraded nodes",
+    "[blockfinalize-transport][end-to-end]" ) {
+    auto result = runScenario( "test/twonodes_blockfinalize_both_new_zmq" );
+
+    CATCH_CAPTURE( result.lastCommittedBlockId );
+    CATCH_REQUIRE( result.stats.zmqClientAttempts > 0 );
+    CATCH_REQUIRE( result.stats.zmqServerRequestsServed > 0 );
+    CATCH_REQUIRE( result.stats.zmqClientFallbacksToTcp == 0 );
+    CATCH_REQUIRE( result.stats.tcpClientRequests == 0 );
+    CATCH_REQUIRE( result.stats.tcpServerRequestsServed == 0 );
+}
+
+CATCH_TEST_CASE( "BlockFinalize falls back from new client to old TCP-only server",
+    "[blockfinalize-transport][end-to-end]" ) {
+    auto result = runScenario( "test/twonodes_blockfinalize_new_client_old_server" );
+
+    CATCH_CAPTURE( result.lastCommittedBlockId );
+    CATCH_REQUIRE( result.stats.zmqClientAttempts > 0 );
+    CATCH_REQUIRE( result.stats.zmqClientFallbacksToTcp > 0 );
+    CATCH_REQUIRE( result.stats.tcpClientRequests > 0 );
+    CATCH_REQUIRE( result.stats.tcpServerRequestsServed > 0 );
+    CATCH_REQUIRE( result.stats.zmqServerRequestsServed == 0 );
+}
+
+CATCH_TEST_CASE( "BlockFinalize keeps legacy TCP path for old client against new server",
+    "[blockfinalize-transport][end-to-end]" ) {
+    auto result = runScenario( "test/twonodes_blockfinalize_old_client_new_server" );
+
+    CATCH_CAPTURE( result.lastCommittedBlockId );
+    CATCH_REQUIRE( result.stats.zmqClientAttempts == 0 );
+    CATCH_REQUIRE( result.stats.zmqClientFallbacksToTcp == 0 );
+    CATCH_REQUIRE( result.stats.tcpClientRequests > 0 );
+    CATCH_REQUIRE( result.stats.tcpServerRequestsServed > 0 );
+    CATCH_REQUIRE( result.stats.zmqServerRequestsServed == 0 );
+}

--- a/tests/e2e/BlockFinalizeTransportCompatTests.cpp
+++ b/tests/e2e/BlockFinalizeTransportCompatTests.cpp
@@ -40,7 +40,7 @@ struct ScenarioResult {
 static ScenarioResult runScenario( const string& _configDir ) {
     ConsensusEngine* testEngine = nullptr;
     auto finalizationDownloadOnlySnapshot =
-        E2EHelper::setTestEnvVar( FINALIZATION_DOWNLOAD_ONLY_ENV, "1", 1 );
+        TestUtils::setTestEnvVar( FINALIZATION_DOWNLOAD_ONLY_ENV, "1", 1 );
 
     try {
         E2EHelper::configureTestEnvironment( true, _configDir );
@@ -56,7 +56,7 @@ static ScenarioResult runScenario( const string& _configDir ) {
         CATCH_REQUIRE( stats.totalRequests() > 0 );
 
         E2EHelper::stopEngineGracefully( testEngine );
-        E2EHelper::restoreTestEnvVar(
+        TestUtils::restoreTestEnvVar(
             FINALIZATION_DOWNLOAD_ONLY_ENV, finalizationDownloadOnlySnapshot );
 
         return { block_id( lastId ), stats };
@@ -64,7 +64,7 @@ static ScenarioResult runScenario( const string& _configDir ) {
         if ( testEngine != nullptr ) {
             E2EHelper::stopEngineGracefully( testEngine );
         }
-        E2EHelper::restoreTestEnvVar(
+        TestUtils::restoreTestEnvVar(
             FINALIZATION_DOWNLOAD_ONLY_ENV, finalizationDownloadOnlySnapshot );
         throw;
     }

--- a/tests/e2e/BlockFinalizeTransportCompatTests.cpp
+++ b/tests/e2e/BlockFinalizeTransportCompatTests.cpp
@@ -34,7 +34,9 @@ static constexpr size_t MAX_POLL_ROUNDS = 20;
 
 struct ScenarioResult {
     block_id lastCommittedBlockId = 0;
-    BlockFinalizeTransportStats stats;
+    BlockFinalizeTransportStats totalStats;
+    BlockFinalizeTransportStats node1Stats;
+    BlockFinalizeTransportStats node2Stats;
 };
 
 static ScenarioResult runScenario( const string& _configDir ) {
@@ -51,15 +53,19 @@ static ScenarioResult runScenario( const string& _configDir ) {
         CATCH_REQUIRE( ( uint64_t ) testEngine->nodesCount() == 2 );
         CATCH_REQUIRE( lastId > 0 );
 
-        auto stats = ConsensusEngineTestAccess::getBlockFinalizeTransportStats( *testEngine );
+        auto totalStats = ConsensusEngineTestAccess::getBlockFinalizeTransportStats( *testEngine );
+        auto node1Stats =
+            ConsensusEngineTestAccess::getBlockFinalizeTransportStatsForNode( *testEngine, 1 );
+        auto node2Stats =
+            ConsensusEngineTestAccess::getBlockFinalizeTransportStatsForNode( *testEngine, 2 );
 
-        CATCH_REQUIRE( stats.totalRequests() > 0 );
+        CATCH_REQUIRE( totalStats.totalRequests() > 0 );
 
         E2EHelper::stopEngineGracefully( testEngine );
         TestUtils::restoreTestEnvVar(
             FINALIZATION_DOWNLOAD_ONLY_ENV, finalizationDownloadOnlySnapshot );
 
-        return { block_id( lastId ), stats };
+        return { block_id( lastId ), totalStats, node1Stats, node2Stats };
     } catch ( ... ) {
         if ( testEngine != nullptr ) {
             E2EHelper::stopEngineGracefully( testEngine );
@@ -79,11 +85,11 @@ CATCH_TEST_CASE( "BlockFinalize uses ZMQ between upgraded nodes",
     auto result = runScenario( "test/twonodes_blockfinalize_both_new_zmq" );
 
     CATCH_CAPTURE( result.lastCommittedBlockId );
-    CATCH_REQUIRE( result.stats.zmqClientAttempts > 0 );
-    CATCH_REQUIRE( result.stats.zmqServerRequestsServed > 0 );
-    CATCH_REQUIRE( result.stats.zmqClientFallbacksToTcp == 0 );
-    CATCH_REQUIRE( result.stats.tcpClientRequests == 0 );
-    CATCH_REQUIRE( result.stats.tcpServerRequestsServed == 0 );
+    CATCH_REQUIRE( result.totalStats.zmqClientAttempts > 0 );
+    CATCH_REQUIRE( result.totalStats.zmqServerRequestsServed > 0 );
+    CATCH_REQUIRE( result.totalStats.zmqClientFallbacksToTcp == 0 );
+    CATCH_REQUIRE( result.totalStats.tcpClientRequests == 0 );
+    CATCH_REQUIRE( result.totalStats.tcpServerRequestsServed == 0 );
 }
 
 CATCH_TEST_CASE( "BlockFinalize falls back from new client to old TCP-only server",
@@ -91,11 +97,11 @@ CATCH_TEST_CASE( "BlockFinalize falls back from new client to old TCP-only serve
     auto result = runScenario( "test/twonodes_blockfinalize_new_client_old_server" );
 
     CATCH_CAPTURE( result.lastCommittedBlockId );
-    CATCH_REQUIRE( result.stats.zmqClientAttempts > 0 );
-    CATCH_REQUIRE( result.stats.zmqClientFallbacksToTcp > 0 );
-    CATCH_REQUIRE( result.stats.tcpClientRequests > 0 );
-    CATCH_REQUIRE( result.stats.tcpServerRequestsServed > 0 );
-    CATCH_REQUIRE( result.stats.zmqServerRequestsServed == 0 );
+    CATCH_REQUIRE( result.node1Stats.zmqClientAttempts > 0 );
+    CATCH_REQUIRE( result.node1Stats.zmqClientFallbacksToTcp > 0 );
+    CATCH_REQUIRE( result.node1Stats.tcpClientRequests > 0 );
+    CATCH_REQUIRE( result.node2Stats.tcpServerRequestsServed > 0 );
+    CATCH_REQUIRE( result.totalStats.zmqServerRequestsServed == 0 );
 }
 
 CATCH_TEST_CASE( "BlockFinalize keeps legacy TCP path for old client against new server",
@@ -103,9 +109,9 @@ CATCH_TEST_CASE( "BlockFinalize keeps legacy TCP path for old client against new
     auto result = runScenario( "test/twonodes_blockfinalize_old_client_new_server" );
 
     CATCH_CAPTURE( result.lastCommittedBlockId );
-    CATCH_REQUIRE( result.stats.zmqClientAttempts == 0 );
-    CATCH_REQUIRE( result.stats.zmqClientFallbacksToTcp == 0 );
-    CATCH_REQUIRE( result.stats.tcpClientRequests > 0 );
-    CATCH_REQUIRE( result.stats.tcpServerRequestsServed > 0 );
-    CATCH_REQUIRE( result.stats.zmqServerRequestsServed == 0 );
+    CATCH_REQUIRE( result.node1Stats.zmqClientAttempts == 0 );
+    CATCH_REQUIRE( result.node1Stats.zmqClientFallbacksToTcp == 0 );
+    CATCH_REQUIRE( result.node1Stats.tcpClientRequests > 0 );
+    CATCH_REQUIRE( result.node2Stats.tcpServerRequestsServed > 0 );
+    CATCH_REQUIRE( result.totalStats.zmqServerRequestsServed == 0 );
 }

--- a/tests/e2e/ConsensusEngineTestAccess.h
+++ b/tests/e2e/ConsensusEngineTestAccess.h
@@ -90,4 +90,28 @@ public:
     static TimeStamp getCurrentLastCommittedBlockTimeStamp( const ConsensusEngine& e ) {
         return getCurrentLastCommittedBlockTimeStampForNode( e, getFirstNodeId( e ) );
     }
+
+    static BlockFinalizeTransportStats getBlockFinalizeTransportStatsForNode(
+        const ConsensusEngine& e, node_id node ) {
+        auto it = e.nodes.find( node );
+        CHECK_STATE2( it != e.nodes.end(), "Node with id " + to_string( node ) + " not found" );
+        CHECK_STATE( it->second );
+        auto schain = it->second->getSchain();
+        CHECK_STATE( schain );
+        return schain->getBlockFinalizeTransportStats();
+    }
+
+    static BlockFinalizeTransportStats getBlockFinalizeTransportStats(
+        const ConsensusEngine& e ) {
+        BlockFinalizeTransportStats totalStats;
+
+        for ( const auto& item : e.nodes ) {
+            CHECK_STATE( item.second );
+            auto schain = item.second->getSchain();
+            CHECK_STATE( schain );
+            totalStats.add( schain->getBlockFinalizeTransportStats() );
+        }
+
+        return totalStats;
+    }
 };

--- a/tests/e2e/E2ETestHelper.h
+++ b/tests/e2e/E2ETestHelper.h
@@ -59,10 +59,10 @@ public:
 
         boost::filesystem::create_directories( TEST_DATA_ROOT_DIR );
 
-        setTestEnvVar( "DATA_DIR", TEST_DATA_ROOT_DIR.c_str() );
+        TestUtils::setTestEnvVar( "DATA_DIR", TEST_DATA_ROOT_DIR.c_str() );
 
         // Keep default runtime for fast tests unless caller already set TEST_TIME_S.
-        setTestEnvVar( "TEST_TIME_S", "4", 0 );
+        TestUtils::setTestEnvVar( "TEST_TIME_S", "4", 0 );
     }
 
     static void startEngine(
@@ -125,37 +125,6 @@ public:
         _engine->testExitGracefullyBlocking();
         delete _engine;
         _engine = nullptr;
-    }
-
-    // ========= Environment variable helpers for tests ========= 
-    struct TestEnvVarSnapshot {
-        bool hadPreviousValue = false;
-        string previousValue;
-    };
-
-    static TestEnvVarSnapshot setTestEnvVar(
-        const string& _envName, const string& _envValue, int _overwrite = 1 ) {
-        TestEnvVarSnapshot snapshot;
-        const char* previousValue = std::getenv( _envName.c_str() );
-        if ( previousValue != nullptr ) {
-            snapshot.hadPreviousValue = true;
-            snapshot.previousValue = previousValue;
-        }
-
-        CATCH_REQUIRE( setenv( _envName.c_str(), _envValue.c_str(), _overwrite ) == 0 );
-        return snapshot;
-    }
-
-    static void unsetTestEnvVar( const string& _envName ) {
-        CATCH_REQUIRE( unsetenv( _envName.c_str() ) == 0 );
-    }
-
-    static void restoreTestEnvVar( const string& _envName, const TestEnvVarSnapshot& _snapshot ) {
-        if ( _snapshot.hadPreviousValue ) {
-            CATCH_REQUIRE( setenv( _envName.c_str(), _snapshot.previousValue.c_str(), 1 ) == 0 );
-        } else {
-            unsetTestEnvVar( _envName );
-        }
     }
 };
 

--- a/tests/unit/network/NodeConfigTests.cpp
+++ b/tests/unit/network/NodeConfigTests.cpp
@@ -1,0 +1,45 @@
+#include "thirdparty/catch.hpp"
+
+#include "SkaleCommon.h"
+#include "tests/TestUtils.h"
+
+namespace {
+
+nlohmann::json makeTestNodeConfig() {
+    nlohmann::json cfg;
+    cfg["nodeID"] = 1;
+    cfg["nodeName"] = "testNode";
+    cfg["bindIP"] = "127.0.0.1";
+    cfg["basePort"] = 31000;
+    return cfg;
+}
+
+}  // namespace
+
+CATCH_TEST_CASE( "BlockFinalize TCP fallback timeout uses config override",
+    "[network][node][unit]" ) {
+    constexpr uint64_t overrideTimeoutMs = 4242;
+    TestUtils::TestEnvVarGuard envGuard( "blockFinalizeDownloadTcpFallbackMs" );
+
+    auto cfg = makeTestNodeConfig();
+    cfg["blockFinalizeDownloadTcpFallbackMs"] = overrideTimeoutMs;
+
+    ConsensusEngine engine( 0, 1000000000 );
+    auto node = TestUtils::createTestNode( cfg, &engine, "http://127.0.0.1:8545" );
+
+    CATCH_REQUIRE( node->getBlockFinalizeDownloadTcpFallbackMs() == overrideTimeoutMs );
+}
+
+CATCH_TEST_CASE( "BlockFinalize TCP fallback timeout uses default when config is unset",
+    "[network][node][unit]" ) {
+    TestUtils::TestEnvVarGuard envGuard( "blockFinalizeDownloadTcpFallbackMs" );
+
+    auto cfg = makeTestNodeConfig();
+
+    ConsensusEngine engine( 0, 1000000000 );
+    auto node = TestUtils::createTestNode( cfg, &engine, "http://127.0.0.1:8545" );
+
+    CATCH_REQUIRE(
+        node->getBlockFinalizeDownloadTcpFallbackMs() ==
+        BLOCK_FINALIZE_DOWNLOAD_TCP_FALLBACK_MS );
+}

--- a/tests/unit/network/NodeConfigTests.cpp
+++ b/tests/unit/network/NodeConfigTests.cpp
@@ -43,3 +43,24 @@ CATCH_TEST_CASE( "BlockFinalize TCP fallback timeout uses default when config is
         node->getBlockFinalizeDownloadTcpFallbackMs() ==
         BLOCK_FINALIZE_DOWNLOAD_TCP_FALLBACK_MS );
 }
+
+CATCH_TEST_CASE( "BlockFinalize ZMQ transport flag uses config override",
+    "[network][node][unit]" ) {
+    auto cfg = makeTestNodeConfig();
+    cfg["blockFinalizeZmqEnabled"] = false;
+
+    ConsensusEngine engine( 0, 1000000000 );
+    auto node = TestUtils::createTestNode( cfg, &engine, "http://127.0.0.1:8545" );
+
+    CATCH_REQUIRE( !node->isBlockFinalizeZmqEnabled() );
+}
+
+CATCH_TEST_CASE( "BlockFinalize ZMQ transport flag defaults to enabled",
+    "[network][node][unit]" ) {
+    auto cfg = makeTestNodeConfig();
+
+    ConsensusEngine engine( 0, 1000000000 );
+    auto node = TestUtils::createTestNode( cfg, &engine, "http://127.0.0.1:8545" );
+
+    CATCH_REQUIRE( node->isBlockFinalizeZmqEnabled() );
+}

--- a/tests/unit/network/NodeTestAccess.h
+++ b/tests/unit/network/NodeTestAccess.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "node/Node.h"
+
+class NodeTestAccess {
+public:
+    static const SocketPortDeltas& getSocketPortDeltas( const Node& _node ) {
+        return _node.socketPortDeltas;
+    }
+};

--- a/tests/unit/network/ZMQErrorClassifierTests.cpp
+++ b/tests/unit/network/ZMQErrorClassifierTests.cpp
@@ -1,0 +1,53 @@
+#include "thirdparty/catch.hpp"
+
+#include <cerrno>
+#include <exception>
+
+#include "exceptions/InvalidStateException.h"
+#include "exceptions/NetworkProtocolException.h"
+#include "exceptions/ParsingException.h"
+#include "exceptions/ZMQTransportException.h"
+#include "network/ZMQErrorClassifier.h"
+#include "zmq.h"
+
+CATCH_TEST_CASE( "ZMQ transport fallback classifier accepts transport errno values",
+    "[network][zmq][unit]" ) {
+    CATCH_REQUIRE( isZMQTransportErrorForTcpFallback( EAGAIN ) );
+    CATCH_REQUIRE( isZMQTransportErrorForTcpFallback( ETIMEDOUT ) );
+    CATCH_REQUIRE( isZMQTransportErrorForTcpFallback( ECONNRESET ) );
+    CATCH_REQUIRE( isZMQTransportErrorForTcpFallback( ECONNREFUSED ) );
+    CATCH_REQUIRE( isZMQTransportErrorForTcpFallback( ENETDOWN ) );
+    CATCH_REQUIRE( isZMQTransportErrorForTcpFallback( ENETUNREACH ) );
+    CATCH_REQUIRE( isZMQTransportErrorForTcpFallback( EHOSTUNREACH ) );
+    CATCH_REQUIRE( isZMQTransportErrorForTcpFallback( EPIPE ) );
+}
+
+CATCH_TEST_CASE( "ZMQ transport fallback classifier rejects non-transport errno values",
+    "[network][zmq][unit]" ) {
+    CATCH_REQUIRE_FALSE( isZMQTransportErrorForTcpFallback( EINVAL ) );
+    CATCH_REQUIRE_FALSE( isZMQTransportErrorForTcpFallback( EFSM ) );
+    CATCH_REQUIRE_FALSE( isZMQTransportErrorForTcpFallback( ETERM ) );
+}
+
+CATCH_TEST_CASE( "BlockFinalize TCP fallback only applies to ZMQ transport exceptions",
+    "[blockfinalize][network][unit]" ) {
+    ZMQTransportException transportException( "transport", EAGAIN, "Test" );
+    ParsingException parsingException( "parsing", "Test" );
+    NetworkProtocolException protocolException( "protocol", "Test" );
+    InvalidStateException invalidStateException( "state", "Test" );
+    auto catchesAsTransport = []( const auto& _exception ) {
+        try {
+            throw _exception;
+        } catch ( const ZMQTransportException& ) {
+            return true;
+        } catch ( ... ) {
+            return false;
+        }
+    };
+
+    CATCH_REQUIRE( transportException.getZmqErrno() == EAGAIN );
+    CATCH_REQUIRE( catchesAsTransport( transportException ) );
+    CATCH_REQUIRE_FALSE( catchesAsTransport( parsingException ) );
+    CATCH_REQUIRE_FALSE( catchesAsTransport( protocolException ) );
+    CATCH_REQUIRE_FALSE( catchesAsTransport( invalidStateException ) );
+}

--- a/tests/unit/network/ZMQSocketsTests.cpp
+++ b/tests/unit/network/ZMQSocketsTests.cpp
@@ -1,0 +1,75 @@
+#include "thirdparty/catch.hpp"
+
+#include "tests/TestUtils.h"
+#include "tests/unit/network/NodeTestAccess.h"
+#include "network/Sockets.h"
+#include "network/ZMQSockets.h"
+#include "network/TCPServerSocket.h"
+
+#include <array>
+#include <unistd.h>
+
+#include "zmq.h"
+
+namespace {
+
+class SocketsCleanupGuard {
+    Sockets& sockets;
+
+public:
+    explicit SocketsCleanupGuard( Sockets& _sockets ) : sockets( _sockets ) {}
+
+    ~SocketsCleanupGuard() {
+        if ( sockets.consensusZMQSockets ) {
+            sockets.consensusZMQSockets->closeAndCleanupAll();
+        }
+        if ( sockets.bulkDataZMQSockets ) {
+            sockets.bulkDataZMQSockets->closeAndCleanupAll();
+        }
+        if ( sockets.blockProposalSocket ) {
+            sockets.blockProposalSocket->closeAndCleanupAll();
+        }
+        if ( sockets.catchupSocket ) {
+            sockets.catchupSocket->closeAndCleanupAll();
+        }
+    }
+};
+
+}  // namespace
+
+CATCH_TEST_CASE( "Bulk data ZMQ bind uses overridden port delta", "[network][zmq][unit]" ) {
+    constexpr uint16_t overrideDelta = 37;
+    const auto basePort = static_cast< uint16_t >( 32000 + ( getpid() % 1000 ) * 20 );
+
+    nlohmann::json cfg;
+    cfg["nodeID"] = 1;
+    cfg["nodeName"] = "testNode";
+    cfg["bindIP"] = "127.0.0.1";
+    cfg["basePort"] = basePort;
+    cfg["ZMQBulkDataPortDelta"] = overrideDelta;
+
+    ConsensusEngine engine( 0, 1000000000 );
+    auto node = TestUtils::createTestNode( cfg, &engine, "http://127.0.0.1:8545" );
+
+    const auto& portDeltas = NodeTestAccess::getSocketPortDeltas( *node );
+    CATCH_REQUIRE( portDeltas.ZMQBulkDataPortDelta == overrideDelta );
+
+    Sockets sockets( *node );
+    sockets.initSockets(
+        node->getBindIP(), static_cast< uint16_t >( node->getBasePort() ), portDeltas );
+    SocketsCleanupGuard cleanup( sockets );
+
+    auto bulkDataSocket = sockets.getBulkDataZMQSockets();
+    void* receiveSocket = nullptr;
+    CATCH_REQUIRE_NOTHROW( receiveSocket = bulkDataSocket->getReceiveSocket() );
+    CATCH_REQUIRE( receiveSocket != nullptr );
+
+    std::array< char, 256 > endpoint{};
+    size_t endpointSize = endpoint.size();
+    CATCH_REQUIRE( zmq_getsockopt(
+                       receiveSocket, ZMQ_LAST_ENDPOINT, endpoint.data(), &endpointSize ) == 0 );
+
+    const auto expectedEndpoint =
+        string( "tcp://127.0.0.1:" ) + to_string( node->getBasePort() + overrideDelta );
+    CATCH_REQUIRE( string( endpoint.data() ) == expectedEndpoint );
+}


### PR DESCRIPTION
# Description

This PR moves `BlockFinalizeDownload` off per-request TCP and onto a new persistent ZMQ bulk-data lane, while preserving backward compatibility with older TCP-only nodes.

## BlockFinalize Refactor

Refactored BlockFinalize logic into clearer transport boundaries:

- `BlockFinalizeDownloader.cpp`
  - owns the client-side BlockFinalize fetch logic
  - decides whether to use ZMQ or TCP
  - performs per-peer TCP fallback caching
  - processes returned fragments / DA sig / BITE shares

- `BlockFinalizeResponder.cpp`
  - owns the transport-neutral server-side BlockFinalize semantics
  - validates requests
  - finds proposal / committed block data
  - builds the BlockFinalize response payload and response header fields

This lets both the legacy TCP path and the new ZMQ path share the same BlockFinalize behavior.

## Generic ZMQ Header/Payload Framing

Added `ZMQHeaderPayloadFrame`, a reusable helper for ZMQ request/reply protocols that use:

- a small structured JSON header
- an optional binary payload

Wire format:

`[uint64 header_len][serialized JSON header][optional payload bytes]`

This helper is used by the new BlockFinalize ZMQ path. It is generic enough to be reused by future non-hot-path ZMQ request/reply flows, but it is not intended for the latency-sensitive binary consensus message path.

## New Bulk-Data ZMQ Lane

Added a separate bulk-data ZMQ lane, distinct from the existing consensus ZMQ lane.

This lane is intended for larger request/reply style recovery or retrieval traffic, such as:

- BlockFinalize
- potentially catchup or similar flows in future PRs

It is not part of the consensus hot path.

## New BlockFinalize ZMQ Server

Added `BlockFinalizeZmqServerAgent`:

- listens on the new bulk-data ZMQ lane
- accepts BlockFinalize requests in `ZMQHeaderPayloadFrame` format
- delegates response construction to `BlockFinalizeResponder`

---

# Backward Compatibility

### Sender

New nodes are ZMQ-first for BlockFinalize:

- try ZMQ first
- on transport/protocol failure, close the cached ZMQ socket for that peer
- mark that peer for temporary TCP fallback
- retry immediately over legacy TCP
- continue using TCP for that peer until the fallback cooldown expires
- after cooldown, probe ZMQ again

This assumes the network will gradually migrate to the new ZMQ path.

### Receiver

Backward compatibility for old senders is preserved:

- `CatchupServerAgent` remains active
- it still serves legacy TCP `BLOCK_FINALIZE_REQ`
- it also still serves normal catchup traffic as before

So old TCP-only nodes can still request BlockFinalize data from upgraded nodes.

---

# Other improvements

- ZMQ socket shutdown was moved to after all threads & agents are joined. Not before.
- Tests were failing unpredictably since we closed ZMQ sockets before joining threads - meaning threads could be trying to read / write to/from ZMQ sockets even after being closed.

---

# Tests

- Tested backward compatibility in 3 cases:
   - 1 node with TCP server, 1 node with ZMQ client enabled
   - 1 node with ZMQ server enabled, 1 node with TCP client
   - 2 nodes with ZMQ server / client
   
- all tests force usage of BlockFinalizeDownload phase

---

# Performance

- No visible speedup testing locally. This code path - BlockFinalizeDownloader is not required, i.e, is optional in a fast enough network and usually not used. But when it is used, then network delay should drop to half time since there's no longer the extra RTT for TCP's 3-way handshake

Fixes #985
