### PR TITLE
Fix hard dependence on own node's SGX decryption shares

### DIFF
--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -107,7 +107,7 @@ void BiteManager::computeAndValidateSGXAESKeyBatch(ptr<BlockProposal> _proposal)
 
 // =============== Stage 3: Compute Ciphertext shares =============== //
 
-void BiteManager::callSGXToCreateMyDecryptionSharesForProposalTransactions(
+void BiteManager::ensureMyDecryptionSharesAreComputed(
         ptr<BlockProposal> _proposal) {
     MONITOR2(__CLASS_NAME__, __FUNCTION__, schain.getMaxExternalBlockProcessingTime());
 
@@ -117,7 +117,7 @@ void BiteManager::callSGXToCreateMyDecryptionSharesForProposalTransactions(
         return;
     }
 
-    computeMyDecryptionSharesForProposalTransactions(_proposal);
+    computeOrLoadMyDecryptionShares(_proposal);
 }
 
 void BiteManager::scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(
@@ -132,7 +132,7 @@ void BiteManager::scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(
     try {
         threadPoolExecutor->add([this, _proposal]() {
             logThreadLocal_ = schain.getNode()->getLog();
-            computeMyDecryptionSharesForProposalTransactions(_proposal);
+            computeOrLoadMyDecryptionShares(_proposal);
         });
     } catch (const std::exception &e) {
         CONS_LOG(err, "Could not schedule local decryption share computation: " << e.what());
@@ -143,7 +143,7 @@ void BiteManager::scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(
     }
 }
 
-void BiteManager::computeMyDecryptionSharesForProposalTransactions(ptr<BlockProposal> _proposal) {
+void BiteManager::computeOrLoadMyDecryptionShares(ptr<BlockProposal> _proposal) {
     CHECK_STATE(_proposal);
 
     try {

--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -176,6 +176,17 @@ void BiteManager::computeOrLoadMyDecryptionShares(ptr<BlockProposal> _proposal) 
             decryptionShareList->totalCiphertextSharesCount() ==
             _proposal->getTransactionCiphertexts()->totalCiphertextCount());
 
+        // Do not write an empty entry to TEDecryptionDB for proposals with no BITE
+        // transactions. An empty share list occupies one slot in decryptionsStore
+        // (which closes the door once size >= requiredSigners), but contributes
+        // nothing to decryptionShareSets. This leaves room for only requiredSigners-1
+        // foreign shares, while the merge still needs requiredSigners valid entries
+        // in decryptionShareSets — so finalization would stall permanently.
+        if ( decryptionShareList->totalCiphertextSharesCount() == 0 ) {
+            _proposal->markMyDecryptionSharesReady( decryptionShareList );
+            return;
+        }
+
         getSchain()->getNode()->getTEDecryptionDB()->addMyDecryptionShares(decryptionShareList);
         _proposal->markMyDecryptionSharesReady(decryptionShareList);
     } catch (const ExitRequestedException &) {

--- a/bite/BiteManager.h
+++ b/bite/BiteManager.h
@@ -62,7 +62,7 @@ public:
      * @brief For a given proposal, computes the decryption shares for all 
      * transactions in SGX synchronously.
      */
-    void callSGXToCreateMyDecryptionSharesForProposalTransactions(
+    void ensureMyDecryptionSharesAreComputed(
             ptr<BlockProposal> _proposal);
 
     /**
@@ -170,7 +170,7 @@ private:
     /**
      * @brief For a given proposal, computes the decryption shares for all transactions.
      */
-    void computeMyDecryptionSharesForProposalTransactions(ptr<BlockProposal> _proposal);
+    void computeOrLoadMyDecryptionShares(ptr<BlockProposal> _proposal);
 
     void stopAndDestroyThreadPoolExecutor();
 };

--- a/blockfinalize/client/BlockFinalizeDownloader.cpp
+++ b/blockfinalize/client/BlockFinalizeDownloader.cpp
@@ -548,9 +548,6 @@ bool BlockFinalizeDownloader::downloadProposalDAProofAndDecryptions() {
                          "Proposal includes invalid format BITE transactions");
 
             biteManager->scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
-            proposal->waitUntilMyDecryptionSharesResolved();
-            CHECK_STATE2(proposal->getMyDecryptionShares(),
-                         "Proposal is missing local decryption shares");
 #endif
 
             getNode()->getBlockProposalDB()->addBlockProposal(proposal);

--- a/catchup/server/CatchupServerAgent.cpp
+++ b/catchup/server/CatchupServerAgent.cpp
@@ -343,7 +343,7 @@ ptr<vector<uint8_t> > CatchupServerAgent::createBlockFinalizeResponse(
         string daSig;
 
 
-        // did not find the proposal or we do not have da proof f`rom it
+        // did not find the proposal or we do not have da proof from it
         // try committed block
         if (!proposal || !getNode()->getDaProofDB()->haveDAProof(proposal)) {
             // Could not find proposal with DA proof. Try committed block
@@ -388,7 +388,7 @@ ptr<vector<uint8_t> > CatchupServerAgent::createBlockFinalizeResponse(
         ptr<AESKeyDecryptionShareList> myDecryptionShares;
 
         if (needDecryptionShares) {
-            // waits up to some default set time
+            // wait for my own decryption shares if they are not ready yet
             proposal->waitUntilMyDecryptionSharesResolved();
 
             // Try the proposal-local cache first. If the proposal came from committed-block

--- a/chains/Schain.cpp
+++ b/chains/Schain.cpp
@@ -682,18 +682,8 @@ void Schain::proposeNextBlock(bool _isCalledAfterCatchup) {
         CHECK_STATE(myProposal->getProposerIndex() == getSchainIndex());
         CHECK_STATE(myProposal->getSignature() != "");
 
-        proposedBlockArrived(myProposal);
-
-        if (getOptimizerAgent()->skipSendingProposalToTheNetwork(_proposedBlockID)) {
-            // a node skips sending and saving its proposal during
-            // optimized block consensus, if the node was not a winner
-            // last time
-            return; // dont propose
-        }
-
 #ifdef BITE
-        // Parse and validate BITE ciphertexts synchronously, then let the local decryption share
-        // computation run in the background while consensus progresses.
+        // Parse and validate BITE ciphertexts
         if (!isProposalCameFromDb) {
             getSchain()->getBiteManager()->computeAndValidateSGXAESKeyBatch(myProposal);
 
@@ -709,7 +699,21 @@ void Schain::proposeNextBlock(bool _isCalledAfterCatchup) {
                 }
                 return;
             }
+        }
+#endif
 
+        // only after the proposal is fully built and validated we can announce it to the network
+        proposedBlockArrived(myProposal);
+
+        if (getOptimizerAgent()->skipSendingProposalToTheNetwork(_proposedBlockID)) {
+            // a node skips sending and saving its proposal during
+            // optimized block consensus, if the node was not a winner
+            // last time
+            return; // dont propose
+        }
+
+#ifdef BITE
+        if (!isProposalCameFromDb) {
             // SGX decryption shares will be computed asynchronously
             getBiteManager()->scheduleSGXToCreateMyDecryptionSharesForProposalTransactions(
                 myProposal);
@@ -812,7 +816,7 @@ void Schain::printBlockLog(const ptr<CommittedBlock> &_block) {
     if (!getNode()->isSyncOnlyNode()) {
         output << ":KNWN:" << pendingTransactionsAgent->getKnownTransactionsSize()
                << ":CONS:" << ServerConnection::getTotalObjects()
-               << ":DSDS:" << getSchain()->getNode()->getNetwork()->computeTotalDelayedSends()
+               << ":DSDS:" << (getSchain()->getNode()->hasNetwork() ? getSchain()->getNode()->getNetwork()->computeTotalDelayedSends() : 0)
                << ":SET:" << CryptoManager::getEcdsaStats()
                << ":SBT:" << CryptoManager::getBLSStats()
 #ifdef BITE
@@ -1649,13 +1653,13 @@ void Schain::finalizeDecidedAndSignedBlockInThread(block_id _blockId, schain_ind
         blockFinalizationFinishTimeMs = Time::getCurrentTimeMs();
 
 #ifdef BITE
-        proposal->waitUntilMyDecryptionSharesResolved();
-
+        // Do not hard-require the local SGX share: if it failed (e.g. SGX node
+        // unreachable), a full threshold of foreign shares is sufficient to
+        // reconstruct the AES keys and finalize the block.
         auto myDecryptionShares = proposal->getMyDecryptionShares();
-        CHECK_STATE2(myDecryptionShares,
-            "Local decryption shares are unavailable for finalized proposal");
-
-        getNode()->getTEDecryptionDB()->addDecryptionShares(myDecryptionShares);
+        if (myDecryptionShares) {
+            getNode()->getTEDecryptionDB()->addDecryptionShares(myDecryptionShares);
+        }
 
         auto count =
                 getNode()->getTEDecryptionDB()->getDecryptionsCount(_blockId);

--- a/db/BlockProposalDB.cpp
+++ b/db/BlockProposalDB.cpp
@@ -209,12 +209,13 @@ ptr< BlockProposal > BlockProposalDB::getBlockProposal(
 
     
 
+    // TODO - validation could be skipped here, since block comes from DB
     biteManager->computeAndValidateSGXAESKeyBatch(proposal);
     CHECK_STATE2(proposal->getFailedTransactionsRef().empty(),
                  "Proposal in database includes invalid format BITE transactions");
 
 
-    biteManager->callSGXToCreateMyDecryptionSharesForProposalTransactions(proposal);
+    biteManager->ensureMyDecryptionSharesAreComputed(proposal);
     CHECK_STATE2(proposal->getFailedTransactionsRef().empty(),
                  "Proposal in database includes invalid BITE transactions");
 #endif

--- a/db/TEDecryptionDB.cpp
+++ b/db/TEDecryptionDB.cpp
@@ -271,12 +271,10 @@ bool TEDecryptionDB::isEnoughForeignShares(block_id _blockID) {
         return false;
 
     const auto& shares = it->second;
-    bool hasOwnShare = shares.find(sChain->getSchainIndex()) != shares.end();
-
-    // if the DB already has the own share, it needs to contain required shares
-    // Else, it needs to contain required - 1 shares
-    size_t requiredShares = hasOwnShare ? requiredSigners : requiredSigners - 1;
-    return shares.size() >= requiredShares;
+    // A full threshold is always required.
+    // - own share present : shares.size() includes own + (requiredSigners-1) foreign
+    // - own share absent  : all requiredSigners must be foreign so merge can succeed
+    return shares.size() >= static_cast<size_t>(requiredSigners);
 }
 
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -438,6 +438,7 @@ public:
     ptr< NodeInfo > getNodeInfoById( node_id _id );
 
     ptr< Network > getNetwork() const;
+    bool hasNetwork() const;
 
     string getBindIP() const;
 

--- a/node/NodeGettersSetters.cpp
+++ b/node/NodeGettersSetters.cpp
@@ -185,6 +185,10 @@ ptr< Network > Node::getNetwork() const {
     return network;
 }
 
+bool Node::hasNetwork() const {
+    return network != nullptr;
+}
+
 nlohmann::json Node::getCfg() const {
     return cfg;
 }

--- a/tests/TestUtils.h
+++ b/tests/TestUtils.h
@@ -25,6 +25,8 @@
 
 #include <memory>
 #include <string>
+#include <cstdlib>
+#include <filesystem>
 
 #include "SkaleCommon.h"
 #include "chains/Schain.h"
@@ -34,6 +36,32 @@
 #include "tests/e2e/ConsensusEngineTestAccess.h"
 #include "thirdparty/json.hpp"
 #include "thirdparty/catch.hpp"
+
+// RAII helper: creates a unique temporary directory for LevelDB files and
+// redirects the engine's dbDir to it for the lifetime of the object.
+// Prevents stale DB state from previous test runs sharing /tmp.
+class TempDbDir {
+public:
+    explicit TempDbDir( ConsensusEngine& engine ) {
+        char tmpl[] = "/tmp/consensus_test_XXXXXX";
+        const char* created = mkdtemp( tmpl );
+        CHECK_STATE2( created != nullptr, "mkdtemp failed" );
+        path_ = created;
+        ConsensusEngineTestAccess::setDbDir( engine, path_ );
+    }
+
+    ~TempDbDir() {
+        if ( !path_.empty() ) {
+            std::filesystem::remove_all( path_ );
+        }
+    }
+
+    TempDbDir( const TempDbDir& ) = delete;
+    TempDbDir& operator=( const TempDbDir& ) = delete;
+
+private:
+    std::string path_;
+};
 
 namespace TestUtils {
 
@@ -48,12 +76,13 @@ namespace TestUtils {
 inline std::shared_ptr<Node> createTestNode(
     const nlohmann::json& cfg,
     ConsensusEngine* engine,
-    const std::string& gethUrl = "") {
+    const std::string& gethUrl = "",
+    bool isSyncNode = false) {
     auto mutableGethUrl = gethUrl;
     
     return std::make_shared<Node>(
         cfg, engine, false, "", "", "", "", nullptr, "", nullptr,
-        nullptr, mutableGethUrl, nullptr, nullptr, nullptr, false, false);
+        nullptr, mutableGethUrl, nullptr, nullptr, nullptr, isSyncNode, false);
 }
 
 /**

--- a/tests/e2e/ConsensusEngineTestAccess.h
+++ b/tests/e2e/ConsensusEngineTestAccess.h
@@ -98,4 +98,8 @@ public:
     static TimeStamp getCurrentLastCommittedBlockTimeStamp( const ConsensusEngine& e ) {
         return getCurrentLastCommittedBlockTimeStampForNode( e, getFirstNodeId( e ) );
     }
+
+    static void setDbDir( ConsensusEngine& e, const std::string& dir ) {
+        e.dbDir = dir;
+    }
 };

--- a/tests/unit/bite/BiteEngineTests.cpp
+++ b/tests/unit/bite/BiteEngineTests.cpp
@@ -184,24 +184,6 @@ std::vector<uint8_t> randomAddress() {
     return randomData(ADDRESS_SIZE);
 }
 
-ptr<AESKeyDecryptionShareList> makeMockupShareList(
-    block_id blockId,
-    schain_index decryptorIdx,
-    const TransactionCiphertextsMap& txCiphertexts
-) {
-    auto list = std::make_shared<AESKeyDecryptionShareList>(blockId, /*proposer*/1, decryptorIdx);
-    for (auto&& [txIdx, txCts] : txCiphertexts) {
-    auto shares = std::make_shared<AESKeyDecryptionShares>();
-    for (auto& encKey : txCts->getCiphertexts()) {
-        // mockupDecrypt expects non-const reference
-        auto copy = encKey;
-        shares->push_back(MockupAESKeyDecryptionShare::mockupDecrypt(copy, decryptorIdx));
-    }
-    list->addShares(txIdx, shares);
-}
-return list;
-}
-
 ptr<AESKeyDecryptionShareList> makeConsensusShareList(
     block_id blockId,
     schain_index decryptorIdx,

--- a/tests/unit/bite/BiteFinalizationTests.cpp
+++ b/tests/unit/bite/BiteFinalizationTests.cpp
@@ -1,0 +1,174 @@
+/*
+    Copyright (C) 2026 SKALE Labs
+
+    This file is part of skale-consensus.
+
+    skale-consensus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skale-consensus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with skale-consensus.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "thirdparty/catch.hpp"
+
+#ifdef BITE
+
+#include <chrono>
+#include <thread>
+
+#include "BiteTestUtils.h"
+#include "bite/BiteManager.h"
+#include "crypto/MockupSignature.h"
+#include "datastructures/BlockProposal.h"
+#include "datastructures/DAProof.h"
+#include "db/DAProofDB.h"
+#include "db/TEDecryptionDB.h"
+#include "node/NodeInfo.h"
+#include "tests/TestUtils.h"
+
+using namespace std;
+using namespace BiteTestUtils;
+
+namespace {
+
+// Build a local 4-node fixture: one Node with 4 NodeInfos registered (indices 1-4),
+// giving totalSigners=4 and requiredSigners=3 at TEDecryptionDB construction time.
+// The local node is index 1.
+void make4NodeFixture(
+    ConsensusEngine& engine,
+    shared_ptr<Schain>& chain_out,
+    shared_ptr<Node>& node_out
+) {
+    nlohmann::json cfg;
+    cfg["nodeID"] = 1;
+    cfg["nodeName"] = "testNode4";
+    cfg["bindIP"] = "127.0.0.1";
+    cfg["basePort"] = 10200;
+
+    node_out = TestUtils::createTestNode(cfg, &engine);
+
+    const schain_id schainId( 1337 );
+    // Index 1 matches node->getNodeID() so the Schain constructor finds thisNodeInfo.
+    node_out->setNodeInfo(
+        make_shared<NodeInfo>( node_id( 1 ), "127.0.0.1", 10200, schainId, schain_index( 1 ) ) );
+    node_out->setNodeInfo(
+        make_shared<NodeInfo>( node_id( 2 ), "127.0.0.1", 10210, schainId, schain_index( 2 ) ) );
+    node_out->setNodeInfo(
+        make_shared<NodeInfo>( node_id( 3 ), "127.0.0.1", 10220, schainId, schain_index( 3 ) ) );
+    node_out->setNodeInfo(
+        make_shared<NodeInfo>( node_id( 4 ), "127.0.0.1", 10230, schainId, schain_index( 4 ) ) );
+
+    string schainName = "testChain4";
+    chain_out = TestUtils::createTestSchain( node_out, schain_index( 1 ), schainId, schainName );
+    node_out->setSchain( chain_out );
+    ConsensusEngineTestAccess::registerNode( engine, node_out );
+}
+
+}  // namespace
+
+// A node whose local SGX share failed must still finalize
+// a decided block when a full threshold of valid foreign shares is available.
+//
+// This test fails on current code at the CHECK_STATE2(myDecryptionShares, ...) guard in
+// Schain::finalizeDecidedAndSignedBlockInThread. It passes after the minimal fix that
+// removes that hard requirement and allows the node to proceed with foreign shares.
+CATCH_TEST_CASE(
+    "Finalization succeeds using foreign threshold shares when local SGX share failed",
+    "[bite][finalization][foreign-shares][regression]" ) {
+
+    // ---- 4-node / threshold-3 fixture ----
+    ConsensusEngine engine( 0, 100000000 );
+    TempDbDir tempDb( engine );  // isolated per-run LevelDB dir; cleaned up on scope exit
+    shared_ptr<Schain> chain;
+    shared_ptr<Node> node;
+    make4NodeFixture( engine, chain, node );
+
+    auto cryptoManager = make_shared<CryptoManager>( *chain );
+
+    // bootstrap() sets isStateInitialized = true, which blockCommitArrived requires.
+    // For a sync-only node it returns immediately after that, so no internal block-1
+    // proposal is created and there is no async decryption race.
+    chain->bootstrap( 0, MODERN_TIME + 1, 0 );
+
+    // ---- build proposal and populate its ciphertext map ----
+    auto kp = generateKeys( 1, 1 );
+    auto proposal = makeAsyncTestProposal( chain, cryptoManager, block_id( 1 ), kp );
+
+    auto biteManager = chain->getBiteManager();
+    CATCH_REQUIRE( biteManager );
+
+    // In mockup mode computeAndValidateSGXAESKeyBatch is a no-op (returns immediately
+    // when !usingRealCrypto). getTransactionCiphertexts() is populated inside
+    // createMyProposal -> parseBITETransactions. The call mirrors the production
+    // stage ordering and confirms no parse/validation failures occurred.
+    biteManager->computeAndValidateSGXAESKeyBatch( proposal );
+    CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
+
+    // ---- simulate local SGX failure ----
+    // Local share generation is an infrastructure operation; failure here must
+    // never produce a failed-transaction entry.
+    CATCH_REQUIRE( proposal->tryBeginMyDecryptionSharesComputation() );
+    proposal->markMyDecryptionSharesFailed();
+    CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
+
+    // ---- supply three foreign mock share lists (decryptors 2, 3, 4) ----
+    // addDecryptionShares blocks until all Folly validation futures complete,
+    // so there is no race between share population and the finalization executor.
+    auto teDB = node->getTEDecryptionDB();
+    for ( int idx = 2; idx <= 4; ++idx ) {
+        auto shares = makeMockupShareList( proposal, schain_index( idx ) );
+        teDB->addDecryptionShares( shares );
+    }
+
+    // ---- register proposal in BlockProposalDB ----
+    chain->proposedBlockArrived( proposal );
+
+    // ---- add one mock DA proof ----
+    // In mockup mode verifyDAProofThresholdSig checks: sig.toString() == hash.toHex().
+    // Supplying the hash hex directly as the signature string satisfies this check.
+    auto hashHex = proposal->getHash().toHex();
+    ptr<ThresholdSignature> mockDASig =
+        make_shared<MockupSignature>( hashHex, proposal->getBlockID(), 4, 3 );
+    auto daProof = make_shared<DAProof>( proposal, mockDASig );
+    node->getDaProofDB()->addDAProof( daProof );
+
+    // Fast-fail: if share setup is broken, fail here with a clear count mismatch
+    // rather than timing out silently at the commit poll below.
+    CATCH_REQUIRE( teDB->getDecryptionsCount( proposal->getBlockID() ) == 3 );
+
+    // ---- trigger finalization via the public entry point ----
+    // nullptr for _reencryptionThresholdSig: BITE2 patch is inactive at MODERN_TIME+1
+    // (bite2PatchTimestamp defaults to 0), so blockCommitArrived asserts it is null.
+    ptr<ThresholdSignature> consensusSig =
+        make_shared<MockupSignature>( hashHex, proposal->getBlockID(), 4, 3 );
+    chain->finalizeDecidedAndSignedBlock(
+        proposal->getBlockID(),
+        proposal->getProposerIndex(),
+        consensusSig,
+        nullptr );
+
+    // ---- wait for commit (bounded poll, 5 s) ----
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( 5 );
+    while ( static_cast<uint64_t>( chain->getLastCommittedBlockID() ) <
+                static_cast<uint64_t>( proposal->getBlockID() ) &&
+            std::chrono::steady_clock::now() < deadline ) {
+        std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
+    }
+
+    CATCH_REQUIRE( static_cast<uint64_t>( chain->getLastCommittedBlockID() ) ==
+                   static_cast<uint64_t>( proposal->getBlockID() ) );
+    // Infrastructure (SGX) failure must never create a parse/validation failure entry
+    // on the proposal. getFailedTransactionsRef() records only stage-1/2 failures,
+    // not AES decryption failures that happen later inside the finalization executor.
+    CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
+}
+
+#endif

--- a/tests/unit/bite/BiteFinalizationTests.cpp
+++ b/tests/unit/bite/BiteFinalizationTests.cpp
@@ -94,11 +94,15 @@ CATCH_TEST_CASE(
     auto cryptoManager = make_shared<CryptoManager>( *chain );
 
     // bootstrap() sets isStateInitialized = true, which blockCommitArrived requires.
-    // For a sync-only node it returns immediately after that, so no internal block-1
-    // proposal is created and there is no async decryption race.
+    // It also calls proposeNextBlock() which fires an async task for block_id(1), but
+    // since the bootstrap proposal has no BITE transactions, that task returns early
+    // without writing to TEDecryptionDB (see BiteManager::computeOrLoadMyDecryptionShares).
     chain->bootstrap( 0, MODERN_TIME + 1, 0 );
 
     // ---- build proposal and populate its ciphertext map ----
+    // Use block_id(1) — blockCommitArrived and processCommittedBlock both require
+    // getLastCommittedBlockID() + 1 == blockId, and lastCommitted starts at 0
+    // after a fresh bootstrap, so only block_id(1) is valid.
     auto kp = generateKeys( 1, 1 );
     auto proposal = makeAsyncTestProposal( chain, cryptoManager, block_id( 1 ), kp );
 
@@ -122,6 +126,10 @@ CATCH_TEST_CASE(
     // ---- supply three foreign mock share lists (decryptors 2, 3, 4) ----
     // addDecryptionShares blocks until all Folly validation futures complete,
     // so there is no race between share population and the finalization executor.
+    // Using indices 2-4 (not 1) because bootstrap fires an async task that calls
+    // computeOrLoadMyDecryptionShares for its block_id(1) proposal. With the fix in
+    // place that task returns early (no addMyDecryptionShares) for proposals with
+    // 0 BITE ciphertexts, so it no longer occupies decryptorIndex=1 in the DB.
     auto teDB = node->getTEDecryptionDB();
     for ( int idx = 2; idx <= 4; ++idx ) {
         auto shares = makeMockupShareList( proposal, schain_index( idx ) );
@@ -168,6 +176,79 @@ CATCH_TEST_CASE(
     // Infrastructure (SGX) failure must never create a parse/validation failure entry
     // on the proposal. getFailedTransactionsRef() records only stage-1/2 failures,
     // not AES decryption failures that happen later inside the finalization executor.
+    CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
+}
+
+// A node whose local SGX share computation is still in-progress (InProgress state,
+// i.e. the async task was launched but has not resolved yet) must still finalize
+// a decided block when a full threshold of valid foreign shares is available.
+//
+// This exercises the same null-check branch as the Failed test but confirms that
+// InProgress also results in getMyDecryptionShares() == nullptr, so finalization
+// does not stall waiting for the local task to complete.
+CATCH_TEST_CASE(
+    "Finalization succeeds using foreign threshold shares when local SGX share is still in-progress",
+    "[bite][finalization][foreign-shares][regression]" ) {
+
+    ConsensusEngine engine( 0, 100000000 );
+    TempDbDir tempDb( engine );
+    shared_ptr<Schain> chain;
+    shared_ptr<Node> node;
+    make4NodeFixture( engine, chain, node );
+
+    auto cryptoManager = make_shared<CryptoManager>( *chain );
+    chain->bootstrap( 0, MODERN_TIME + 1, 0 );
+
+    auto kp = generateKeys( 1, 1 );
+    auto proposal = makeAsyncTestProposal( chain, cryptoManager, block_id( 1 ), kp );
+
+    auto biteManager = chain->getBiteManager();
+    CATCH_REQUIRE( biteManager );
+    biteManager->computeAndValidateSGXAESKeyBatch( proposal );
+    CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
+
+    // Simulate the async SGX task having been launched but not yet resolved.
+    // tryBeginMyDecryptionSharesComputation transitions state to InProgress.
+    // Neither markMyDecryptionSharesReady nor markMyDecryptionSharesFailed is
+    // called, leaving the proposal permanently in InProgress.
+    // getMyDecryptionShares() returns nullptr in this state, so finalization
+    // must proceed on foreign shares alone without waiting for resolution.
+    CATCH_REQUIRE( proposal->tryBeginMyDecryptionSharesComputation() );
+    CATCH_REQUIRE( proposal->getMyDecryptionShares() == nullptr );
+
+    auto teDB = node->getTEDecryptionDB();
+    for ( int idx = 2; idx <= 4; ++idx ) {
+        auto shares = makeMockupShareList( proposal, schain_index( idx ) );
+        teDB->addDecryptionShares( shares );
+    }
+
+    chain->proposedBlockArrived( proposal );
+
+    auto hashHex = proposal->getHash().toHex();
+    ptr<ThresholdSignature> mockDASig =
+        make_shared<MockupSignature>( hashHex, proposal->getBlockID(), 4, 3 );
+    auto daProof = make_shared<DAProof>( proposal, mockDASig );
+    node->getDaProofDB()->addDAProof( daProof );
+
+    CATCH_REQUIRE( teDB->getDecryptionsCount( proposal->getBlockID() ) == 3 );
+
+    ptr<ThresholdSignature> consensusSig =
+        make_shared<MockupSignature>( hashHex, proposal->getBlockID(), 4, 3 );
+    chain->finalizeDecidedAndSignedBlock(
+        proposal->getBlockID(),
+        proposal->getProposerIndex(),
+        consensusSig,
+        nullptr );
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( 5 );
+    while ( static_cast<uint64_t>( chain->getLastCommittedBlockID() ) <
+                static_cast<uint64_t>( proposal->getBlockID() ) &&
+            std::chrono::steady_clock::now() < deadline ) {
+        std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
+    }
+
+    CATCH_REQUIRE( static_cast<uint64_t>( chain->getLastCommittedBlockID() ) ==
+                   static_cast<uint64_t>( proposal->getBlockID() ) );
     CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
 }
 

--- a/tests/unit/bite/BiteTestUtils.h
+++ b/tests/unit/bite/BiteTestUtils.h
@@ -21,6 +21,13 @@
 #include "node/ConsensusEngine.h"
 #include "node/Node.h"
 #include "node/NodeInfo.h"
+#include "crypto/AESKeyDecryptionShareList.h"
+#include "crypto/MockupAESKeyDecryptionShare.h"
+#include "datastructures/BlockProposal.h"
+#include "datastructures/MyBlockProposal.h"
+#include "datastructures/TransactionCiphertextsMap.h"
+#include "datastructures/TransactionList.h"
+#include "libBLS/test/utils.h"
 #include "rlp/EthTransactionEncoder.h"
 #include "thirdparty/json.hpp"
 #include "tests/TestUtils.h"
@@ -158,6 +165,73 @@ inline std::shared_ptr< CryptoManager > createTestCryptoManager(
 inline std::shared_ptr< BiteManager > createTestBiteManager(
     std::shared_ptr< Schain >& chain ) {
     return std::make_shared< BiteManager >( *chain );
+}
+
+// Create a single-transaction BITE1 block proposal for testing.
+// The caller supplies the TE keypair; use generateKeys(1,1) for tests that do not
+// exercise decryption and generateKeys(t,n) when the fixture requires specific shares.
+inline ptr<BlockProposal> makeAsyncTestProposal(
+    const std::shared_ptr<Schain>& chain,
+    const std::shared_ptr<CryptoManager>& cryptoManager,
+    block_id blockId,
+    const keys& kp) {
+    auto epoch = epoch_id(chain->getNode()->getCurrentEpochId());
+
+    auto tx = buildBite1Transaction(
+        std::vector<uint8_t>{0x01, 0x02, 0x03},
+        std::vector<uint8_t>(20, 0x11),
+        static_cast<uint64_t>(epoch),
+        kp.commonPublic);
+
+    auto txs = std::make_shared<std::vector<ptr<Transaction>>>();
+    txs->push_back(tx);
+
+    const auto timeStamp =
+        std::max<uint64_t>(static_cast<uint64_t>(std::time(nullptr)),
+                           static_cast<uint64_t>(MODERN_TIME + 1));
+
+    return MyBlockProposal::createMyProposal(
+        *chain,
+        blockId,
+        epoch,
+        chain->getSchainIndex(),
+        std::make_shared<TransactionList>(txs),
+        u256(0x1234),
+        timeStamp,
+        1,
+        cryptoManager);
+}
+
+// Build a mockup AESKeyDecryptionShareList for the given ciphertext map.
+// Uses MockupAESKeyDecryptionShare (no real crypto); compatible with the
+// mockup merge path when SGX is disabled.
+inline ptr<AESKeyDecryptionShareList> makeMockupShareList(
+    block_id blockId,
+    schain_index proposerIdx,
+    schain_index decryptorIdx,
+    const TransactionCiphertextsMap& txCiphertexts) {
+    auto list = std::make_shared<AESKeyDecryptionShareList>(blockId, proposerIdx, decryptorIdx);
+    for (auto&& [txIdx, txCts] : txCiphertexts) {
+        auto shares = std::make_shared<AESKeyDecryptionShares>();
+        for (auto& encKey : txCts->getCiphertexts()) {
+            auto copy = encKey;
+            shares->push_back(MockupAESKeyDecryptionShare::mockupDecrypt(copy, decryptorIdx));
+        }
+        list->addShares(txIdx, shares);
+    }
+    return list;
+}
+
+// Proposal-wrapping overload: extracts block ID, proposer index, and ciphertexts
+// from the proposal so call sites need only pass the proposal and decryptor index.
+inline ptr<AESKeyDecryptionShareList> makeMockupShareList(
+    const ptr<BlockProposal>& proposal,
+    schain_index decryptorIdx) {
+    return makeMockupShareList(
+        proposal->getBlockID(),
+        proposal->getProposerIndex(),
+        decryptorIdx,
+        *proposal->getTransactionCiphertexts());
 }
 
 }  // namespace BiteTestUtils

--- a/tests/unit/bite/BlockProposalAsyncDecryptionSharesTests.cpp
+++ b/tests/unit/bite/BlockProposalAsyncDecryptionSharesTests.cpp
@@ -17,38 +17,6 @@ using namespace BiteTestUtils;
 
 namespace {
 
-ptr<BlockProposal> makeAsyncTestProposal(
-    const shared_ptr<Schain> &chain,
-    const shared_ptr<CryptoManager> &cryptoManager,
-    block_id blockId) {
-    auto keys = generateKeys(1, 1);
-    auto epoch = epoch_id(chain->getNode()->getCurrentEpochId());
-
-    auto tx = buildBite1Transaction(
-        vector<uint8_t>{0x01, 0x02, 0x03},
-        vector<uint8_t>(20, 0x11),
-        static_cast<uint64_t>(epoch),
-        keys.commonPublic);
-
-    auto txs = make_shared<vector<ptr<Transaction>>>();
-    txs->push_back(tx);
-
-    const auto timeStamp =
-        std::max<uint64_t>(static_cast<uint64_t>(std::time(nullptr)),
-                           static_cast<uint64_t>(MODERN_TIME + 1));
-
-    return MyBlockProposal::createMyProposal(
-        *chain,
-        blockId,
-        epoch,
-        chain->getSchainIndex(),
-        make_shared<TransactionList>(txs),
-        u256(0x1234),
-        timeStamp,
-        1,
-        cryptoManager);
-}
-
 ptr<AESKeyDecryptionShareList> makeEmptyShareList(
     const ptr<BlockProposal> &proposal,
     schain_index decryptorIndex) {
@@ -68,7 +36,8 @@ CATCH_TEST_CASE(
     shared_ptr<Node> node;
     auto cryptoManager = createTestCryptoManager(chain, node, engine);
 
-    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(501));
+    auto kp = generateKeys(1, 1);
+    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(501), kp);
     auto readyShares = makeEmptyShareList(proposal, chain->getSchainIndex());
 
     CATCH_REQUIRE(proposal->tryBeginMyDecryptionSharesComputation());
@@ -99,7 +68,8 @@ CATCH_TEST_CASE(
     shared_ptr<Node> node;
     auto cryptoManager = createTestCryptoManager(chain, node, engine);
 
-    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(502));
+    auto kp = generateKeys(1, 1);
+    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(502), kp);
 
     CATCH_REQUIRE(proposal->tryBeginMyDecryptionSharesComputation());
 
@@ -129,7 +99,8 @@ CATCH_TEST_CASE(
     shared_ptr<Node> node;
     auto cryptoManager = createTestCryptoManager(chain, node, engine);
 
-    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(503));
+    auto kp = generateKeys(1, 1);
+    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(503), kp);
 
     CATCH_REQUIRE(proposal->tryBeginMyDecryptionSharesComputation());
     CATCH_REQUIRE_FALSE(proposal->tryBeginMyDecryptionSharesComputation());
@@ -147,7 +118,8 @@ CATCH_TEST_CASE(
     shared_ptr<Node> node;
     auto cryptoManager = createTestCryptoManager(chain, node, engine);
 
-    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(504));
+    auto kp = generateKeys(1, 1);
+    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(504), kp);
     auto biteManager = chain->getBiteManager();
 
     CATCH_REQUIRE(biteManager);


### PR DESCRIPTION
## Summary

This PR fixes two reliability issues in the async BITE decryption-share pipeline that could leave a decided block permanently uncommitted.

Before this change, finalization hard-required the local node's own SGX decryption shares. If the local SGX wallet was unreachable, slow, or failed after ciphertext validation passed, the node would wait up to five seconds and then hard-fail — even if a full threshold of valid foreign shares was already available in `TEDecryptionDB`. A decided block could then never be committed on that node without operator intervention.

## Changes

- `finalizeDecidedAndSignedBlockInThread`: removed `waitUntilMyDecryptionSharesResolved()` and the hard `CHECK_STATE2` requiring local shares. Local shares are added to `TEDecryptionDB` opportunistically when available; a full foreign threshold is now sufficient to proceed. We no longer hard-wait nor hard-require our own share to proceed.
- `BlockFinalizeDownloader`: removed the same wait + check from the download path. Local SGX computation is scheduled fire-and-forget; the downloader's completion condition already guarantees a full threshold is in the DB.
- `TEDecryptionDB::isEnoughForeignShares`: simplified to always require a full `requiredSigners` threshold, removing the `requiredSigners - 1` short-circuit that assumed the local share would always close the gap.
- Skip persisting empty decryption share lists — when a proposal has no BITE-encrypted transactions, the local share computation now marks shares as ready without writing an empty entry to the decryption share database. Previously, the empty entry occupied one of the threshold-count slots, leaving room for only `requiredSigners - 1` valid foreign shares and permanently stalling finalization for such blocks.

**Latent bug fix:**
- `proposeNextBlock`: moved `computeAndValidateSGXAESKeyBatch` before `proposedBlockArrived`. Previously, an own proposal with invalid BITE ciphertexts could be written to LevelDB before validation ran, causing a crash on restart when `getBlockProposal` tried to re-validate it.

**Other:**
- Added `hasNetwork()` null-guard in `printBlockLog` to prevent a null-dereference on sync/test nodes.
- Renamed `callSGXToCreateMyDecryptionSharesForProposalTransactions` → `ensureMyDecryptionSharesAreComputed` and `computeMyDecryptionSharesForProposalTransactions` → `computeOrLoadMyDecryptionShares` to better reflect that SGX is only called when shares are not already persisted.

## Test coverage

Regression test in BiteFinalizationTests.cpp: 4-node / threshold-3 mock chain, local share marked `Failed`, full foreign threshold present — node commits the block and `failedTransactions` remains empty.