### PR TITLE
Compute sgx decryption shares async on block proposal

### DIFF
--- a/SkaleCommon.h
+++ b/SkaleCommon.h
@@ -188,6 +188,9 @@ static constexpr uint64_t CATCHUP_TIMEOUT_SEC = 30;
 
 static constexpr uint64_t SYNC_NODE_CATCHUP_TIMEOUT_SEC = 300;
 
+// Max wait time for SGX decryption share computation from node's own SGXWallet
+static constexpr uint64_t BITE_LOCAL_DECRYPTION_SHARES_WAIT_TIMEOUT_MS = 2000;
+
 static constexpr uint64_t READ_JSON_HEADER_TIMEOUT_SEC = 6;
 
 static constexpr uint64_t SYNC_NODE_READ_JSON_HEADER_TIMEOUT_SEC = 300;

--- a/SkaleCommon.h
+++ b/SkaleCommon.h
@@ -189,7 +189,7 @@ static constexpr uint64_t CATCHUP_TIMEOUT_SEC = 30;
 static constexpr uint64_t SYNC_NODE_CATCHUP_TIMEOUT_SEC = 300;
 
 // Max wait time for SGX decryption share computation from node's own SGXWallet
-static constexpr uint64_t BITE_LOCAL_DECRYPTION_SHARES_WAIT_TIMEOUT_MS = 2000;
+static constexpr uint64_t BITE_LOCAL_DECRYPTION_SHARES_WAIT_TIMEOUT_MS = 5000;
 
 static constexpr uint64_t READ_JSON_HEADER_TIMEOUT_SEC = 6;
 

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -25,6 +25,8 @@
 #include "datastructures/TransactionList.h"
 #include "datastructures/TransactionCiphertextsMap.h"
 
+#include <exceptions/ExitRequestedException.h>
+#include <exceptions/SkaleException.h>
 #include <monitoring/LivelinessMonitor.h>
 
 #include "db/TEDecryptionDB.h"
@@ -110,44 +112,85 @@ void BiteManager::callSGXToCreateMyDecryptionSharesForProposalTransactions(
     MONITOR2(__CLASS_NAME__, __FUNCTION__, schain.getMaxExternalBlockProcessingTime());
 
     CHECK_STATE(_proposal);
-    // check we are not verifying twice
-
-    auto savedShares = getSchain()->getNode()->getTEDecryptionDB()->getMyDecryptionShares(_proposal->getBlockID(),
-                                                                                          _proposal->getProposerIndex());
-
-    if (savedShares) {
-        // we already successfully parsed and decrypted shares
-        _proposal->setMyDecryptionShares(savedShares);
+    if (!_proposal->tryBeginMyDecryptionSharesComputation()) {
+        _proposal->waitUntilMyDecryptionSharesResolved();
         return;
     }
 
-    auto transactions = _proposal->getTransactionList()->getItems();
+    computeMyDecryptionSharesForProposalTransactions(_proposal);
+}
 
-    CHECK_STATE(transactions);
+void BiteManager::scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(
+        ptr<BlockProposal> _proposal) {
+    MONITOR2(__CLASS_NAME__, __FUNCTION__, schain.getMaxExternalBlockProcessingTime());
 
-    if (!_proposal->getFailedTransactionsRef().empty()) {
+    CHECK_STATE(_proposal);
+    if (!_proposal->tryBeginMyDecryptionSharesComputation()) {
         return;
     }
 
-    CHECK_STATE(_proposal->getTransactionCiphertexts());
-
-
-    // this function will not throw exception
-    auto decryptionShareList = getDecryptionSharesForProposal(_proposal);
-    if (!_proposal->getFailedTransactionsRef().empty()) {
-        // the block includes invalid transactions, and at this point we know
-        // each of them. So we just return them
-        return;
+    try {
+        threadPoolExecutor->add([this, _proposal]() {
+            logThreadLocal_ = schain.getNode()->getLog();
+            computeMyDecryptionSharesForProposalTransactions(_proposal);
+        });
+    } catch (const std::exception &e) {
+        CONS_LOG(err, "Could not schedule local decryption share computation: " << e.what());
+        _proposal->markMyDecryptionSharesFailed();
+    } catch (...) {
+        CONS_LOG(err, "Could not schedule local decryption share computation");
+        _proposal->markMyDecryptionSharesFailed();
     }
+}
 
-    CHECK_STATE(decryptionShareList);
-    CHECK_STATE(decryptionShareList->totalCiphertextSharesCount() == _proposal->getTransactionCiphertexts()->totalCiphertextCount());
-    // no we know that the decryption shares are valid, we can set them to the proposal
-    // now we set the decryption shares list to the block proposal so it is committed to the
-    // database when proposal is committed
-    _proposal->setMyDecryptionShares(decryptionShareList);
+void BiteManager::computeMyDecryptionSharesForProposalTransactions(ptr<BlockProposal> _proposal) {
+    CHECK_STATE(_proposal);
 
-    getSchain()->getNode()->getTEDecryptionDB()->addMyDecryptionShares(decryptionShareList);
+    try {
+        auto savedShares = getSchain()->getNode()->getTEDecryptionDB()->getMyDecryptionShares(
+            _proposal->getBlockID(), _proposal->getProposerIndex());
+
+        if (savedShares) {
+            _proposal->markMyDecryptionSharesReady(savedShares);
+            return;
+        }
+
+        auto transactions = _proposal->getTransactionList()->getItems();
+
+        CHECK_STATE(transactions);
+
+        if (!_proposal->getFailedTransactionsRef().empty()) {
+            _proposal->markMyDecryptionSharesFailed();
+            return;
+        }
+
+        CHECK_STATE(_proposal->getTransactionCiphertexts());
+
+        auto decryptionShareList = getDecryptionSharesForProposal(_proposal);
+        if (!_proposal->getFailedTransactionsRef().empty() || !decryptionShareList) {
+            _proposal->markMyDecryptionSharesFailed();
+            return;
+        }
+
+        CHECK_STATE(
+            decryptionShareList->totalCiphertextSharesCount() ==
+            _proposal->getTransactionCiphertexts()->totalCiphertextCount());
+
+        getSchain()->getNode()->getTEDecryptionDB()->addMyDecryptionShares(decryptionShareList);
+        _proposal->markMyDecryptionSharesReady(decryptionShareList);
+    } catch (const ExitRequestedException &) {
+        _proposal->markMyDecryptionSharesFailed();
+    } catch (const std::exception &e) {
+        CONS_LOG(err, "Could not compute local decryption shares for proposal "
+                          << _proposal->getBlockID() << ":" << _proposal->getProposerIndex()
+                          << ": " << e.what());
+        SkaleException::logNested(e);
+        _proposal->markMyDecryptionSharesFailed();
+    } catch (...) {
+        CONS_LOG(err, "Could not compute local decryption shares for proposal "
+                          << _proposal->getBlockID() << ":" << _proposal->getProposerIndex());
+        _proposal->markMyDecryptionSharesFailed();
+    }
 }
 
 

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -58,7 +58,18 @@ public:
 
     // =============== Stage 3: Compute Ciphertext shares =============== //
 
+    /**
+     * @brief For a given proposal, computes the decryption shares for all 
+     * transactions in SGX synchronously.
+     */
     void callSGXToCreateMyDecryptionSharesForProposalTransactions(
+            ptr<BlockProposal> _proposal);
+
+    /**
+     * @brief Schedules the computation of decryption shares in SGX for the given proposal.
+     * If the computation has already started, returns right away.
+     */
+    void scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(
             ptr<BlockProposal> _proposal);
 
     // =============== Stage 4: Share merging =============== //
@@ -155,5 +166,11 @@ public:
     [[nodiscard]] ptr<vector<uint8_t> > generateEmptyCTXData(uint64_t epochId);
 
 private:
+
+    /**
+     * @brief For a given proposal, computes the decryption shares for all transactions.
+     */
+    void computeMyDecryptionSharesForProposalTransactions(ptr<BlockProposal> _proposal);
+
     void stopAndDestroyThreadPoolExecutor();
 };

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -547,9 +547,10 @@ bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
             CHECK_STATE2(proposal->getFailedTransactionsRef().empty(),
                          "Proposal includes invalid format BITE transactions");
 
-            biteManager->callSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
-            CHECK_STATE2(proposal->getFailedTransactionsRef().empty(),
-                         "Proposal includes invalid BITE transactions");
+            biteManager->scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
+            proposal->waitUntilMyDecryptionSharesResolved();
+            CHECK_STATE2(proposal->getMyDecryptionShares(),
+                         "Proposal is missing local decryption shares");
 #endif
 
             getNode()->getBlockProposalDB()->addBlockProposal(proposal);

--- a/blockproposal/server/BlockProposalServerAgent.cpp
+++ b/blockproposal/server/BlockProposalServerAgent.cpp
@@ -482,19 +482,21 @@ pair<ConnectionStatus, ConnectionSubStatus> BlockProposalServerAgent::processPro
 
     send(_connection, finalResponseHeader);
 
+    auto [status, subStatus] = finalResponseHeader->getStatusSubStatus();
+
 #ifdef BITE
-    // we talk to sgx after we sent response to the proposer since sgx is time consuming
-    biteManager->callSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
-    if (!proposal->getFailedTransactionsRef().empty()) {
-        CONS_LOG(err, "Can not create decryptions for network proposal" +
-        to_string(proposal->getFailedTransactionsRef().begin()->second));
+    if (status == CONNECTION_SUCCESS) {
+        // Local share generation is slower than proposal validation, so keep it off the
+        // network response path and let late consumers wait only when they truly need it.
+        biteManager->scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
     }
-    CHECK_STATE(proposal->getMyDecryptionShares())
 #endif
 
-    sChain->proposedBlockArrived(proposal);
+    if (status == CONNECTION_SUCCESS) {
+        sChain->proposedBlockArrived(proposal);
+    }
 
-    return finalResponseHeader->getStatusSubStatus();
+    return {status, subStatus};
 }
 
 

--- a/catchup/server/CatchupServerAgent.cpp
+++ b/catchup/server/CatchupServerAgent.cpp
@@ -388,11 +388,20 @@ ptr<vector<uint8_t> > CatchupServerAgent::createBlockFinalizeResponse(
         ptr<AESKeyDecryptionShareList> myDecryptionShares;
 
         if (needDecryptionShares) {
-            // try get cached decryption shares from proposal first
+            // waits up to some default set time (2s)
+            bool sharesResolved = proposal->waitUntilMyDecryptionSharesResolved();
+            // time out reached - something wrong happenned
+            if (!sharesResolved) {
+                        CONS_LOG(debug, "Timed out waiting for local decryption shares for proposal "
+                                            << proposal->getBlockID() << ":"
+                                            << proposal->getProposerIndex());
+            }
+
+            // Try the proposal-local cache first. If the proposal came from committed-block
+            // storage it may still not carry local shares, so fall back to the DB.
             myDecryptionShares = proposal->getMyDecryptionShares();
             if (!myDecryptionShares) {
-                // if proposal does not have decryption shares, try to get from DB 
-                // (e.g., in case of finalized block, shares might not be in proposal but should be in DB)
+                // If proposal does not have decryption shares, try to get them from the DB.
                 myDecryptionShares = getNode()->getTEDecryptionDB()->getMyDecryptionShares(proposal->getBlockID(),
                     proposal->getProposerIndex());
                 if (!myDecryptionShares) {

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -692,8 +692,8 @@ void Schain::proposeNextBlock(bool _isCalledAfterCatchup) {
         }
 
 #ifdef BITE
-        // Compute decryption shares before proposing block - else, could include incorrect
-        // BITE transactions
+        // Parse and validate BITE ciphertexts synchronously, then let the local decryption share
+        // computation run in the background while consensus progresses.
         if (!isProposalCameFromDb) {
             getSchain()->getBiteManager()->computeAndValidateSGXAESKeyBatch(myProposal);
 
@@ -710,21 +710,10 @@ void Schain::proposeNextBlock(bool _isCalledAfterCatchup) {
                 return;
             }
 
-            getBiteManager()->callSGXToCreateMyDecryptionSharesForProposalTransactions(myProposal);
-            if (!myProposal->getFailedTransactionsRef().empty()) {
-                CONS_LOG(err, "Critical error - could not decrypt BITE transactions");
-                CONS_LOG(err, "Rejecting proposal and triggering fallback consensus for default block");
-                try {
-                    timeoutAgent->forceEarlyTimeout();
-                } catch (ExitRequestedException &) {
-                    throw;
-                } catch (...) {
-                    CONS_LOG(err, "Could not trigger fallback consensus for default block");
-                }
-                return;
-            }
+            // SGX decryption shares will be computed asynchronously
+            getBiteManager()->scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(
+                myProposal);
         }
-        CHECK_STATE(myProposal->getMyDecryptionShares());       
 #endif
 
         CONS_LOG(debug, "PROPOSING BLOCK NUMBER:" << to_string( _proposedBlockID ));
@@ -1271,9 +1260,8 @@ void Schain::bootstrap(block_id _lastCommittedBlockID, uint64_t _lastCommittedBl
         while (lastCommittedBlockIDInConsensus > _lastCommittedBlockID)
 
             try {
-                bool isBite2PatchEnabledForBlock = false;
 #ifdef BITE
-                isBite2PatchEnabledForBlock = bite2Patch( _lastCommittedBlockTimeStamp );
+                bool isBite2PatchEnabledForBlock = bite2Patch( _lastCommittedBlockTimeStamp );
 #endif
                 auto block = getNode()->getBlockDB()->getBlock(
                     _lastCommittedBlockID + 1, getCryptoManager() );
@@ -1661,7 +1649,13 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
         blockFinalizationFinishTimeMs = Time::getCurrentTimeMs();
 
 #ifdef BITE
-        getNode()->getTEDecryptionDB()->addDecryptionShares(proposal->getMyDecryptionShares());
+        proposal->waitUntilMyDecryptionSharesResolved();
+
+        auto myDecryptionShares = proposal->getMyDecryptionShares();
+        CHECK_STATE2(myDecryptionShares,
+            "Local decryption shares are unavailable for finalized proposal");
+
+        getNode()->getTEDecryptionDB()->addDecryptionShares(myDecryptionShares);
 
         auto count =
                 getNode()->getTEDecryptionDB()->getDecryptionsCount(_blockId);

--- a/datastructures/BlockProposal.cpp
+++ b/datastructures/BlockProposal.cpp
@@ -237,6 +237,63 @@ string BlockProposal::getSignature() {
     return signature;
 }
 
+#ifdef BITE
+bool BlockProposal::tryBeginMyDecryptionSharesComputation() {
+    unique_lock<recursive_mutex> lock(m);
+
+    if (myDecryptionSharesState.load(std::memory_order_acquire) !=
+        MyDecryptionSharesState::NotStarted) {
+        // already started or finished
+        return false;
+    }
+
+    myDecryptionSharesState.store(MyDecryptionSharesState::InProgress, std::memory_order_release);
+    return true;
+}
+
+void BlockProposal::markMyDecryptionSharesReady(
+    const ptr<AESKeyDecryptionShareList> &_myDecryptionShares) {
+    CHECK_STATE(_myDecryptionShares);
+
+    unique_lock<recursive_mutex> lock(m);
+    auto state = myDecryptionSharesState.load(std::memory_order_acquire);
+    CHECK_STATE(state == MyDecryptionSharesState::NotStarted ||
+                state == MyDecryptionSharesState::InProgress);
+    CHECK_STATE(std::atomic_load(&myDecryptionShares) == nullptr);
+
+    std::atomic_store(&myDecryptionShares, _myDecryptionShares);
+    myDecryptionSharesState.store(MyDecryptionSharesState::Ready, std::memory_order_release);
+
+    lock.unlock();
+    myDecryptionSharesCond.notify_all();
+}
+
+void BlockProposal::markMyDecryptionSharesFailed() {
+    unique_lock<recursive_mutex> lock(m);
+    auto state = myDecryptionSharesState.load(std::memory_order_acquire);
+    CHECK_STATE(state != MyDecryptionSharesState::Ready);
+    CHECK_STATE(std::atomic_load(&myDecryptionShares) == nullptr);
+
+    myDecryptionSharesState.store(MyDecryptionSharesState::Failed, std::memory_order_release);
+
+    lock.unlock();
+    myDecryptionSharesCond.notify_all();
+}
+
+bool BlockProposal::waitUntilMyDecryptionSharesResolved(uint64_t _timeoutMs) {
+    unique_lock<recursive_mutex> lock(m);
+    return myDecryptionSharesCond.wait_for(lock, chrono::milliseconds(_timeoutMs), [this]() {
+        return myDecryptionSharesState.load(std::memory_order_acquire) !=
+               MyDecryptionSharesState::InProgress;
+    });
+}
+
+void BlockProposal::setMyDecryptionShares(
+    const ptr<AESKeyDecryptionShareList> &_myDecryptionShares) {
+    markMyDecryptionSharesReady(_myDecryptionShares);
+}
+#endif
+
 ptr<BlockProposalRequestHeader> BlockProposal::createProposalRequestHeader(Schain *_sChain) {
     CHECK_ARGUMENT(_sChain);
 

--- a/datastructures/BlockProposal.h
+++ b/datastructures/BlockProposal.h
@@ -200,12 +200,24 @@ public:
     static uint64_t getTotalObjects();
 
 #ifdef BITE
+
+    enum class MyDecryptionSharesState {
+        NotStarted,  // not yet scheduled
+        InProgress,  // scheduled and waiting for result
+        Ready,       // ready and available
+        Failed       // decryption shares could not be computed
+    };
+
     // For BITE protocol when a node receives a block proposal, it verifies and decrypts BITE shares for this proposal
     // using the SGX server
     // the resulting AESKeyDecryptionShareList is then saved together with the block proposal.
 
 private:
     ptr<AESKeyDecryptionShareList> myDecryptionShares = nullptr;
+
+    atomic<MyDecryptionSharesState> myDecryptionSharesState = MyDecryptionSharesState::NotStarted;
+    // this condition variable is notified when myDecryptionSharesState changes to Ready or Failed
+    condition_variable_any myDecryptionSharesCond;
 
     // Stores 1 or more ciphertexts associated with some transaction index
     ptr<TransactionCiphertextsMap> transactionCiphertexts = nullptr;
@@ -222,9 +234,21 @@ public:
 
 
     [[nodiscard]] ptr<AESKeyDecryptionShareList> getMyDecryptionShares() const {
+        if (myDecryptionSharesState.load(std::memory_order_acquire) !=
+            MyDecryptionSharesState::Ready) {
+            return nullptr;
+        }
         auto result = std::atomic_load(&myDecryptionShares);
         return result;
     }
+
+    [[nodiscard]] bool tryBeginMyDecryptionSharesComputation();
+
+    void markMyDecryptionSharesReady(const ptr<AESKeyDecryptionShareList> &_myDecryptionShares);
+
+    void markMyDecryptionSharesFailed();
+
+    bool waitUntilMyDecryptionSharesResolved(uint64_t _timeoutMs = BITE_LOCAL_DECRYPTION_SHARES_WAIT_TIMEOUT_MS);
 
 
     [[nodiscard]] ptr<vector<string>> getSGXAESKeyBatch() const {
@@ -238,11 +262,7 @@ public:
     }
 
 
-    void setMyDecryptionShares(const ptr<AESKeyDecryptionShareList> &_myDecryptionShares) {
-        CHECK_STATE(_myDecryptionShares);
-        // verify we are not setting it twice
-        CHECK_STATE(std::atomic_exchange(&myDecryptionShares, _myDecryptionShares) == nullptr);
-    }
+    void setMyDecryptionShares(const ptr<AESKeyDecryptionShareList> &_myDecryptionShares);
 
 
     void setTransactionCiphertexts(ptr<TransactionCiphertextsMap> _EncryptedAESKeyMap) {

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -614,6 +614,7 @@ void Node::doSoftAndThenHardExit() {
     RETURN_IF_PREVIOUSLY_CALLED( exitCalled )
 
     exitOnBlockBoundaryRequested = true;
+    const bool wasStarted = isStarted();
 
     // this handles the case when exit is called very early
     // so that the start barriers were not released yet
@@ -621,6 +622,14 @@ void Node::doSoftAndThenHardExit() {
     // so it can finish
     releaseGlobalClientBarrier();
     releaseGlobalServerBarrier();
+
+    // Test helpers can construct a node/schain pair without starting services.
+    // Releasing the barriers above mutates the started flags, so use the state
+    // captured before the release to detect this case correctly.
+    if ( !wasStarted ) {
+        exitImmediately();
+        return;
+    }
 
     // we try to wait until the next block is mined, unless the exit
     // was initiated by a fatal error in consensus. In the latter case

--- a/tests/TestUtils.h
+++ b/tests/TestUtils.h
@@ -119,8 +119,10 @@ inline void createTestNodeAndSchain(
     auto nodeInfo = std::make_shared<NodeInfo>(nodeId, bindIP, basePort, schainId, schainIndex);
     node_out->setNodeInfo(nodeInfo);
     
-    // Create the schain
+    // Create the schain and register it on the node so that initLevelDBs() runs
+    // and all database handles (including teDecryptionDB) are initialised.
     chain_out = createTestSchain(node_out, schainIndex, schainId, schainName);
+    node_out->setSchain(chain_out);
 }
 
 }  // namespace TestUtils

--- a/tests/TestUtils.h
+++ b/tests/TestUtils.h
@@ -31,6 +31,7 @@
 #include "node/ConsensusEngine.h"
 #include "node/Node.h"
 #include "node/NodeInfo.h"
+#include "tests/e2e/ConsensusEngineTestAccess.h"
 #include "thirdparty/json.hpp"
 #include "thirdparty/catch.hpp"
 
@@ -123,6 +124,7 @@ inline void createTestNodeAndSchain(
     // and all database handles (including teDecryptionDB) are initialised.
     chain_out = createTestSchain(node_out, schainIndex, schainId, schainName);
     node_out->setSchain(chain_out);
+    ConsensusEngineTestAccess::registerNode(engine, node_out);
 }
 
 }  // namespace TestUtils

--- a/tests/e2e/ConsensusEngineTestAccess.h
+++ b/tests/e2e/ConsensusEngineTestAccess.h
@@ -6,6 +6,14 @@
 
 class ConsensusEngineTestAccess {
 public:
+    static void registerNode( ConsensusEngine& e, const ptr< Node >& node ) {
+        CHECK_STATE( node );
+        CHECK_STATE( e.nodes.count( node->getNodeID() ) == 0 );
+
+        e.nodes[node->getNodeID()] = node;
+        e.nodeIDs.insert( node->getNodeID() );
+    }
+
     static node_id getFirstNodeId( const ConsensusEngine& e ) {
         CHECK_STATE( e.nodes.size() > 0 );
         auto it = e.nodes.begin();

--- a/tests/unit/bite/BlockProposalAsyncDecryptionSharesTests.cpp
+++ b/tests/unit/bite/BlockProposalAsyncDecryptionSharesTests.cpp
@@ -1,0 +1,177 @@
+#include "thirdparty/catch.hpp"
+
+#ifdef BITE
+
+#include <future>
+
+#include "BiteTestUtils.h"
+#include "crypto/AESKeyDecryptionShareList.h"
+#include "datastructures/BlockProposal.h"
+#include "datastructures/MyBlockProposal.h"
+#include "datastructures/TransactionList.h"
+#include "db/TEDecryptionDB.h"
+#include "libBLS/test/utils.h"
+
+using namespace std;
+using namespace BiteTestUtils;
+
+namespace {
+
+ptr<BlockProposal> makeAsyncTestProposal(
+    const shared_ptr<Schain> &chain,
+    const shared_ptr<CryptoManager> &cryptoManager,
+    block_id blockId) {
+    auto keys = generateKeys(1, 1);
+    auto epoch = epoch_id(chain->getNode()->getCurrentEpochId());
+
+    auto tx = buildBite1Transaction(
+        vector<uint8_t>{0x01, 0x02, 0x03},
+        vector<uint8_t>(20, 0x11),
+        static_cast<uint64_t>(epoch),
+        keys.commonPublic);
+
+    auto txs = make_shared<vector<ptr<Transaction>>>();
+    txs->push_back(tx);
+
+    const auto timeStamp =
+        std::max<uint64_t>(static_cast<uint64_t>(std::time(nullptr)),
+                           static_cast<uint64_t>(MODERN_TIME + 1));
+
+    return MyBlockProposal::createMyProposal(
+        *chain,
+        blockId,
+        epoch,
+        chain->getSchainIndex(),
+        make_shared<TransactionList>(txs),
+        u256(0x1234),
+        timeStamp,
+        1,
+        cryptoManager);
+}
+
+ptr<AESKeyDecryptionShareList> makeEmptyShareList(
+    const ptr<BlockProposal> &proposal,
+    schain_index decryptorIndex) {
+    return make_shared<AESKeyDecryptionShareList>(
+        proposal->getBlockID(),
+        proposal->getProposerIndex(),
+        decryptorIndex);
+}
+
+}  // namespace
+
+CATCH_TEST_CASE(
+    "BlockProposal waiters resume when decryption shares become ready",
+    "[bite][proposal][shares][async][ready]") {
+    ConsensusEngine engine(0, 100000000);
+    shared_ptr<Schain> chain;
+    shared_ptr<Node> node;
+    auto cryptoManager = createTestCryptoManager(chain, node, engine);
+
+    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(501));
+    auto readyShares = makeEmptyShareList(proposal, chain->getSchainIndex());
+
+    CATCH_REQUIRE(proposal->tryBeginMyDecryptionSharesComputation());
+
+    promise<void> waiterStarted;
+    auto waiterStartedFuture = waiterStarted.get_future();
+    auto waiterFinished = std::async(std::launch::async, [&]() {
+        waiterStarted.set_value();
+        proposal->waitUntilMyDecryptionSharesResolved();
+    });
+
+    waiterStartedFuture.wait();
+    CATCH_REQUIRE(
+        waiterFinished.wait_for(std::chrono::milliseconds(50)) == std::future_status::timeout);
+
+    proposal->markMyDecryptionSharesReady(readyShares);
+
+    CATCH_REQUIRE(
+        waiterFinished.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
+    CATCH_REQUIRE(proposal->getMyDecryptionShares() == readyShares);
+}
+
+CATCH_TEST_CASE(
+    "BlockProposal waiters resume when decryption share computation fails",
+    "[bite][proposal][shares][async][failed]") {
+    ConsensusEngine engine(0, 100000000);
+    shared_ptr<Schain> chain;
+    shared_ptr<Node> node;
+    auto cryptoManager = createTestCryptoManager(chain, node, engine);
+
+    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(502));
+
+    CATCH_REQUIRE(proposal->tryBeginMyDecryptionSharesComputation());
+
+    promise<void> waiterStarted;
+    auto waiterStartedFuture = waiterStarted.get_future();
+    auto waiterFinished = std::async(std::launch::async, [&]() {
+        waiterStarted.set_value();
+        proposal->waitUntilMyDecryptionSharesResolved();
+    });
+
+    waiterStartedFuture.wait();
+    CATCH_REQUIRE(
+        waiterFinished.wait_for(std::chrono::milliseconds(50)) == std::future_status::timeout);
+
+    proposal->markMyDecryptionSharesFailed();
+
+    CATCH_REQUIRE(
+        waiterFinished.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
+    CATCH_REQUIRE(proposal->getMyDecryptionShares() == nullptr);
+}
+
+CATCH_TEST_CASE(
+    "BlockProposal only starts decryption share computation once",
+    "[bite][proposal][shares][async][single-flight]") {
+    ConsensusEngine engine(0, 100000000);
+    shared_ptr<Schain> chain;
+    shared_ptr<Node> node;
+    auto cryptoManager = createTestCryptoManager(chain, node, engine);
+
+    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(503));
+
+    CATCH_REQUIRE(proposal->tryBeginMyDecryptionSharesComputation());
+    CATCH_REQUIRE_FALSE(proposal->tryBeginMyDecryptionSharesComputation());
+
+    proposal->markMyDecryptionSharesFailed();
+
+    CATCH_REQUIRE_FALSE(proposal->tryBeginMyDecryptionSharesComputation());
+}
+
+CATCH_TEST_CASE(
+    "BiteManager schedules and persists local decryption shares",
+    "[bite][manager][shares][async]") {
+    ConsensusEngine engine(0, 100000000);
+    shared_ptr<Schain> chain;
+    shared_ptr<Node> node;
+    auto cryptoManager = createTestCryptoManager(chain, node, engine);
+
+    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(504));
+    auto biteManager = chain->getBiteManager();
+
+    CATCH_REQUIRE(biteManager);
+
+    biteManager->computeAndValidateSGXAESKeyBatch(proposal);
+    CATCH_REQUIRE(proposal->getFailedTransactionsRef().empty());
+
+    biteManager->scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
+    biteManager->scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
+
+    proposal->waitUntilMyDecryptionSharesResolved();
+
+    auto proposalShares = proposal->getMyDecryptionShares();
+    CATCH_REQUIRE(proposalShares != nullptr);
+
+    auto dbShares = node->getTEDecryptionDB()->getMyDecryptionShares(
+        proposal->getBlockID(), proposal->getProposerIndex());
+    CATCH_REQUIRE(dbShares != nullptr);
+    CATCH_REQUIRE(
+        dbShares->totalCiphertextSharesCount() ==
+        proposalShares->totalCiphertextSharesCount());
+    CATCH_REQUIRE(dbShares->getBlockId() == proposal->getBlockID());
+    CATCH_REQUIRE(dbShares->getProposerIndex() == proposal->getProposerIndex());
+    CATCH_REQUIRE(dbShares->getDecryptorIndex() == chain->getSchainIndex());
+}
+
+#endif


### PR DESCRIPTION
## Description

This PR introduces an optimization in the block proposal phase: when a node proposes a block proposal, it **computes its own local decryption shares asynchronously** instead of blocking the proposal hot path on the SGX call.

The goal is to **overlap local SGX decryption-share generation with time that is already spent on block propagation and subsequent consensus message exchanges**. In practice, this lets the node use existing network and consensus latency to hide much of the SGX cost, reducing proposal-path latency without changing the core consensus or BITE validation logic.

Scope is intentionally narrow:

- asynchronous computation is used only on the block proposal path 
- all other paths keep synchronous behavior, including DB reload / rehydration paths

To support this safely, the PR adds proposal-local synchronization around myDecryptionShares, so consumers can wait until the background computation has either completed or failed. 

For **liveness protection, the catchup path uses a bounded wait with a maximum timeout of 5s**, avoiding indefinite blocking on network-facing request handling.

## Tests

No logical changes to consensus flow. All tests pass.

## Results

New version shows up to 10% TPS improvement for smaller blocks. The improvement lowers with larger blocks, since the time saved is mostly fixed (fixed network delay of 40ms).
<img width="1000" height="600" alt="sgx-async" src="https://github.com/user-attachments/assets/f0c87848-e4a1-40c2-8ce0-8145778b0d6e" />

Fixes #1012 
