### PR TITLE
Add consensus pause functionality

### DIFF
--- a/monitoring/MonitoringAgent.cpp
+++ b/monitoring/MonitoringAgent.cpp
@@ -58,6 +58,11 @@ void MonitoringAgent::monitor() {
         usleep( 100000 );
     }
 
+    // While consensus is paused (e.g. via debug_pauseConsensus), block-processing
+    // threads intentionally sit idle past their normal liveliness timeouts, so
+    // "stuck" warnings would just be noise. Skip reporting until unpaused.
+    if ( getNode()->isPaused() )
+        return;
 
     map< uint64_t, weak_ptr< LivelinessMonitor > > monitorsCopy;
 

--- a/monitoring/StuckDetectionAgent.cpp
+++ b/monitoring/StuckDetectionAgent.cpp
@@ -159,7 +159,8 @@ bool StuckDetectionAgent::stuckCheck( uint64_t _restartIntervalMs, uint64_t _tim
 
     auto result = ( currentTimeMs - getSchain()->getStartTimeMs() ) > _restartIntervalMs &&
                   ( currentTimeMs - getSchain()->getLastCommitTimeMs() > _restartIntervalMs ) &&
-                  ( Time::getCurrentTimeMs() - _timeStamp > _restartIntervalMs ) &&
+                  ( currentTimeMs - _timeStamp > _restartIntervalMs ) &&
+                  ( currentTimeMs - getNode()->getLastUnpauseTimeMs() > _restartIntervalMs ) &&
                   checkNodesAreOnline();
 
     return result;
@@ -169,6 +170,10 @@ bool StuckDetectionAgent::stuckCheck( uint64_t _restartIntervalMs, uint64_t _tim
 // othewise it returns Linux time in ms when to restart
 uint64_t StuckDetectionAgent::doStuckCheckAndReturnTimeWhenToRestart(uint64_t _restartIteration ) {
     CHECK_STATE( _restartIteration >= 1 );
+
+    if (getNode()->isPaused()) {
+        return 0;  // do not restart if consensus is paused
+    }
 
     auto restartIntervalMs = getSchain()->getNode()->getStuckRestartIntervalMs();
 

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -1045,7 +1045,11 @@ string ConsensusEngine::getDbDir() const {
 }
 
 void ConsensusEngine::setPaused(bool paused) {
-    nodes.begin()->second->setPaused(paused);
+    CHECK_STATE( nodes.size() > 0 );
+    for ( auto&& it : nodes ) {
+        CHECK_STATE( it.second );
+        it.second->setPaused( paused );
+    }
 }
 
 void ConsensusEngine::setTestPatchTimestamps( const std::map< string, uint64_t >& _patchTimestamps ) {

--- a/node/ConsensusEngine.cpp
+++ b/node/ConsensusEngine.cpp
@@ -1040,6 +1040,10 @@ string ConsensusEngine::getDbDir() const {
     return dbDir;
 }
 
+void ConsensusEngine::setPaused(bool paused) {
+    nodes.begin()->second->setPaused(paused);
+}
+
 void ConsensusEngine::setTestPatchTimestamps( const std::map< string, uint64_t >& _patchTimestamps ) {
     patchTimestamps = _patchTimestamps;
 }

--- a/node/ConsensusEngine.h
+++ b/node/ConsensusEngine.h
@@ -306,6 +306,8 @@ public:
         ptr< vector< ptr< vector< string > > > >& _blsPublicKeyShares, uint64_t _requiredSigners,
         uint64_t _totalSigners, bool _isSyncNode );
 
+    void setPaused(bool paused) override;
+
 
     void setRotationHistory( ptr< map< uint64_t, vector< string > > > _previousBLSKeys,
         ptr< map< uint64_t, string > > _historicECDSAKeys,

--- a/node/ConsensusInterface.h
+++ b/node/ConsensusInterface.h
@@ -99,6 +99,8 @@ public:
 
     virtual consensus_engine_status getStatus() const = 0;
 
+    virtual void setPaused(bool _paused) = 0;
+
 
 #define ORACLE_SUCCESS 0
 #define ORACLE_UNKNOWN_RECEIPT 1

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -494,6 +494,24 @@ void Node::testNodeInfos() {
     ptr< map< uint64_t, ptr< NodeInfo > > > testNodeInfosById;
 }
 
+void Node::setPaused(bool paused) {
+    if ( paused && !consensusIsPaused ) {
+        CONS_LOG( warn, "Consensus stopped (paused)" );
+    }
+    else if ( !paused && consensusIsPaused ) {
+        lastUnpauseTimeMs = Time::getCurrentTimeMs();
+        CONS_LOG( warn, "Consensus resumed (unpaused)" );
+    }
+    consensusIsPaused = paused;
+}
+
+bool Node::isPaused() const {
+    return consensusIsPaused;
+}
+
+uint64_t Node::getLastUnpauseTimeMs() const {
+    return lastUnpauseTimeMs;
+}
 
 void Node::setNodeInfo( const ptr< NodeInfo >& _nodeInfo ) {
     CHECK_ARGUMENT( _nodeInfo );

--- a/node/Node.h
+++ b/node/Node.h
@@ -105,6 +105,9 @@ class Node {
 
     atomic_bool closeAllSocketsCalled = false;
 
+    atomic_bool consensusIsPaused = false;
+    atomic< uint64_t > lastUnpauseTimeMs = 0;
+
     void exitImmediately();
 
     bool isExitOnBlockBoundaryRequested() const;
@@ -477,6 +480,8 @@ public:
 
     uint64_t getWaitAfterNetworkErrorMs();
 
+    uint64_t getLastUnpauseTimeMs() const;
+
 #ifdef FAIR
     uint64_t getConstantGasPrice() const;
 #endif
@@ -496,6 +501,8 @@ public:
     void setEmptyBlockIntervalAfterCatchupMs( uint64_t _interval ) {
         this->emptyBlockIntervalAfterCatchupMs = _interval;
     }
+
+    void setPaused(bool paused);
 
 #ifdef FAIR
     void setConstantGasPrice( uint64_t _price ) {
@@ -520,6 +527,8 @@ public:
     bool isSyncOnlyNode() const;
 
     bool isArchiveMode() const;
+
+    bool isPaused() const;
 
     bool verifyRealSignatures() const;
 

--- a/pendingqueue/PendingTransactionsAgent.cpp
+++ b/pendingqueue/PendingTransactionsAgent.cpp
@@ -129,6 +129,11 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
     while (transactions.empty()) {
         getSchain()->getNode()->exitCheck();
 
+        if (getNode()->isPaused()) {
+            usleep(1000 * 1000); // sleep for 1s while paused
+            continue;
+        }
+
         if (sChain->getExtFace()) {
             getSchain()->getNode()->checkForExitOnBlockBoundaryAndExitIfNeeded();
             transactions = sChain->getExtFace()->pendingTransactions(needMax, stateRoot);


### PR DESCRIPTION
## Description

- Moved consensus debug pause functionality into consensus:
    - Consensus now is responsible for keeping pause status
    - Exposes `setPause(bool)` to consensus users (skaled) to allow pause/resume consensus
    - Pause selecting txs into block (as skaled used to do)
    - When paused, all monitoring agents stop printing `... got stuck` logs - as it is expected for consensus to not do work while paused
    - added `warn` logs to show when consensus got paused, and when it resumed
    - consensus no longer tries to restart if it detects it has been stuck for the default 3h
    
 - In rare cases, consensus may still propose 1 block right after the pause consensus log appears
    
## Tests
- Tested locally with 1 node - paused:
   - logs show
   - no blocks are produced while stopped
   - no restart after the defined restart ammount by `StuckDetectionAgent`