### PR TITLE
Synchronize pause consensus with a mutex

### DIFF
--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -503,10 +503,21 @@ void Node::setPaused(bool paused) {
         CONS_LOG( warn, "Consensus resumed (unpaused)" );
     }
     consensusIsPaused = paused;
+
+    if ( paused ) {
+        // Set the flag first, then drain. A fetch that is already in flight holds
+        // proposalFetchMutex - possibly blocked for a few ms inside skaled waiting for a
+        // transaction to appear - so this blocks until it returns.
+        std::lock_guard< std::mutex > drainInFlightFetch( proposalFetchMutex );
+    }
 }
 
 bool Node::isPaused() const {
     return consensusIsPaused;
+}
+
+mutex& Node::getProposalFetchMutex() {
+    return proposalFetchMutex;
 }
 
 uint64_t Node::getLastUnpauseTimeMs() const {

--- a/node/Node.cpp
+++ b/node/Node.cpp
@@ -516,8 +516,8 @@ bool Node::isPaused() const {
     return consensusIsPaused;
 }
 
-mutex& Node::getProposalFetchMutex() {
-    return proposalFetchMutex;
+std::unique_lock< std::mutex > Node::lockProposalFetch() {
+    return std::unique_lock< std::mutex >( proposalFetchMutex );
 }
 
 uint64_t Node::getLastUnpauseTimeMs() const {

--- a/node/Node.h
+++ b/node/Node.h
@@ -108,6 +108,9 @@ class Node {
     atomic_bool consensusIsPaused = false;
     atomic< uint64_t > lastUnpauseTimeMs = 0;
 
+    // Serializes proposal transaction fetches against setPaused()
+    mutex proposalFetchMutex;
+
     void exitImmediately();
 
     bool isExitOnBlockBoundaryRequested() const;
@@ -533,6 +536,8 @@ public:
     bool isArchiveMode() const;
 
     bool isPaused() const;
+
+    mutex& getProposalFetchMutex();
 
     bool verifyRealSignatures() const;
 

--- a/node/Node.h
+++ b/node/Node.h
@@ -537,7 +537,7 @@ public:
 
     bool isPaused() const;
 
-    mutex& getProposalFetchMutex();
+    std::unique_lock< std::mutex > lockProposalFetch();
 
     bool verifyRealSignatures() const;
 

--- a/pendingqueue/PendingTransactionsAgent.cpp
+++ b/pendingqueue/PendingTransactionsAgent.cpp
@@ -130,25 +130,40 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
         getSchain()->getNode()->exitCheck();
 
         if (getNode()->isPaused()) {
-            usleep(1000 * 1000); // sleep for 1s while paused
+            // deliberately not holding proposalFetchMutex here - setPaused() drains that
+            // mutex, so parking while holding it would deadlock the pausing thread
+            usleep(10 * 1000); // poll while paused
             continue;
         }
 
-        if (sChain->getExtFace()) {
-            getSchain()->getNode()->checkForExitOnBlockBoundaryAndExitIfNeeded();
-            transactions = sChain->getExtFace()->pendingTransactions(needMax, stateRoot);
-            // block boundary is the safest place for exit
-            // exit immediately if exit has been requested
-            // this will initiate immediate exit and throw ExitRequestedException
-            getSchain()->getNode()->checkForExitOnBlockBoundaryAndExitIfNeeded();
-        } else {
-            stateRootSample++;
-            stateRoot = 7;
+        {
+            // Serialize the fetch against setPaused(): while this is held, a pause request
+            // blocks, so debug_pauseConsensus only returns once no fetch is running. The
+            // re-check below covers the opposite order - flag set and mutex released before
+            // we got here - which would otherwise let a transaction submitted after the
+            // pause still end up in this proposal.
+            std::lock_guard< std::mutex > fetchLock(getNode()->getProposalFetchMutex());
+
+            if (getNode()->isPaused())
+                continue;
+
+            if (sChain->getExtFace()) {
+                getSchain()->getNode()->checkForExitOnBlockBoundaryAndExitIfNeeded();
+                transactions = sChain->getExtFace()->pendingTransactions(needMax, stateRoot);
+                // block boundary is the safest place for exit
+                // exit immediately if exit has been requested
+                // this will initiate immediate exit and throw ExitRequestedException
+                getSchain()->getNode()->checkForExitOnBlockBoundaryAndExitIfNeeded();
+            } else {
+                stateRootSample++;
+                stateRoot = 7;
 #ifdef BITE
-            transactions = sChain->getTestMessageGeneratorAgent()->pendingTransactionsBITE(needMax);
+                transactions =
+                    sChain->getTestMessageGeneratorAgent()->pendingTransactionsBITE(needMax);
 #else
-            transactions = sChain->getTestMessageGeneratorAgent()->pendingTransactions(needMax);
+                transactions = sChain->getTestMessageGeneratorAgent()->pendingTransactions(needMax);
 #endif
+            }
         }
 
         auto finishTime = Time::getCurrentTimeMs();

--- a/pendingqueue/PendingTransactionsAgent.cpp
+++ b/pendingqueue/PendingTransactionsAgent.cpp
@@ -142,7 +142,7 @@ PendingTransactionsAgent::createTransactionsListForProposal(bool _isCalledAfterC
             // re-check below covers the opposite order - flag set and mutex released before
             // we got here - which would otherwise let a transaction submitted after the
             // pause still end up in this proposal.
-            std::lock_guard< std::mutex > fetchLock(getNode()->getProposalFetchMutex());
+            auto fetchLock = getNode()->lockProposalFetch();
 
             if (getNode()->isPaused())
                 continue;


### PR DESCRIPTION
## Description

`setPaused()` only flipped an atomic flag, and the proposal loop only read that flag at the top of each retry. Nothing re-checked it once a fetch was underway, so setPaused(true) didn't stop a pendingTransactions() call already in flight.
So a transaction submitted after the pause was acknowledged still landed in a block. 


## What changed
`setPaused(true)` now returns only once no fetch is running and none can start.

- `Node::proposalFetchMutex`, held only around the fetch in `createTransactionsListForProposal`.
- `setPaused()` sets the flag first, then acquires/releases the mutex — the flag excludes later fetches, the mutex drains the in-flight one.
- The loop re-checks `isPaused()` inside the lock, covering the reverse ordering (flag set and mutex released before the agent got there).

## Behaviour change
- `setPaused(true)` can block for the duration of an in-flight fetch (~100 ms). `setPaused(false)` is unchanged.

Fixes #1034 