### PR TITLE
Consensus performance improvement

### DIFF
--- a/SkaleCommon.h
+++ b/SkaleCommon.h
@@ -202,8 +202,6 @@ static constexpr size_t PARTIAL_HASH_LEN = 8;
 
 #ifdef BITE
 static constexpr size_t EXTRA_DATA_LEN = 32;
-
-static constexpr size_t NUM_BITE_VALIDATION_THREADS = 8;
 #endif
 
 static constexpr uint32_t SLOW_TEST_INITIAL_GENERATE = 0;
@@ -255,6 +253,15 @@ enum port_type {
     , BITE_SERVER = 11
 #endif
 };
+
+#ifdef BITE
+
+inline size_t getNumBiteValidationThreads() {
+    const unsigned int n = std::thread::hardware_concurrency();
+    return n == 0 ? 8 : static_cast<size_t>(n);
+}
+
+#endif
 
 
 template < typename T >

--- a/abstracttcpclient/AbstractClientAgent.cpp
+++ b/abstracttcpclient/AbstractClientAgent.cpp
@@ -46,7 +46,6 @@ blic License as published
 
 #include "datastructures/BlockProposal.h"
 #include "datastructures/DAProof.h"
-#include "utils/Time.h"
 
 
 AbstractClientAgent::AbstractClientAgent( Schain& _sChain, port_type _portType )

--- a/abstracttcpserver/AbstractServerAgent.cpp
+++ b/abstracttcpserver/AbstractServerAgent.cpp
@@ -39,6 +39,7 @@
 #include "network/ServerConnection.h"
 #include "network/Sockets.h"
 #include "network/TCPServerSocket.h"
+#include <netinet/tcp.h>
 
 
 #include "AbstractServerAgent.h"
@@ -138,8 +139,9 @@ void AbstractServerAgent::acceptTCPConnectionsLoop() {
         while ( !getSchain()->getNode()->isExitRequested() ) {
             int newConnection = accept( s, ( sockaddr* ) &clientAddress, &sizeOfClientAddress );
 
-            // static  int one = 1;
-            // CHECK_STATE(setsockopt(newConnection, SOL_TCP, TCP_NODELAY, &one, sizeof(one)) == 0);
+            // Enable NODELAY option
+            static  int one = 1;
+            CHECK_STATE(setsockopt(newConnection, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one)) == 0);
 
             if ( getSchain()->getNode()->isExitRequested() ) {
                 return;

--- a/bite/BiteAESDecryptionShareSerializer.cpp
+++ b/bite/BiteAESDecryptionShareSerializer.cpp
@@ -78,7 +78,7 @@ void BiteAESDecryptionShareSerializer::serializedSanityCheck(
 
 ptr< AESKeyDecryptionShareList > BiteAESDecryptionShareSerializer::deserialize(
     const ptr< vector< uint8_t > >& _serializedDecryptionShares,
-    const ptr< CryptoManager >& _manager, bool ) {
+    const ptr< CryptoManager >& _manager, bool _validate ) {
     CHECK_ARGUMENT( _serializedDecryptionShares );
     CHECK_ARGUMENT( _manager );
 
@@ -96,29 +96,31 @@ ptr< AESKeyDecryptionShareList > BiteAESDecryptionShareSerializer::deserialize(
     CHECK_STATE( fbDecryptionSharesHandle );
 
     return getDecryptionShares(blockId, proposerIndex, decryptorIndex, fbDecryptionSharesHandle,
-        _manager->getSchain()->getBiteManager());
+        _manager->getSchain()->getBiteManager(), _validate );
 }
 
 
 shared_ptr< AESKeyDecryptionShareList > BiteAESDecryptionShareSerializer::getDecryptionShares(
     const block_id _blockId, const schain_index _proposerIndex, const schain_index _decryptorIndex,
     const flatbuffers::Vector< ::flatbuffers::Offset< skale_fb::DecryptionShare > >*
-        _fbDecryptionSharesHandle, ptr<BiteManager> _biteManager) {
+        _fbDecryptionSharesHandle, ptr<BiteManager> _biteManager, bool _validate) {
     CHECK_STATE(_biteManager)
 
     const size_t numShares = _fbDecryptionSharesHandle->size();
     auto shares = make_shared< AESKeyDecryptionShareList >( _blockId, _proposerIndex, _decryptorIndex );
 
     std::vector<folly::Future<folly::Unit>> futures;
-    futures.reserve(NUM_BITE_VALIDATION_THREADS);
+    
+    const size_t numThreads = getNumBiteValidationThreads();
+    futures.reserve(numThreads);
 
-    const size_t chunkSize = (numShares + NUM_BITE_VALIDATION_THREADS - 1) / NUM_BITE_VALIDATION_THREADS;
+    const size_t chunkSize = (numShares + numThreads - 1) / numThreads;
 
     // Thread-local storage for results to minimize lock contention
     std::vector<std::vector<std::pair<transaction_index, ptr<AESKeyDecryptionShares>>>>
-            threadLocalShares(NUM_BITE_VALIDATION_THREADS);
+            threadLocalShares(numThreads);
 
-    for (size_t threadId = 0; threadId < NUM_BITE_VALIDATION_THREADS; ++threadId) {
+    for (size_t threadId = 0; threadId < numThreads; ++threadId) {
         size_t startIdx = threadId * chunkSize;
         size_t endIdx = std::min(startIdx + chunkSize, numShares);
 
@@ -127,7 +129,8 @@ shared_ptr< AESKeyDecryptionShareList > BiteAESDecryptionShareSerializer::getDec
 
         auto future = folly::via(_biteManager->getExecutor().get(),
                                  [threadId, startIdx, endIdx, _fbDecryptionSharesHandle,
-                                _decryptorIndex, _biteManager, &threadLocalShares]() {
+                                _decryptorIndex, _biteManager, &threadLocalShares,
+                                _validate]() {
             threadLocalShares[threadId].reserve(endIdx - startIdx);
 
             for (size_t i = startIdx; i < endIdx; ++i) {
@@ -139,7 +142,8 @@ shared_ptr< AESKeyDecryptionShareList > BiteAESDecryptionShareSerializer::getDec
 
                 string decryptionShareStr( rawData, rawData + fbdecryptionShareHandle->data()->size() );
                 auto decryptionShares = _biteManager->createAESDecryptionShares(
-                    decryptionShareStr, _decryptorIndex, fbdecryptionShareHandle->decryption_failed() );
+                    decryptionShareStr, _decryptorIndex, 
+                    fbdecryptionShareHandle->decryption_failed(), _validate );
 
                 threadLocalShares[threadId].emplace_back(
                     fbdecryptionShareHandle->transaction_index(), decryptionShares);
@@ -151,12 +155,11 @@ shared_ptr< AESKeyDecryptionShareList > BiteAESDecryptionShareSerializer::getDec
         futures.push_back(std::move(future));
     }
 
-    // Wait for all tasks to complete
-    auto allResults = folly::collectAll(futures).get();
+    folly::collectAll(futures).get();
 
     // Merge results from all threads
     shares->reserve( numShares );
-    for (size_t threadId = 0; threadId < NUM_BITE_VALIDATION_THREADS; ++threadId) {
+    for (size_t threadId = 0; threadId < numThreads; ++threadId) {
         for (auto& [txId, decryptionShares] : threadLocalShares.at(threadId)) {
             shares->addShares(txId, decryptionShares);
         }

--- a/bite/BiteAESDecryptionShareSerializer.h
+++ b/bite/BiteAESDecryptionShareSerializer.h
@@ -17,5 +17,5 @@ public:
     static shared_ptr< AESKeyDecryptionShareList > getDecryptionShares( const block_id _blockId,
         const schain_index _proposerIndex, const schain_index _decryptorIndex,
         const flatbuffers::Vector< ::flatbuffers::Offset< skale_fb::DecryptionShare > >*
-            _fbDecryptionSharesHandle, ptr<BiteManager> _biteManager);
+            _fbDecryptionSharesHandle, ptr<BiteManager> _biteManager, bool _validate = true );
 };

--- a/bite/BiteEngine.cpp
+++ b/bite/BiteEngine.cpp
@@ -2,6 +2,8 @@
 #include <folly/futures/Future.h>
 #include <folly/Unit.h>
 
+#include <atomic>
+
 #include "crypto/DecryptedAESKeyList.h"
 #include "crypto/AESKeyDecryptionShareList.h"
 #include "node/ConsensusTypes.h"
@@ -155,37 +157,153 @@ BiteEngine::ParseResult BiteEngine::parseAndCacheBITETransactions(
     return result;
 }
 
+// ================ Validate Ciphertexts =================== //
 
-/**
- * @brief Helper function - appends ciphertexts from TransactionCiphertexts to vector of CipheredKey
- */
-void appendCiphertextsToVector(ptr<TransactionCiphertexts> _ciphertexts, std::vector< libBLS::CipheredKey >& _vec, size_t& _ciphertextIdx) {
-    // Allow transactions with no ciphertexts (e.g., CTX txs with empty ciphertext)
-    if (_ciphertexts->count() == 0) {
+// ------ Helpers ------ //
+
+namespace {
+
+struct PendingTxBatch {
+    transaction_index txIdx;
+    ptr<TransactionCiphertexts> ciphertexts;
+    size_t futureStartIdx = 0;
+    size_t ciphertextCount = 0;
+};
+
+struct ScheduledCiphertextParsing {
+    std::vector<PendingTxBatch> pendingTxs;
+    std::vector<folly::Future<libBLS::CipheredKey>> parseFutures;
+};
+
+// Schedules individual CipheredKey::fromBytes() calls
+// for all ciphertexts in the map, using the provided executor.
+// 1 CipheredKey per folly future.
+// @note Tested with batched version, setting batched deserializations
+// per folly future, but the code complexity increased & the measured 
+// performance benefit is not worth it.
+ScheduledCiphertextParsing scheduleCiphertextParsing(
+    const TransactionCiphertextsMap& txsCiphertexts,
+    folly::Executor* executor,
+    BiteEngine::CiphertextValidationResult& engineResult)
+{
+    ScheduledCiphertextParsing scheduled;
+    scheduled.pendingTxs.reserve(txsCiphertexts.size());
+    scheduled.parseFutures.reserve(txsCiphertexts.totalCiphertextCount());
+
+    for (auto&& [idx, ciphertexts] : txsCiphertexts) {
+        try {
+            CHECK_STATE(ciphertexts);
+
+            const size_t count = ciphertexts->count();
+            const size_t futureStartIdx = scheduled.parseFutures.size();
+
+            scheduled.pendingTxs.push_back(
+                PendingTxBatch{idx, ciphertexts, futureStartIdx, count});
+
+            for (size_t i = 0; i < count; ++i) {
+                scheduled.parseFutures.push_back(
+                    folly::via(executor, [ciphertexts, i]() {
+                        return libBLS::CipheredKey::fromBytes((*ciphertexts)[i].data());
+                    }));
+            }
+        }
+        catch (exception& _e) {
+            engineResult.invalidCiphertextIndices.push_back(idx);
+            engineResult.failureReasons.push_back(
+                "Ciphertext scheduling failed to start: " + std::string(_e.what()));
+        }
+    }
+
+    return scheduled;
+}
+
+// Checks if any of the parse results for the given pending batch has an exception.
+bool findParseFailure(
+    const PendingTxBatch& pending,
+    const std::vector<folly::Try<libBLS::CipheredKey>>& parseResults,
+    size_t& failingIdx,
+    std::string& parseError)
+{
+    for (size_t i = 0; i < pending.ciphertextCount; ++i) {
+        const auto& result = parseResults[pending.futureStartIdx + i];
+        if (!result.hasException()) {
+            continue;
+        }
+
+        failingIdx = i;
+        try {
+            result.exception().throw_exception();
+        }
+        catch (const std::exception& e) {
+            parseError = e.what();
+        }
+        catch (...) {
+            parseError = "unknown exception";
+        }
+        return true;
+    }
+
+    return false;
+}
+
+void appendAADForTransaction(
+    ptr<TransactionCiphertexts> ciphertexts,
+    std::vector<std::vector<uint8_t>>& aadTE,
+    bool& hasAnyAAD)
+{
+    if (!ciphertexts->isCTX()) {
         return;
     }
-    
-    if (_ciphertexts->count() > 1) {
-        std::vector< libBLS::CipheredKey > cipheredKeysLocal;
-        cipheredKeysLocal.reserve(_ciphertexts->count());
-        for (const auto& encryptedKey : *_ciphertexts) {
-            cipheredKeysLocal.emplace_back(libBLS::CipheredKey::fromBytes(encryptedKey.data()));
-            _ciphertextIdx++;
-        }
-        // Only insert all after all have been successfully created (there could be exceptions thrown)
-        _vec.insert(_vec.end(), cipheredKeysLocal.begin(), cipheredKeysLocal.end());
+
+    const auto& scAddr = ciphertexts->getScAddressAadTE();
+    CHECK_STATE(scAddr.has_value());
+
+    std::vector<uint8_t> aadBytes(scAddr->begin(), scAddr->end());
+
+    for (size_t i = 0; i < ciphertexts->count(); ++i) {
+        aadTE.push_back(aadBytes);
     }
-    else {
-        auto cipheredKey = libBLS::CipheredKey::fromBytes((*_ciphertexts)[0].data());
-        _vec.push_back(cipheredKey);
+
+    hasAnyAAD = true;
+}
+
+void appendSemanticValidationFailures(
+    const std::vector<std::pair<transaction_index, size_t>>& parsedTxs,
+    const BiteCore::CiphertextValidationResult& coreResult,
+    BiteEngine::CiphertextValidationResult& engineResult)
+{
+    size_t ciphertextGlobalIdx = 0;
+
+    for (const auto& [idx, numCiphertexts] : parsedTxs) {
+        bool alreadyHasOneInvalidCiphertext = false;
+
+        for (size_t i = 0; i < numCiphertexts; ++i) {
+            if (!coreResult.validationResults[ciphertextGlobalIdx] &&
+                !alreadyHasOneInvalidCiphertext) {
+                engineResult.invalidCiphertextIndices.push_back(idx);
+                engineResult.failureReasons.push_back(
+                    "Ciphertext with global index " +
+                    std::to_string(ciphertextGlobalIdx) +
+                    " failed semantic validation");
+                alreadyHasOneInvalidCiphertext = true;
+            }
+            ciphertextGlobalIdx++;
+        }
     }
 }
 
+} // anonymous namespace
 
-BiteEngine::CiphertextValidationResult BiteEngine::validateCiphertexts(const TransactionCiphertextsMap& txsCiphertexts) const {
+// ------ Main function ------ //
+
+
+BiteEngine::CiphertextValidationResult BiteEngine::validateCiphertexts(
+    const TransactionCiphertextsMap& txsCiphertexts,
+    const BiteRuntimeContext& runtimeContext) const
+{
     CiphertextValidationResult engineResult;
 
-    std::vector< libBLS::CipheredKey > cipheredKeys;
+    std::vector<libBLS::CipheredKey> cipheredKeys;
     cipheredKeys.reserve(txsCiphertexts.totalCiphertextCount());
 
     // AAD vector aligned with cipheredKeys - empty vector means no AAD for that ciphertext
@@ -197,66 +315,73 @@ BiteEngine::CiphertextValidationResult BiteEngine::validateCiphertexts(const Tra
     std::vector<std::pair<transaction_index, size_t>> parsedTxs;
     size_t expectedValidationResults = 0;
 
-    // build CipheredKey vector & identify invalid ones
-    for ( auto && [idx, ciphertexts]: txsCiphertexts) {
-        size_t failingIdx = 0; // ciphertext idx for each tx starts at 0
-        try {
-            CHECK_STATE(ciphertexts)
-            appendCiphertextsToVector(ciphertexts, cipheredKeys, failingIdx);
-            parsedTxs.emplace_back(idx, ciphertexts->count());
-            expectedValidationResults += ciphertexts->count();
+    // Phase 1: Schedule parsing all ciphertext from bytes & also validating individual ciphertexts
+    auto scheduled = scheduleCiphertextParsing(
+        txsCiphertexts,
+        runtimeContext.threadPoolExecutor.get(),
+        engineResult);
 
-            // Build AAD only for CTX transactions - regular txs don't need AAD entries
-            if (ciphertexts->isCTX()) {
-                const auto& scAddr = ciphertexts->getScAddressAadTE();
-                CHECK_STATE(scAddr.has_value());
-                std::vector<uint8_t> aadBytes(scAddr->begin(), scAddr->end());
-                // same AAD for all ciphertexts in this transaction
-                for (size_t i = 0; i < ciphertexts->count(); ++i) {
-                    aadTE.push_back(aadBytes);
-                }
-                hasAnyAAD = true;
-            }
-            // Regular transactions don't need AAD entries - libBLS handles partial AAD
+    auto parseResults = folly::collectAll(scheduled.parseFutures).get();
+
+    // Build CipheredKey vector & identify invalid ones
+    for (const auto& pending : scheduled.pendingTxs) {
+        size_t failingIdx = 0;
+        std::string parseError;
+
+        // Look for exceptions during execution
+        if (findParseFailure(pending, parseResults, failingIdx, parseError)) {
+            engineResult.invalidCiphertextIndices.push_back(pending.txIdx);
+            engineResult.failureReasons.push_back(
+                "Ciphertext with index " + std::to_string(failingIdx) +
+                " failed to parse: " + parseError);
+            continue;
         }
-        catch (exception &_e) {
-            engineResult.invalidCiphertextIndices.push_back(idx);
-            engineResult.failureReasons.push_back("Ciphertext with index " + std::to_string(failingIdx) + " failed to parse: " + std::string(_e.what()));
+
+        try {
+            // add AAD for TE validation if it's a CTX.
+            // updates the hashAnyAAD flag if at least one CTX is present in the batch
+            appendAADForTransaction(pending.ciphertexts, aadTE, hasAnyAAD);
+            
+            for (size_t i = 0; i < pending.ciphertextCount; ++i) {
+                cipheredKeys.push_back(
+                    std::move(parseResults[pending.futureStartIdx + i]).value());
+            }
+
+            parsedTxs.emplace_back(pending.txIdx, pending.ciphertextCount);
+            expectedValidationResults += pending.ciphertextCount;
+        }
+        catch (exception& _e) {
+            engineResult.invalidCiphertextIndices.push_back(pending.txIdx);
+            engineResult.failureReasons.push_back(
+                "Ciphertext metadata validation failed: " + std::string(_e.what()));
         }
     }
 
     // From the successfully built CipheredKey vector, validate ciphertexts
     // Pass AAD only if we have at least one CTX transaction
-    BiteCore::CiphertextValidationResult coreResult = core.validateCiphertexts(
-        cipheredKeys, hasAnyAAD ? &aadTE : nullptr);
+    BiteCore::CiphertextValidationResult coreResult =
+        core.validateCiphertexts(cipheredKeys, hasAnyAAD ? &aadTE : nullptr);
+
     CHECK_STATE(coreResult.validationResults.size() == expectedValidationResults);
 
     if (!coreResult.allValid) {
-        size_t ciphertextGlobalIdx = 0;
-        for (auto& [idx, numCiphertexts] : parsedTxs) {
-            bool alreadyHasOneInvalidCiphertext = false;
-            for (size_t i = 0; i < numCiphertexts; ++i) {
-                if (!coreResult.validationResults[ciphertextGlobalIdx] && !alreadyHasOneInvalidCiphertext) {
-                    engineResult.invalidCiphertextIndices.push_back(idx);
-                    engineResult.failureReasons.push_back("Ciphertext with global index " + std::to_string(ciphertextGlobalIdx) + " failed semantic validation");
-                    alreadyHasOneInvalidCiphertext = true;
-                }
-                ciphertextGlobalIdx++;
-            }
-        }
+        appendSemanticValidationFailures(parsedTxs, coreResult, engineResult);
     }
 
     // Only add public decryption values if both
     // 1) ciphertext parsing was successful
     // 2) core validation marked all as valid
     if (engineResult.allValid() && coreResult.allValid) {
-        // convert to string all successful decryption shares
         engineResult.publicDecryptionValues =
-            libBLS::CipheredKey::getDecryptionShareInputBatch( cipheredKeys );
+            libBLS::CipheredKey::getDecryptionShareInputBatch(cipheredKeys);
     }
 
     return engineResult;
 }
+
+
+// ================ Merge AES Keys =================== //
+
 
 std::shared_ptr<DecryptedAESKeyList> BiteEngine::mergeAESKeys(
     block_id _blockId,
@@ -277,6 +402,8 @@ std::shared_ptr<DecryptedAESKeyList> BiteEngine::mergeAESKeys(
         CHECK_STATE(list->totalCiphertextSharesCount() == expectedSharesCount);
     }
 
+    // Initialize decryption share sets & build CipheredKey vectors for TE validation
+
     // 1 per transaction (but each tx may contain multiple ciphertexts)
     std::map<transaction_index, ptr<AESKeyDecryptionShareSet>> decryptionShareSets;
     auto encryptions = std::make_shared<std::map<transaction_index, std::vector<libBLS::CipheredKey>>>();
@@ -289,6 +416,7 @@ std::shared_ptr<DecryptedAESKeyList> BiteEngine::mergeAESKeys(
         if (config.sgxEnabled) {
             auto& ciphertextsForCurrTx = *_txCiphertexts.at(idx);
             for (auto& ciphertext : ciphertextsForCurrTx) {
+                // deserialize - no validation needed
                 (*encryptions)[idx].push_back(
                     libBLS::CipheredKey::fromBytes(ciphertext.data(), toValidate));
             }
@@ -301,7 +429,13 @@ std::shared_ptr<DecryptedAESKeyList> BiteEngine::mergeAESKeys(
     auto aesKeys = make_shared< DecryptedAESKeyList >();
     auto aesKeysMutex = std::make_shared<std::mutex>();
 
-    auto processTx = [this, aesKeys, aesKeysMutex, &_txCiphertexts, &_decryptionShareMap, &_tePublicKeyShares, encryptions, config = this->config](transaction_index txId, ptr<AESKeyDecryptionShareSet> decryptionSet) -> folly::Unit {
+
+    // Initialize decryption share sets & build CipheredKey vectors for TE validation
+
+    auto processTx = [aesKeys, aesKeysMutex, &_txCiphertexts, 
+        &_decryptionShareMap, &_tePublicKeyShares, encryptions, config = this->config
+    ](transaction_index txId, ptr<AESKeyDecryptionShareSet> decryptionSet) -> folly::Unit {
+
         size_t numberOfCiphertexts = _txCiphertexts.at(txId)->count();
         // still not enough shares - validate & add more
         if (!decryptionSet->isEnough()) {
@@ -642,7 +776,8 @@ std::vector<uint8_t> BiteEngine::buildCTXData(
 std::shared_ptr<AESKeyDecryptionShares> BiteEngine::createDecryptionSharesObjects(
     const std::vector<std::string_view>& shareStrs,
     schain_index decryptorIndex,
-    bool decryptionFailed
+    bool decryptionFailed, 
+    bool validate
 ) const {
     auto shares = std::make_shared<AESKeyDecryptionShares>();
     for (auto shareStr : shareStrs) {
@@ -650,7 +785,7 @@ std::shared_ptr<AESKeyDecryptionShares> BiteEngine::createDecryptionSharesObject
         if (usingRealCrypto()) {
             shares->push_back(
                 std::make_shared<ConsensusAESKeyDecryptionShare>(
-                    s, decryptorIndex, decryptionFailed));
+                    s, decryptorIndex, decryptionFailed, validate));
         } else {
             shares->push_back(
                 std::make_shared<MockupAESKeyDecryptionShare>(

--- a/bite/BiteEngine.h
+++ b/bite/BiteEngine.h
@@ -90,7 +90,8 @@ public:
      * Only if all ciphertexts are valid, public decryption values are returned.
      */
     CiphertextValidationResult validateCiphertexts(
-        const TransactionCiphertextsMap& txsCiphertexts
+        const TransactionCiphertextsMap& txsCiphertexts,
+        const BiteRuntimeContext& runtimeContext
     ) const;
 
     //=================== Stage 3: Merging TE Decryption Shares into AES Keys  =================== //
@@ -139,10 +140,21 @@ public:
     ) const;
 
 
+    /**
+     * @brief Creates AESKeyDecryptionShares objects from their string representations.
+     * If using real crypto, optionally validates the shares during creation. 
+     * If validation fails, an exception is thrown.
+     * If using mockup, no validation.
+     * @param shareStrs vector of string representations of decryption shares, each corresponding to a ciphertext
+     * @param decryptorIndex the index of the decryptor that created these shares
+     * @param decryptionFailed whether the decryption shares correspond to a failed decryption
+     * @param validate whether to validate the shares during creation (only applicable if using real crypto)
+     */
     ptr<AESKeyDecryptionShares> createDecryptionSharesObjects(
         const std::vector<std::string_view>& shareStrs,
         schain_index decryptorIndex,
-        bool decryptionFailed
+        bool decryptionFailed,
+        bool validate = true
     ) const;
 
     ptr<AESKeyDecryptionShareSet> createAESDecryptionShareSetObject(

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -30,7 +30,6 @@
 #include "db/TEDecryptionDB.h"
 
 #include "libBLS/bls/BLSPublicKey.h"
-
 BiteManager::BiteManager(Schain& _schain)
   : schain(_schain), 
     biteEngine(
@@ -42,7 +41,7 @@ BiteManager::BiteManager(Schain& _schain)
             }
         )
 {
-    threadPoolExecutor = std::make_shared<folly::CPUThreadPoolExecutor>(NUM_BITE_VALIDATION_THREADS);
+    threadPoolExecutor = std::make_shared<folly::CPUThreadPoolExecutor>(getNumBiteValidationThreads());
 }
 
 BiteManager::~BiteManager() {
@@ -86,7 +85,10 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
     ptr<TransactionCiphertextsMap> txsCiphertexts = _proposal->getTransactionCiphertexts();
     auto& failedTransactionRef = _proposal->getFailedTransactionsRef();
 
-    BiteEngine::CiphertextValidationResult validationResult = biteEngine.validateCiphertexts(*txsCiphertexts);
+    BiteRuntimeContext biteCtx;
+    biteCtx.threadPoolExecutor = threadPoolExecutor;
+    BiteEngine::CiphertextValidationResult validationResult =
+        biteEngine.validateCiphertexts(*txsCiphertexts, biteCtx);
 
     if (!validationResult.allValid()) {
         for (auto invalidIdx : validationResult.invalidCiphertextIndices) {
@@ -180,8 +182,8 @@ DecryptedTransactions BiteManager::verifyAndDecryptTransactionList(
 
     BiteRuntimeContext runtimeCtx {
         .currentEpoch = _epochId,
-        .threadPoolExecutor = threadPoolExecutor
-        , .isBite2PatchEnabled = _isBite2PatchEnabledForBlock
+        .threadPoolExecutor = threadPoolExecutor, 
+        .isBite2PatchEnabled = _isBite2PatchEnabledForBlock
     };
 
     return biteEngine.decryptTransactionsListInParallel(
@@ -251,14 +253,13 @@ ptr<vector<ptr<AESKeyDecryptionShares> > > BiteManager::getDecryptionSharesFromA
         flattenedShares,
         _decryptorIndex
     );
-
 }
 
 
 ptr<AESKeyDecryptionShares> BiteManager::createAESDecryptionShares(
-        const string& _aesKeyDecryptionShares, schain_index _decryptorIndex, bool _decryptionFailed) {
+        const string& _aesKeyDecryptionShares, schain_index _decryptorIndex, bool _decryptionFailed, bool _validate) {
     auto shareStrs = BiteCodec::splitShares(_aesKeyDecryptionShares);
-    return biteEngine.createDecryptionSharesObjects(shareStrs, _decryptorIndex, _decryptionFailed);
+    return biteEngine.createDecryptionSharesObjects(shareStrs, _decryptorIndex, _decryptionFailed, _validate);
 }
 
 ptr<AESKeyDecryptionShareSet> BiteManager::createAESDecryptionShareSet(

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -111,10 +111,13 @@ public:
      * separated by commas.
      * @param _decryptorIndex - index of the decryptor node that created these shares
      * @param _decryptionFailed - whether decryption failed for this transaction
+     * @param _validate - whether to validate the shares during creation (only applicable if using real crypto). 
+     * If true and validation fails, an exception is thrown.
      */
     [[nodiscard]] ptr<AESKeyDecryptionShares> createAESDecryptionShares(const string& _aesKeyDecryptionShares,
                                                                       schain_index _decryptorIndex,
-                                                                      bool _decryptionFailed);
+                                                                      bool _decryptionFailed,
+                                                                      bool _validate = true);
 
 
     [[nodiscard]] ptr<AESKeyDecryptionShareSet> createAESDecryptionShareSet(

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -220,11 +220,9 @@ void BlockFinalizeDownloader::downloadFragment(
         CATCH_LOG_AND_RETHROW_ANY_EXCEPTION(err, "Could not add decryption shares to DB");
     }
 
-
     if (!needFragmentData) {
         return;
     }
-
 #endif
 
     fragmentList.addFragment(blockFragment);
@@ -475,7 +473,7 @@ void BlockFinalizeDownloader::workerThreadFragmentDownloadLoop(
         } catch (DoNotHaveProposalYetException &) {
             // this is ok, we just do not have proposal yet on this destionation node
             // we keep trying to download the fragment until the node has the proposal
-            _agent->waitAfterNoProposal();;
+            _agent->waitAfterNoProposal();
         } catch (ExitRequestedException &) {
         } catch (ConnectionRefusedException &e) {
             // the node may be down. We will wait a little and try again

--- a/blockproposal/pusher/BlockProposalClientAgent.cpp
+++ b/blockproposal/pusher/BlockProposalClientAgent.cpp
@@ -314,8 +314,9 @@ pair< ConnectionStatus, ConnectionSubStatus > BlockProposalClientAgent::sendBloc
     } catch ( ... ) {
     }
 
-    if ( finalResult.first != ConnectionStatus::CONNECTION_SUCCESS )
+    if ( finalResult.first != ConnectionStatus::CONNECTION_SUCCESS ) {
         return finalResult;
+    }
 
 
     auto sigShare = getSchain()->getCryptoManager()->createDAProofSigShare(

--- a/blockproposal/server/BlockProposalServerAgent.cpp
+++ b/blockproposal/server/BlockProposalServerAgent.cpp
@@ -268,7 +268,7 @@ void BlockProposalServerAgent::processDAProofRequest(
 }
 
 pair<ConnectionStatus, ConnectionSubStatus> BlockProposalServerAgent::processProposalRequest(
-        const ptr<ServerConnection> &_connection, nlohmann::json _proposalRequest) {
+        const ptr<ServerConnection> &_connection, nlohmann::json _proposalRequest ) {
     CHECK_ARGUMENT(_connection);
 
     ptr<BlockProposalRequestHeader> requestHeader = nullptr;

--- a/catchup/server/CatchupServerAgent.cpp
+++ b/catchup/server/CatchupServerAgent.cpp
@@ -388,16 +388,22 @@ ptr<vector<uint8_t> > CatchupServerAgent::createBlockFinalizeResponse(
         ptr<AESKeyDecryptionShareList> myDecryptionShares;
 
         if (needDecryptionShares) {
-            myDecryptionShares = getNode()->getTEDecryptionDB()->getMyDecryptionShares(proposal->getBlockID(),
-                proposal->getProposerIndex());
+            // try get cached decryption shares from proposal first
+            myDecryptionShares = proposal->getMyDecryptionShares();
             if (!myDecryptionShares) {
-                _responseHeader->setStatusSubStatus(
-                    CONNECTION_DISCONNECT, CONNECTION_FINALIZE_DONT_HAVE_DECRYPTION_SHARES);
-                _responseHeader->setComplete();
-                return nullptr;
+                // if proposal does not have decryption shares, try to get from DB 
+                // (e.g., in case of finalized block, shares might not be in proposal but should be in DB)
+                myDecryptionShares = getNode()->getTEDecryptionDB()->getMyDecryptionShares(proposal->getBlockID(),
+                    proposal->getProposerIndex());
+                if (!myDecryptionShares) {
+                    _responseHeader->setStatusSubStatus(
+                        CONNECTION_DISCONNECT, CONNECTION_FINALIZE_DONT_HAVE_DECRYPTION_SHARES);
+                    _responseHeader->setComplete();
+                    return nullptr;
+                }
             }
         } else {
-            // just returtn emptyu list
+            // just return empty list
             myDecryptionShares = make_shared<AESKeyDecryptionShareList>(_blockID, proposerIndex,
                                                                         getSchain()->getSchainIndex());
         }

--- a/crypto/ConsensusAESDecryptionShare.cpp
+++ b/crypto/ConsensusAESDecryptionShare.cpp
@@ -25,14 +25,15 @@ ConsensusAESKeyDecryptionShare::ConsensusAESKeyDecryptionShare(
 
 
 ConsensusAESKeyDecryptionShare::ConsensusAESKeyDecryptionShare(
-    const string& _decryptionShare, schain_index _decryptorIndex, bool _decryptionFailed )
+    const string& _decryptionShare, schain_index _decryptorIndex, bool _decryptionFailed, 
+    bool _validate )
     : AESKeyDecryptionShare( _decryptorIndex, _decryptionFailed ) {
     CHECK_ARGUMENT( _decryptionShare != "" );
 
     try {
         // validate() is called in TEDecryptionShare constructor
         aesKeyDecryptionShare =
-            std::make_shared< TEDecryptionShare >( _decryptionShare, ( uint64_t ) _decryptorIndex );
+            std::make_shared< TEDecryptionShare >( _decryptionShare, ( uint64_t ) _decryptorIndex, _validate );
     } CATCH_LOG_AND_RETHROW_ANY_EXCEPTION( err, "Could not create TEDecryptionShare" );
 }
 

--- a/crypto/ConsensusAESKeyDecryptionShare.h
+++ b/crypto/ConsensusAESKeyDecryptionShare.h
@@ -19,7 +19,8 @@ public:
 
     ConsensusAESKeyDecryptionShare(const string &_decryptionShare,
                                   schain_index _decryptorIndex,
-                                   bool _decryptionFailed);
+                                   bool _decryptionFailed,
+                                  bool _validate = true);
 
 
     [[nodiscard]] ptr<libBLS::TEDecryptionShare> getTEDecryptionShare() const;

--- a/crypto/CryptoManager.cpp
+++ b/crypto/CryptoManager.cpp
@@ -867,6 +867,14 @@ ptr<ThresholdSigShare> CryptoManager::signSigShare(
 ptr<vector<ptr<AESKeyDecryptionShare> > > CryptoManager::sgxDecryptAESKeyShareBatch(
     std::vector<std::string> &_publicDecryptionValues) {
 
+    // do not validate decryption share from node's own SGX.
+    // Since SGX is owned by same node, we should treat it as an internal
+    // operation, and 'trust' it locally.
+    // If any share is invalid (very unlikely), other nodes will eventually 
+    // reject the shares from this node. The only advantage of validating 
+    // here would be early stopping at the cost of extra latency (~100ms)
+    static constexpr bool validateTEDecryptionShareFromSGX = false;
+
     MONITOR(__CLASS_NAME__, __FUNCTION__)
 
     uint64_t time = 0;
@@ -889,9 +897,11 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > CryptoManager::sgxDecryptAESKeyShareBa
         sgxBlockProcessingTimeMs += finishTimeMs - startTimeMs;
 
         CHECK_STATE(stringShares);
+
         result->reserve( stringShares->size() );
         for (auto&& stringShare : *stringShares) {
-            auto share = make_shared<libBLS::TEDecryptionShare>(stringShare, (uint64_t) getSchain()->getSchainIndex());
+            auto share = make_shared<libBLS::TEDecryptionShare>(stringShare, (uint64_t) getSchain()->getSchainIndex(),
+                validateTEDecryptionShareFromSGX); // do not validate
             auto consensusDecryptShare =
                 make_shared<ConsensusAESKeyDecryptionShare>(share, sChain->getSchainIndex(), false);
             result->push_back(consensusDecryptShare);
@@ -922,7 +932,8 @@ ptr<vector<ptr<AESKeyDecryptionShare> > > CryptoManager::sgxDecryptAESKeyShareBa
         result->reserve( sharesArray.size() );
         for (Json::Value::ArrayIndex i = 0; i < sharesArray.size(); ++i) {
             string shareStr = sharesArray[i].asString();
-            auto share = make_shared<libBLS::TEDecryptionShare>(shareStr, (uint64_t) getSchain()->getSchainIndex());
+            auto share = make_shared<libBLS::TEDecryptionShare>(shareStr, (uint64_t) getSchain()->getSchainIndex(), 
+                validateTEDecryptionShareFromSGX); // do not validate
             auto consensusDecryptShare =
                 make_shared<ConsensusAESKeyDecryptionShare>(share, sChain->getSchainIndex(), false);
             result->push_back(consensusDecryptShare);

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -25,6 +25,7 @@
 #include <oids.h>
 #ifdef BITE
 
+#include <atomic>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/futures/Future.h>
 #include <folly/Unit.h>
@@ -65,7 +66,8 @@ TEDecryptionDB::TEDecryptionDB(
     Schain* _sChain, string& _dirName, string& _prefix, node_id _nodeId, uint64_t _maxDBSize )
     : CacheLevelDB( _sChain, _dirName, _prefix, _nodeId, _maxDBSize,
           LevelDBOptions::getTEDecryptionDBOptions(), false ) {
-    threadPoolExecutor = std::make_shared<folly::CPUThreadPoolExecutor>(NUM_BITE_VALIDATION_THREADS);
+
+    threadPoolExecutor = std::make_shared<folly::CPUThreadPoolExecutor>(getNumBiteValidationThreads());
 }
 
 TEDecryptionDB::~TEDecryptionDB() {
@@ -101,9 +103,6 @@ void TEDecryptionDB::addDecryptionShares(
     if ( decryptionsStore.count(_decryptionShareList->getBlockId()) > 0 )
         if ( decryptionsStore.at(_decryptionShareList->getBlockId()).count(index) > 0 )
             return;
-
-    auto serializedList = BiteAESDecryptionShareSerializer::serialize( _decryptionShareList );
-    CHECK_STATE( serializedList );
 
     std::vector<folly::Future<folly::Unit>> futures;
     futures.reserve(decryptionShareSets.size());
@@ -204,7 +203,6 @@ ptr< DecryptedAESKeyList > TEDecryptionDB::mergeAESKeys(block_id _blockId, ptr<T
     }
 
     CHECK_STATE(decryptionsStore.size() <= 2 * totalSigners);
-
 
     return aesKeys;
 }

--- a/network/ClientSocket.cpp
+++ b/network/ClientSocket.cpp
@@ -67,6 +67,15 @@ int ClientSocket::createTCPSocket() {
             FatalError( "Could not create outgoing socket:" + string( strerror( errno ) ) ) );
     }
 
+    // Disable Nagle so protocol steps that send small control messages back-to-back
+    // do not wait for an ACK before flushing the next write.
+    int noDelay = 1;
+    if ( setsockopt( s, IPPROTO_TCP, TCP_NODELAY, &noDelay, sizeof( noDelay ) ) < 0 ) {
+        close( s );
+        BOOST_THROW_EXCEPTION(
+            FatalError( "Could not set TCP_NODELAY: " + std::string( strerror( errno ) ) ) );
+    }
+
 
     // Since we frequently reconnect to the same address, we set options
     // that help with fast TCP reconnections

--- a/pendingqueue/TestMessageGeneratorAgent.cpp
+++ b/pendingqueue/TestMessageGeneratorAgent.cpp
@@ -164,57 +164,56 @@ void TestMessageGeneratorAgent::sendTestRequestEthCall() {
 
 ConsensusExtFace::Transactions TestMessageGeneratorAgent::pendingTransactionsBITE(
     size_t _limit ) {
+    // pre-built pool sizes — large enough to avoid repetition within a single block
+    static constexpr size_t numTotalRegularTxs = 1000;
+    static constexpr size_t numTotalCTXTxs     = 200;
+
     static size_t txIdxInPrecomputedBatchRegular = 0;
-    static size_t txIdxInPrecomputedBatchCTX = 0;
-    // contains 3/4 BITE encrypted & 1/4 unencrypted regular transactions
+    static size_t txIdxInPrecomputedBatchCTX     = 0;
+
+    // pool of regular txs: BITE-encrypted and unencrypted, interleaved by proportion
     static ConsensusExtFace::Transactions onlyRegularTxs;
-    // contains only BITE2 CTX transactions (with encrypted args)
+    // pool of CTX txs: non-empty and empty CTXs, scattered throughout the pool
     static ConsensusExtFace::Transactions onlyCTXs;
     static std::once_flag initFlag;
-    static size_t numTotalRegularTxs = 1000;
-    static size_t numTotalCTXTxs = 200;
-    static double CTXsProportion = 0;
 
-    // build test transactions only once at start (includes encrypting them)
-    std::call_once(initFlag, [&] () {
-        CTXsProportion = (double) numTotalCTXTxs / (numTotalRegularTxs + numTotalCTXTxs);
+    // Target proportions per block
+    static double CTXsProportion       = 0.2;
+    static double BITEProportion        = 0.5;
+    static double UnencryptedProportion = 1 - CTXsProportion - BITEProportion;
+
+    // Build both pools once at startup (includes encrypting transactions).
+    std::call_once(initFlag, [this] () {
+        ConsensusExtFace::Transactions tmpOnlyRegularTxs;
         ConsensusExtFace::Transactions tmponlyCTXs;
 
-        ConsensusExtFace::Transactions tmpOnlyRegularTxs;
-
-        // setup only regular txs
+        // Build the regular pool with BITE and unencrypted txs interleaved according to
+        // their relative proportions (BITEProportion : UnencryptedProportion).
+        // Bresenham-style tracking ensures they are evenly scattered rather than bunched.
+        size_t biteBuilt = 0, unencBuilt = 0;
         for ( uint64_t i = 0; i < numTotalRegularTxs; i++ ) {
             auto tx = EthTransactionEncoder::generateSampleTx();
-            // 3/4 chance of being bite encoded
-            // make one quarter unencrypted
-            if ( i % 4 != 0 ) {
+            bool isBITE = ( biteBuilt * UnencryptedProportion <= unencBuilt * BITEProportion );
+            if ( isBITE ) {
                 EthTransactionEncoder::encryptRegularTransaction( tx, sChain->getBiteManager() );
+                biteBuilt++;
+            } else {
+                unencBuilt++;
             }
             auto signedTx = EthTransactionEncoder::signAndEncodeTx( tx );
             tmpOnlyRegularTxs.emplaceBackRegular( std::move(*signedTx) );
         }
         onlyRegularTxs = std::move(tmpOnlyRegularTxs);
 
-        // setup ctx txs - include some empty CTXs for coverage
-        // Empty CTXs will be at positions: 0 (start), numTotalCTXTxs/2 (middle), numTotalCTXTxs-1 (end)
-        // and every 10th transaction to ensure ~10% are empty CTXs
+        // Build the CTX pool with ~10% empty CTXs scattered evenly throughout.
         for ( uint64_t i = 0; i < numTotalCTXTxs; i++ ) {
             auto tx = EthTransactionEncoder::generateSampleTx();
-            
-            // Make empty CTX at start, middle, end, and every 10th transaction
-            bool isEmptyCTX = (i == 0) || 
-                              (i == numTotalCTXTxs / 2) || 
-                              (i == numTotalCTXTxs - 1) ||
-                              (i % 10 == 0);
-            
-            if (isEmptyCTX) {
-                // CTX with no encrypted arguments (empty ciphertexts)
+            if ( i % 10 == 0 ) {
+                // empty CTX: no encrypted arguments
                 EthTransactionEncoder::encryptEmptyCTXTransaction( tx, sChain->getBiteManager() );
             } else {
-                // Regular CTX with encrypted arguments
                 EthTransactionEncoder::encryptCTXTransaction( tx, sChain->getBiteManager() );
             }
-            
             auto signedTx = EthTransactionEncoder::signAndEncodeTx( tx );
             tmponlyCTXs.emplaceBackCTX( std::move(*signedTx) );
         }
@@ -224,32 +223,31 @@ ConsensusExtFace::Transactions TestMessageGeneratorAgent::pendingTransactionsBIT
     ConsensusExtFace::Transactions selectedTxs;
 
     auto test = sChain->getBlockProposerTest();
-
     CHECK_STATE( !test.empty() );
-
     if ( test == SchainTest::NONE )
         return selectedTxs;
 
-    // compute how many CTXs / non-CTXs to include
-    const size_t numCTXs = (CTXsProportion * _limit);
+    // CTXs must occupy the front of the Transactions vector (data structure invariant).
+    // Both pools are pre-built with their types scattered, so pulling sequentially from
+    // each pool naturally distributes empty CTXs within the CTX section and
+    // BITE/unencrypted txs within the regular section.
+    const size_t numCTXs       = static_cast<size_t>( CTXsProportion * _limit );
     const size_t numRegularTxs = _limit - numCTXs;
-    size_t ctxIdx = txIdxInPrecomputedBatchCTX;
 
-    // place all CTXs at the start
+    size_t ctxIdx = txIdxInPrecomputedBatchCTX;
     for ( size_t i = 0; i < numCTXs; i++ ) {
         ctxIdx = (ctxIdx + 1) % numTotalCTXTxs;
         selectedTxs.emplaceBackCTX( onlyCTXs.at(ctxIdx) );
     }
-    ( void ) numTotalCTXTxs;
     txIdxInPrecomputedBatchCTX = ctxIdx;
 
     size_t regularIdx = txIdxInPrecomputedBatchRegular;
-    for ( uint64_t i = 0; i < numRegularTxs; i++ ) {
+    for ( size_t i = 0; i < numRegularTxs; i++ ) {
         regularIdx = (regularIdx + 1) % numTotalRegularTxs;
         selectedTxs.emplaceBackRegular( onlyRegularTxs.at(regularIdx) );
     }
     txIdxInPrecomputedBatchRegular = regularIdx;
-    
+
     return selectedTxs;
 };
 #endif

--- a/tests/unit/bite/BiteEngineTests.cpp
+++ b/tests/unit/bite/BiteEngineTests.cpp
@@ -384,6 +384,7 @@ CATCH_TEST_CASE("BiteEngine ignores non-BITE transactions", "[bite][engine][pars
 CATCH_TEST_CASE("BiteEngine validateCiphertexts succeeds for valid inputs, when using 1 ciphertext per tx", "[bite][engine][validate]") {
     BiteEngine engine = makeEngine(true);
     TransactionCiphertextsMap map;
+    BiteRuntimeContext runtimeContext;
 
     auto c1 = makeValidCiphertext(5);
     auto c2 = makeValidCiphertext(6);
@@ -391,7 +392,7 @@ CATCH_TEST_CASE("BiteEngine validateCiphertexts succeeds for valid inputs, when 
     map.emplace(0, std::make_shared<TransactionCiphertexts>(c1));
     map.emplace(1, std::make_shared<TransactionCiphertexts>(c2));
 
-    auto result = engine.validateCiphertexts(map);
+    auto result = engine.validateCiphertexts(map, runtimeContext);
     CATCH_REQUIRE(result.allValid());
     CATCH_REQUIRE(result.invalidCiphertextIndices.empty());
     CATCH_REQUIRE(result.publicDecryptionValues.size() == map.totalCiphertextCount());
@@ -407,7 +408,8 @@ CATCH_TEST_CASE("BiteEngine validateCiphertexts invalid not parseable", "[bite][
     map.emplace(0, std::make_shared<TransactionCiphertexts>(valid));
     map.emplace(1, std::make_shared<TransactionCiphertexts>(invalid));
 
-    auto result = engine.validateCiphertexts(map);
+    BiteRuntimeContext runtimeContext;
+    auto result = engine.validateCiphertexts(map, runtimeContext);
     CATCH_REQUIRE_FALSE(result.allValid());
     CATCH_REQUIRE(result.invalidCiphertextIndices.size() == 1);
     CATCH_REQUIRE(result.invalidCiphertextIndices.front() == 1);
@@ -429,7 +431,8 @@ CATCH_TEST_CASE("BiteEngine validateCiphertexts invalid parseable but semantical
     map.emplace(0, std::make_shared<TransactionCiphertexts>(valid));
     map.emplace(1, std::make_shared<TransactionCiphertexts>(invalid));
 
-    auto result = engine.validateCiphertexts(map);
+    BiteRuntimeContext runtimeContext;
+    auto result = engine.validateCiphertexts(map, runtimeContext);
     CATCH_REQUIRE_FALSE(result.allValid());
     CATCH_REQUIRE(result.invalidCiphertextIndices.size() == 1);
     CATCH_REQUIRE(result.invalidCiphertextIndices.front() == 1);
@@ -443,7 +446,8 @@ CATCH_TEST_CASE("BiteEngine validateCiphertexts invalid parseable but semantical
 CATCH_TEST_CASE("BiteEngine validateCiphertexts empty map is valid", "[bite][engine][validate][empty]") {
     BiteEngine engine = makeEngine(true);
     TransactionCiphertextsMap map;
-    auto result = engine.validateCiphertexts(map);
+    BiteRuntimeContext runtimeContext;
+    auto result = engine.validateCiphertexts(map, runtimeContext);
     CATCH_REQUIRE(result.allValid());
     CATCH_REQUIRE(result.invalidCiphertextIndices.empty());
     CATCH_REQUIRE(result.publicDecryptionValues.empty());
@@ -456,7 +460,8 @@ CATCH_TEST_CASE("BiteEngine validateCiphertexts parse failure only", "[bite][eng
     auto badCipher = makeInvalidParseCiphertext(5);
     map.emplace(0, std::make_shared<TransactionCiphertexts>(badCipher));
 
-    auto result = engine.validateCiphertexts(map);
+    BiteRuntimeContext runtimeContext;
+    auto result = engine.validateCiphertexts(map, runtimeContext);
     CATCH_REQUIRE_FALSE(result.allValid());
     CATCH_REQUIRE(result.invalidCiphertextIndices.size() == 1);
     CATCH_REQUIRE(result.invalidCiphertextIndices.front() == 0);
@@ -485,7 +490,8 @@ CATCH_TEST_CASE("BiteEngine validateCiphertexts single invalid ciphertext invali
     tx2Ciphertexts.push_back( makeInvalidSemanticCiphertext(8) );
     map.emplace(2, std::make_shared<TransactionCiphertexts>(tx2Ciphertexts));
 
-    auto result = engine.validateCiphertexts(map);
+    BiteRuntimeContext runtimeContext;
+    auto result = engine.validateCiphertexts(map, runtimeContext);
     CATCH_REQUIRE_FALSE(result.allValid());
     CATCH_REQUIRE(result.invalidCiphertextIndices.size() == 2);
     CATCH_REQUIRE(result.invalidCiphertextIndices.front() == 1);
@@ -963,7 +969,8 @@ CATCH_TEST_CASE("BiteEngine validateCiphertexts handles CAT with empty ciphertex
     auto c3 = makeValidCiphertext(5);
     map.emplace(2, std::make_shared<TransactionCiphertexts>(c3));
 
-    auto result = engine.validateCiphertexts(map);
+    BiteRuntimeContext runtimeContext;
+    auto result = engine.validateCiphertexts(map, runtimeContext);
     CATCH_REQUIRE(result.allValid());
     CATCH_REQUIRE(result.invalidCiphertextIndices.empty());
     // public values only for non-empty ciphertexts (tx0 has 2, tx1 has 0, tx2 has 1 = 3 total)
@@ -1203,6 +1210,64 @@ CATCH_TEST_CASE("BiteEngine tryGetEncryptedCTXArgs caches SC address as AAD", "[
     auto cachedScAddr = catTx->getScAddressAadTE();
     CATCH_REQUIRE(cachedScAddr != nullptr);
     CATCH_REQUIRE(std::vector<uint8_t>(cachedScAddr->begin(), cachedScAddr->end()) == scAddress);
+}
+
+// Performance Tests
+
+CATCH_TEST_CASE("BiteEngine mergeAESKeys performance", "[bite][engine][merge][performance]") {
+    const block_id blockId = 30;
+
+    // 10 node threshold out of 15
+    const size_t required = 3;
+    const size_t total = 4;
+
+    // total BITE txs
+    const uint32_t numTxs = 250;
+    const uint32_t numCATTxs = 100;
+
+    const uint64_t epoch = 10;
+
+    BiteEngine engine = makeEngine(true, BiteConfig{required, total});
+    auto keySet = generateKeys(required, total);
+
+    // build ciphertexts of timer
+    TransactionCiphertextsMap txCiphertexts;
+    for (size_t i = 0; i < numCATTxs; ++i) {
+        auto c = makeCatCiphertextsWithKey(epoch, keySet.commonPublic, 2); // CAT with 2 ciphertexts each
+        txCiphertexts.emplace(i, std::make_shared<TransactionCiphertexts>(c));
+    }
+
+    for (size_t i = 0; i < numTxs; ++i) {
+        auto c = makeValidCiphertextWithKey(epoch, keySet.commonPublic);
+        txCiphertexts.emplace(i, std::make_shared<TransactionCiphertexts>(c));
+    }
+
+    // compute decryption shares off timer
+    std::map<schain_index, std::shared_ptr<AESKeyDecryptionShareList>> shareMap;
+    for (size_t i = 1; i <= total; ++i) {
+        shareMap.emplace(i, makeConsensusShareList(blockId, i, txCiphertexts, keySet));
+    }
+
+    BiteRuntimeContext ctx{
+        epoch,
+        std::make_shared<folly::CPUThreadPoolExecutor>(20), // use thread pool for merging in performance test 
+    };
+    
+    auto start = std::chrono::high_resolution_clock::now();
+    auto aesKeys = engine.mergeAESKeys(
+        blockId,
+        txCiphertexts,
+        shareMap,
+        keySet.publicKeys,
+        ctx
+    );
+    auto end = std::chrono::high_resolution_clock::now();
+    
+    std::chrono::duration<double> duration = end - start;
+    std::cout << "mergeAESKeys took " << duration.count() << " seconds for " << numTxs 
+              << " BITE transactions + " << numCATTxs << " CAT transactions" << std::endl;
+
+    CATCH_REQUIRE(aesKeys);
 }
 
 #endif // BITE


### PR DESCRIPTION
## Description

1. Try get local decryption shares when serving `BlockFinalizeDownload` requests - avoids going to DB altogether - most common case. 
2. Got rid of decryption share validation on the node when building the block finalize download, reading from node’s own DB → Shares in DB are already valid
3. Increased thread count for BITE thread pool executors from 8 to max supported concurrency by the hardware
4. Set no delay flag on proposal → -1 RTT delay on block proposal. It was sending a magic first (1RTT), and only then the proposal (2RTT). With `NO_DELAY` flag, proposer sends both messages right away, without waiting on the 1st message's ACK.
5. Proposal validation parallelization - Proposer now builds `CipheredKey::fromBytes()` with validation flag `true` in parallel. This call does expensive point validation.
6. Skip decryption share validation from own SGX. A node-SGX relationship should work as 1 entity alone. Thus, the node should trust its SGX, since they are run by same validator.

## Results

The results below were captured by running: 
- 4 nodes sharing 1 SGX 
- CPU: 12th Gen Intel(R) Core(TM) i7-1280P
- Network delay: simulated 40 ms RTT

It is expected higher TPS if running a single node + single SGX.



- **BITE version:** Reached up to **+56% higher TPS for same block size**, meaning block time has decreased by ~33% **for BITE**
- **Non-BITE version:** Shows up to **+11% higher TPS**, mainly due to -1 RTT during proposal 

#### BITE

<img width="1000" height="600" alt="new-consensus" src="https://github.com/user-attachments/assets/52cab823-850c-4775-a5a5-c5bdb44fdc0c" />

#### Non BITE

<img width="1000" height="600" alt="new_consensus_2" src="https://github.com/user-attachments/assets/80745a93-c053-4433-aa97-41f57ce1be47" />

Fixes #1018 