### PR TITLE
Revert skip saving empty decryption shares list

### DIFF
--- a/bite/BiteManager.cpp
+++ b/bite/BiteManager.cpp
@@ -176,17 +176,6 @@ void BiteManager::computeOrLoadMyDecryptionShares(ptr<BlockProposal> _proposal) 
             decryptionShareList->totalCiphertextSharesCount() ==
             _proposal->getTransactionCiphertexts()->totalCiphertextCount());
 
-        // Do not write an empty entry to TEDecryptionDB for proposals with no BITE
-        // transactions. An empty share list occupies one slot in decryptionsStore
-        // (which closes the door once size >= requiredSigners), but contributes
-        // nothing to decryptionShareSets. This leaves room for only requiredSigners-1
-        // foreign shares, while the merge still needs requiredSigners valid entries
-        // in decryptionShareSets — so finalization would stall permanently.
-        if ( decryptionShareList->totalCiphertextSharesCount() == 0 ) {
-            _proposal->markMyDecryptionSharesReady( decryptionShareList );
-            return;
-        }
-
         getSchain()->getNode()->getTEDecryptionDB()->addMyDecryptionShares(decryptionShareList);
         _proposal->markMyDecryptionSharesReady(decryptionShareList);
     } catch (const ExitRequestedException &) {

--- a/tests/unit/bite/BiteFinalizationTests.cpp
+++ b/tests/unit/bite/BiteFinalizationTests.cpp
@@ -39,122 +39,99 @@ using namespace BiteTestUtils;
 
 namespace {
 
+// Holds the Node/Schain pair produced by make4NodeFixture().
+struct NodeFixture {
+    shared_ptr<Schain> chain;
+    shared_ptr<Node> node;
+};
+
 // Build a local 4-node fixture: one Node with 4 NodeInfos registered (indices 1-4),
 // giving totalSigners=4 and requiredSigners=3 at TEDecryptionDB construction time.
 // The local node is index 1.
-void make4NodeFixture(
-    ConsensusEngine& engine,
-    shared_ptr<Schain>& chain_out,
-    shared_ptr<Node>& node_out
-) {
+NodeFixture make4NodeFixture( ConsensusEngine& engine ) {
     nlohmann::json cfg;
     cfg["nodeID"] = 1;
     cfg["nodeName"] = "testNode4";
     cfg["bindIP"] = "127.0.0.1";
     cfg["basePort"] = 10200;
 
-    node_out = TestUtils::createTestNode(cfg, &engine);
+    auto node = TestUtils::createTestNode( cfg, &engine );
 
     const schain_id schainId( 1337 );
     // Index 1 matches node->getNodeID() so the Schain constructor finds thisNodeInfo.
-    node_out->setNodeInfo(
+    node->setNodeInfo(
         make_shared<NodeInfo>( node_id( 1 ), "127.0.0.1", 10200, schainId, schain_index( 1 ) ) );
-    node_out->setNodeInfo(
+    node->setNodeInfo(
         make_shared<NodeInfo>( node_id( 2 ), "127.0.0.1", 10210, schainId, schain_index( 2 ) ) );
-    node_out->setNodeInfo(
+    node->setNodeInfo(
         make_shared<NodeInfo>( node_id( 3 ), "127.0.0.1", 10220, schainId, schain_index( 3 ) ) );
-    node_out->setNodeInfo(
+    node->setNodeInfo(
         make_shared<NodeInfo>( node_id( 4 ), "127.0.0.1", 10230, schainId, schain_index( 4 ) ) );
 
     string schainName = "testChain4";
-    chain_out = TestUtils::createTestSchain( node_out, schain_index( 1 ), schainId, schainName );
-    node_out->setSchain( chain_out );
-    ConsensusEngineTestAccess::registerNode( engine, node_out );
+    auto chain = TestUtils::createTestSchain( node, schain_index( 1 ), schainId, schainName );
+    node->setSchain( chain );
+    ConsensusEngineTestAccess::registerNode( engine, node );
+
+    return { chain, node };
+}
+
+// Polls until chain has committed up to _blockId, or _timeout elapses.
+void waitForCommit( const shared_ptr<Schain>& chain, block_id _blockId,
+    std::chrono::milliseconds _timeout = std::chrono::seconds( 5 ) ) {
+    const auto deadline = std::chrono::steady_clock::now() + _timeout;
+    while ( static_cast<uint64_t>( chain->getLastCommittedBlockID() ) <
+                static_cast<uint64_t>( _blockId ) &&
+            std::chrono::steady_clock::now() < deadline ) {
+        std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
+    }
 }
 
 }  // namespace
 
-// A node whose local SGX share failed must still finalize
-// a decided block when a full threshold of valid foreign shares is available.
-//
-// This test fails on current code at the CHECK_STATE2(myDecryptionShares, ...) guard in
-// Schain::finalizeDecidedAndSignedBlockInThread. It passes after the minimal fix that
-// removes that hard requirement and allows the node to proceed with foreign shares.
+// A failed local SGX share must not block finalization once a foreign threshold is met.
 CATCH_TEST_CASE(
     "Finalization succeeds using foreign threshold shares when local SGX share failed",
     "[bite][finalization][foreign-shares][regression]" ) {
 
-    // ---- 4-node / threshold-3 fixture ----
+    auto kp = generateKeys( 1, 1 );
     ConsensusEngine engine( 0, 100000000 );
-    TempDbDir tempDb( engine );  // isolated per-run LevelDB dir; cleaned up on scope exit
-    shared_ptr<Schain> chain;
-    shared_ptr<Node> node;
-    make4NodeFixture( engine, chain, node );
+    TempDbDir tempDb( engine );  // isolated per-run LevelDB dir
+    auto [chain, node] = make4NodeFixture( engine );
 
     auto cryptoManager = make_shared<CryptoManager>( *chain );
-
-    // bootstrap() sets isStateInitialized = true, which blockCommitArrived requires.
-    // It also calls proposeNextBlock() which fires an async task for block_id(1), but
-    // since the bootstrap proposal has no BITE transactions, that task returns early
-    // without writing to TEDecryptionDB (see BiteManager::computeOrLoadMyDecryptionShares).
     chain->bootstrap( 0, MODERN_TIME + 1, 0 );
 
-    // ---- build proposal and populate its ciphertext map ----
-    // Use block_id(1) — blockCommitArrived and processCommittedBlock both require
-    // getLastCommittedBlockID() + 1 == blockId, and lastCommitted starts at 0
-    // after a fresh bootstrap, so only block_id(1) is valid.
-    auto kp = generateKeys( 1, 1 );
-    auto proposal = makeAsyncTestProposal( chain, cryptoManager, block_id( 1 ), kp );
-
+    auto proposal = makeTestProposal( chain, cryptoManager, block_id( 1 ), kp );
     auto biteManager = chain->getBiteManager();
     CATCH_REQUIRE( biteManager );
-
-    // In mockup mode computeAndValidateSGXAESKeyBatch is a no-op (returns immediately
-    // when !usingRealCrypto). getTransactionCiphertexts() is populated inside
-    // createMyProposal -> parseBITETransactions. The call mirrors the production
-    // stage ordering and confirms no parse/validation failures occurred.
     biteManager->computeAndValidateSGXAESKeyBatch( proposal );
     CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
 
-    // ---- simulate local SGX failure ----
-    // Local share generation is an infrastructure operation; failure here must
-    // never produce a failed-transaction entry.
+    // Simulate local SGX share failure — must not register as a failed transaction.
     CATCH_REQUIRE( proposal->tryBeginMyDecryptionSharesComputation() );
     proposal->markMyDecryptionSharesFailed();
     CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
 
-    // ---- supply three foreign mock share lists (decryptors 2, 3, 4) ----
-    // addDecryptionShares blocks until all Folly validation futures complete,
-    // so there is no race between share population and the finalization executor.
-    // Using indices 2-4 (not 1) because bootstrap fires an async task that calls
-    // computeOrLoadMyDecryptionShares for its block_id(1) proposal. With the fix in
-    // place that task returns early (no addMyDecryptionShares) for proposals with
-    // 0 BITE ciphertexts, so it no longer occupies decryptorIndex=1 in the DB.
+    // Foreign shares from decryptors 2-4 (index 1 is reserved for the local node).
     auto teDB = node->getTEDecryptionDB();
     for ( int idx = 2; idx <= 4; ++idx ) {
         auto shares = makeMockupShareList( proposal, schain_index( idx ) );
         teDB->addDecryptionShares( shares );
     }
+    CATCH_REQUIRE( teDB->getDecryptionsCount( proposal->getBlockID() ) == 3 );
 
-    // ---- register proposal in BlockProposalDB ----
+    // register proposal in block proposal DB
     chain->proposedBlockArrived( proposal );
 
-    // ---- add one mock DA proof ----
-    // In mockup mode verifyDAProofThresholdSig checks: sig.toString() == hash.toHex().
-    // Supplying the hash hex directly as the signature string satisfies this check.
+    // Mock DA proof: mockup mode accepts sig.toString() == hash.toHex().
     auto hashHex = proposal->getHash().toHex();
     ptr<ThresholdSignature> mockDASig =
         make_shared<MockupSignature>( hashHex, proposal->getBlockID(), 4, 3 );
     auto daProof = make_shared<DAProof>( proposal, mockDASig );
     node->getDaProofDB()->addDAProof( daProof );
 
-    // Fast-fail: if share setup is broken, fail here with a clear count mismatch
-    // rather than timing out silently at the commit poll below.
-    CATCH_REQUIRE( teDB->getDecryptionsCount( proposal->getBlockID() ) == 3 );
-
-    // ---- trigger finalization via the public entry point ----
-    // nullptr for _reencryptionThresholdSig: BITE2 patch is inactive at MODERN_TIME+1
-    // (bite2PatchTimestamp defaults to 0), so blockCommitArrived asserts it is null.
+    // nullptr reencryption sig: BITE2 patch inactive at MODERN_TIME+1.
     ptr<ThresholdSignature> consensusSig =
         make_shared<MockupSignature>( hashHex, proposal->getBlockID(), 4, 3 );
     chain->finalizeDecidedAndSignedBlock(
@@ -163,56 +140,36 @@ CATCH_TEST_CASE(
         consensusSig,
         nullptr );
 
-    // ---- wait for commit (bounded poll, 5 s) ----
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( 5 );
-    while ( static_cast<uint64_t>( chain->getLastCommittedBlockID() ) <
-                static_cast<uint64_t>( proposal->getBlockID() ) &&
-            std::chrono::steady_clock::now() < deadline ) {
-        std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
-    }
+    waitForCommit( chain, proposal->getBlockID() );
 
     CATCH_REQUIRE( static_cast<uint64_t>( chain->getLastCommittedBlockID() ) ==
                    static_cast<uint64_t>( proposal->getBlockID() ) );
-    // Infrastructure (SGX) failure must never create a parse/validation failure entry
-    // on the proposal. getFailedTransactionsRef() records only stage-1/2 failures,
-    // not AES decryption failures that happen later inside the finalization executor.
+    // SGX (infrastructure) failure must never create a failed-transaction entry.
     CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
 }
 
-// A node whose local SGX share computation is still in-progress (InProgress state,
-// i.e. the async task was launched but has not resolved yet) must still finalize
-// a decided block when a full threshold of valid foreign shares is available.
-//
-// This exercises the same null-check branch as the Failed test but confirms that
-// InProgress also results in getMyDecryptionShares() == nullptr, so finalization
-// does not stall waiting for the local task to complete.
+// Same as above, but the local SGX task is left in InProgress (never resolved)
+// instead of Failed — finalization must not stall waiting for it.
 CATCH_TEST_CASE(
     "Finalization succeeds using foreign threshold shares when local SGX share is still in-progress",
     "[bite][finalization][foreign-shares][regression]" ) {
 
     ConsensusEngine engine( 0, 100000000 );
     TempDbDir tempDb( engine );
-    shared_ptr<Schain> chain;
-    shared_ptr<Node> node;
-    make4NodeFixture( engine, chain, node );
+    auto [chain, node] = make4NodeFixture( engine );
 
     auto cryptoManager = make_shared<CryptoManager>( *chain );
     chain->bootstrap( 0, MODERN_TIME + 1, 0 );
 
     auto kp = generateKeys( 1, 1 );
-    auto proposal = makeAsyncTestProposal( chain, cryptoManager, block_id( 1 ), kp );
+    auto proposal = makeTestProposal( chain, cryptoManager, block_id( 1 ), kp );
 
     auto biteManager = chain->getBiteManager();
     CATCH_REQUIRE( biteManager );
     biteManager->computeAndValidateSGXAESKeyBatch( proposal );
     CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
 
-    // Simulate the async SGX task having been launched but not yet resolved.
-    // tryBeginMyDecryptionSharesComputation transitions state to InProgress.
-    // Neither markMyDecryptionSharesReady nor markMyDecryptionSharesFailed is
-    // called, leaving the proposal permanently in InProgress.
-    // getMyDecryptionShares() returns nullptr in this state, so finalization
-    // must proceed on foreign shares alone without waiting for resolution.
+    // Leave the local share computation InProgress: getMyDecryptionShares() == nullptr.
     CATCH_REQUIRE( proposal->tryBeginMyDecryptionSharesComputation() );
     CATCH_REQUIRE( proposal->getMyDecryptionShares() == nullptr );
 
@@ -221,6 +178,7 @@ CATCH_TEST_CASE(
         auto shares = makeMockupShareList( proposal, schain_index( idx ) );
         teDB->addDecryptionShares( shares );
     }
+    CATCH_REQUIRE( teDB->getDecryptionsCount( proposal->getBlockID() ) == 3 );
 
     chain->proposedBlockArrived( proposal );
 
@@ -230,7 +188,63 @@ CATCH_TEST_CASE(
     auto daProof = make_shared<DAProof>( proposal, mockDASig );
     node->getDaProofDB()->addDAProof( daProof );
 
+    ptr<ThresholdSignature> consensusSig =
+        make_shared<MockupSignature>( hashHex, proposal->getBlockID(), 4, 3 );
+    chain->finalizeDecidedAndSignedBlock(
+        proposal->getBlockID(),
+        proposal->getProposerIndex(),
+        consensusSig,
+        nullptr );
+
+    waitForCommit( chain, proposal->getBlockID() );
+
+    CATCH_REQUIRE( static_cast<uint64_t>( chain->getLastCommittedBlockID() ) ==
+                   static_cast<uint64_t>( proposal->getBlockID() ) );
+    CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
+}
+
+// node only needs a threshold including its own. Even for blocks with no ciphertexts,
+// local node stores an empty decryption shares list that is accounted for the threshold.
+CATCH_TEST_CASE(
+    "Finalization succeeds for an empty-ciphertext block when one of four nodes is down",
+    "[bite][finalization][foreign-shares][regression]" ) {
+
+    ConsensusEngine engine( 0, 100000000 );
+    TempDbDir tempDb( engine );
+    auto [chain, node] = make4NodeFixture( engine );
+
+    auto cryptoManager = make_shared<CryptoManager>( *chain );
+    chain->bootstrap( 0, MODERN_TIME + 1, 0 );
+
+    // This node's own honest proposal, with no BITE transactions at all.
+    auto proposal = makeEmptyTestProposal( chain, cryptoManager, block_id( 1 ) );
+    auto biteManager = chain->getBiteManager();
+    CATCH_REQUIRE( biteManager );
+    biteManager->computeAndValidateSGXAESKeyBatch( proposal );
+    CATCH_REQUIRE( proposal->getFailedTransactionsRef().empty() );
+
+    // Local SGX share computation succeeds and is stored right away - this is
+    // exactly the behavior restored by removing BiteManager's early-return for
+    // zero-ciphertext proposals.
+    biteManager->ensureMyDecryptionSharesAreComputed( proposal );
+    CATCH_REQUIRE( proposal->getMyDecryptionShares() );
+
+    // Only 2 of the remaining 3 nodes (indices 2,3) respond - index 4 is down.
+    auto teDB = node->getTEDecryptionDB();
+    for ( int idx = 2; idx <= 3; ++idx ) {
+        auto shares = makeMockupShareList( proposal, schain_index( idx ) );
+        teDB->addDecryptionShares( shares );
+    }
+    // local (1) + foreign (2, 3) == requiredSigners (3).
     CATCH_REQUIRE( teDB->getDecryptionsCount( proposal->getBlockID() ) == 3 );
+
+    chain->proposedBlockArrived( proposal );
+
+    auto hashHex = proposal->getHash().toHex();
+    ptr<ThresholdSignature> mockDASig =
+        make_shared<MockupSignature>( hashHex, proposal->getBlockID(), 4, 3 );
+    auto daProof = make_shared<DAProof>( proposal, mockDASig );
+    node->getDaProofDB()->addDAProof( daProof );
 
     ptr<ThresholdSignature> consensusSig =
         make_shared<MockupSignature>( hashHex, proposal->getBlockID(), 4, 3 );
@@ -240,12 +254,7 @@ CATCH_TEST_CASE(
         consensusSig,
         nullptr );
 
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds( 5 );
-    while ( static_cast<uint64_t>( chain->getLastCommittedBlockID() ) <
-                static_cast<uint64_t>( proposal->getBlockID() ) &&
-            std::chrono::steady_clock::now() < deadline ) {
-        std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
-    }
+    waitForCommit( chain, proposal->getBlockID() );
 
     CATCH_REQUIRE( static_cast<uint64_t>( chain->getLastCommittedBlockID() ) ==
                    static_cast<uint64_t>( proposal->getBlockID() ) );

--- a/tests/unit/bite/BiteTestUtils.h
+++ b/tests/unit/bite/BiteTestUtils.h
@@ -170,7 +170,7 @@ inline std::shared_ptr< BiteManager > createTestBiteManager(
 // Create a single-transaction BITE1 block proposal for testing.
 // The caller supplies the TE keypair; use generateKeys(1,1) for tests that do not
 // exercise decryption and generateKeys(t,n) when the fixture requires specific shares.
-inline ptr<BlockProposal> makeAsyncTestProposal(
+inline ptr<BlockProposal> makeTestProposal(
     const std::shared_ptr<Schain>& chain,
     const std::shared_ptr<CryptoManager>& cryptoManager,
     block_id blockId,
@@ -185,6 +185,32 @@ inline ptr<BlockProposal> makeAsyncTestProposal(
 
     auto txs = std::make_shared<std::vector<ptr<Transaction>>>();
     txs->push_back(tx);
+
+    const auto timeStamp =
+        std::max<uint64_t>(static_cast<uint64_t>(std::time(nullptr)),
+                           static_cast<uint64_t>(MODERN_TIME + 1));
+
+    return MyBlockProposal::createMyProposal(
+        *chain,
+        blockId,
+        epoch,
+        chain->getSchainIndex(),
+        std::make_shared<TransactionList>(txs),
+        u256(0x1234),
+        timeStamp,
+        1,
+        cryptoManager);
+}
+
+// Build a proposal with zero BITE transactions (an "empty" block) - used to
+// exercise the finalization threshold math for empty-ciphertext proposals.
+inline ptr<BlockProposal> makeEmptyTestProposal(
+    const std::shared_ptr<Schain>& chain,
+    const std::shared_ptr<CryptoManager>& cryptoManager,
+    block_id blockId) {
+    auto epoch = epoch_id(chain->getNode()->getCurrentEpochId());
+
+    auto txs = std::make_shared<std::vector<ptr<Transaction>>>();
 
     const auto timeStamp =
         std::max<uint64_t>(static_cast<uint64_t>(std::time(nullptr)),

--- a/tests/unit/bite/BlockProposalAsyncDecryptionSharesTests.cpp
+++ b/tests/unit/bite/BlockProposalAsyncDecryptionSharesTests.cpp
@@ -37,7 +37,7 @@ CATCH_TEST_CASE(
     auto cryptoManager = createTestCryptoManager(chain, node, engine);
 
     auto kp = generateKeys(1, 1);
-    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(501), kp);
+    auto proposal = makeTestProposal(chain, cryptoManager, block_id(501), kp);
     auto readyShares = makeEmptyShareList(proposal, chain->getSchainIndex());
 
     CATCH_REQUIRE(proposal->tryBeginMyDecryptionSharesComputation());
@@ -69,7 +69,7 @@ CATCH_TEST_CASE(
     auto cryptoManager = createTestCryptoManager(chain, node, engine);
 
     auto kp = generateKeys(1, 1);
-    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(502), kp);
+    auto proposal = makeTestProposal(chain, cryptoManager, block_id(502), kp);
 
     CATCH_REQUIRE(proposal->tryBeginMyDecryptionSharesComputation());
 
@@ -100,7 +100,7 @@ CATCH_TEST_CASE(
     auto cryptoManager = createTestCryptoManager(chain, node, engine);
 
     auto kp = generateKeys(1, 1);
-    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(503), kp);
+    auto proposal = makeTestProposal(chain, cryptoManager, block_id(503), kp);
 
     CATCH_REQUIRE(proposal->tryBeginMyDecryptionSharesComputation());
     CATCH_REQUIRE_FALSE(proposal->tryBeginMyDecryptionSharesComputation());
@@ -119,7 +119,7 @@ CATCH_TEST_CASE(
     auto cryptoManager = createTestCryptoManager(chain, node, engine);
 
     auto kp = generateKeys(1, 1);
-    auto proposal = makeAsyncTestProposal(chain, cryptoManager, block_id(504), kp);
+    auto proposal = makeTestProposal(chain, cryptoManager, block_id(504), kp);
     auto biteManager = chain->getBiteManager();
 
     CATCH_REQUIRE(biteManager);


### PR DESCRIPTION
### Description
Fixes a consensus finalization stall on proposals with zero BITE transactions when a node is offline. 

- Removed the early return in `BiteManager::computeOrLoadMyDecryptionShares()` for zero-ciphertext proposals so the local node's empty `AESKeyDecryptionShareList` is properly recorded in `TEDecryptionDB`.
- Ensures `TEDecryptionDB::isEnoughForeignShares()` meets the required threshold ($T$) from the local share plus $(T-1)$ foreign shares, even when up to $F$ nodes are offline.
- Refactored finalization unit tests

### Tests
- Added unit test to tests/unit/bite/BiteFinalizationTests.cpp: `Finalization succeeds for an empty-ciphertext block when one of four nodes is down`.
- Existing BITE unit and finalization test suite.
- Tested with skaled running 4 nodes locally, and exiting 1 of the nodes

Fixes skalenetwork/skaled#2529